### PR TITLE
Don't run pip 3 times.

### DIFF
--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -40,7 +40,6 @@ if CLAS_config.get("MAIN","Update Check").lower() == "true":
 
     try: # AUTO UPDATE PIP, INSTALL & LIST PACKAGES
         subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--upgrade', 'pip'])
-        subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'requests'])
         subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--upgrade', 'requests'])
         reqs = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])
         # installed_packages = [r.decode().split('==')[0] for r in reqs.split()]


### PR DESCRIPTION
pip with the --upgrade option behaves just like a normal install if there is no version to upgrade from.