### PR TITLE
Multiple small fixes and changes.

### DIFF
--- a/Scan Crashlogs.ini
+++ b/Scan Crashlogs.ini
@@ -1,4 +1,6 @@
-#This file contains configuration settings for Scan Crashlogs.py 
+[MAIN] #This file contains configuration settings for Scan Crashlogs.py 
+#Set to true if you want Auto-Scanner to check Python version and if all required packages are installed.
+Update Check = true
 
 #Set to true if you want Auto-Scanner to check if Buffout 4 and its requirements are installed correctly. 
 #FCX - File Check eXtended | If Auto-Scanner fails to scan your logs, revert this setting back to false. 


### PR DESCRIPTION
Add "Update Check" and MAIN section header to bundled INI file.
Only run the User_Documents query if running on Windows.
Simplify home directory querying for Linux.
Fix the INI query for locating the F4SE directory.
The variables looking for an INI_Line variable had no INI_Line variable to query.
Add commented out proposal for using ConfigParser to fix Fallout4Custom.ini