### PR TITLE
For loop cleanup

### DIFF
--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -299,7 +299,7 @@ for file in logs:
         # BUFFOUT VERSION CHECK
         buff_latest = "Buffout 4 v1.26.2\n"
         output.write(f"Main Error: {buff_error}\n")
-        output.write("====================================================")
+        output.write("====================================================\n")
         output.write(f"Detected Buffout Version: {buff_ver.strip()}\n")
         output.write(f"Latest Buffout Version: {buff_latest.strip()}\n")
 
@@ -720,7 +720,7 @@ for file in logs:
         # ===========================================================
         if ("ButtonEvent" or "MenuControls" or "MenuOpenCloseHandler" or "PlayerControls" or "DXGISwapChain") in logtext:
             output.write("Checking for *[Input Crash]...............DETECTED!\n")
-            output.write(f'> Priority : [5] | ButtonEvent : {logtext.count("ButtonEvent")} | MenuControls : {logtext.count("MenuControls")}')
+            output.write(f'> Priority : [5] | ButtonEvent : {logtext.count("ButtonEvent")} | MenuControls : {logtext.count("MenuControls")}\n')
             output.write(f'                        MenuOpenCloseHandler : {logtext.count("MenuOpenCloseHandler")} | PlayerControls : {logtext.count("PlayerControls")}\n')
             output.write(f'                        DXGISwapChain : {logtext.count("DXGISwapChain")}\n')
             Buffout_Trap = True
@@ -1354,6 +1354,7 @@ for file in logs:
                 output.write("-----\n")
         else:
             output.write(nopluginlist)
+        
         output.write("====================================================\n")
         output.write("SCANNING THE LOG FOR SPECIFIC (POSSIBLE) CUPLRITS...\n")
         output.write("====================================================\n")
@@ -1478,7 +1479,7 @@ for file in logs:
 
         output.write("FOR FULL LIST OF MODS THAT CAUSE PROBLEMS, THEIR ALTERNATIVES AND DETAILED SOLUTIONS,\n")
         output.write("VISIT THE BUFFOUT 4 CRASH ARTICLE: https://www.nexusmods.com/fallout4/articles/3115\n")
-        output.write("===============================================================================")
+        output.write("===============================================================================\n")
         output.write(f"END OF AUTOSCAN | Author/Made By: Poet#9800 (DISCORD) | {CLAS_Date}")
 
     # MOVE UNSOLVED LOGS TO SPECIAL FOLDER

--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -267,7 +267,7 @@ for file in logs:
     logpath = Path(file).resolve()
     scanpath = Path(str(logpath.name).replace(".log", "-AUTOSCAN.md")).resolve()
     logname = logpath.name
-    logtext = logpath.read_text()
+    logtext = logpath.read_text(encoding="utf-8")
     loglines: list | None = None
     with logpath.open("r+", encoding="utf-8", errors="ignore") as lines:
         loglines = lines.readlines()

--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -267,207 +267,202 @@ for file in logs:
     logpath = Path(file).resolve()
     scanpath = Path(str(logpath).replace(".log", "-AUTOSCAN.md"))
     logname = logpath.name
-    output = scanpath.open("w", encoding='utf-8-sig', errors="ignore")
     logtext = logpath.read_text()
     loglines: list | None = None
     with logpath.open("r+", encoding="utf-8", errors="ignore") as lines:
         loglines = lines.readlines()
-
-    output.writelines([logname,
-                       "This crash log was automatically scanned.",
-                       f"VER {CLAS_Current[-4:]} | MIGHT CONTAIN FALSE POSITIVES."
-                       ])
-    if CLAS_Update == True:
-        output.write("# NOTICE: YOU NEED TO UPDATE THE AUTO-SCANNER! #")
-    output.write("====================================================")
+    with scanpath.open("w", encoding='utf-8-sig', errors="ignore") as output:
+        output.write(logname)
+        output.write("This crash log was automatically scanned.")
+        output.write(f"VER {CLAS_Current[-4:]} | MIGHT CONTAIN FALSE POSITIVES.")
+        if CLAS_Update == True:
+            output.write("# NOTICE: YOU NEED TO UPDATE THE AUTO-SCANNER! #")
+        output.write("====================================================")
 
     # DEFINE LINE INDEXES FOR EVERYTHING REQUIRED HERE
-    buff_ver = loglines[1].strip()
-    buff_error = loglines[3].strip()
-    plugin_idx = 1
-    for line in loglines:
-        if not "F4SE" in line and "PLUGINS:" in line:
-            plugin_idx = loglines.index(line)
+        buff_ver = loglines[1].strip()
+        buff_error = loglines[3].strip()
+        plugin_idx = 1
+        for line in loglines:
+            if not "F4SE" in line and "PLUGINS:" in line:
+                plugin_idx = loglines.index(line)
 
-    plugin_list = loglines[plugin_idx:]
-    if os.path.exists("loadorder.txt"):
-        plugin_list = []
-        with open("loadorder.txt", "r", errors="ignore") as loadorder_check:
-            plugin_format = loadorder_check.readlines()
-            for line in plugin_format:
-                line = "[LO] " + line.strip()
-                plugin_list.append(line)
+        plugin_list = loglines[plugin_idx:]
+        if os.path.exists("loadorder.txt"):
+            plugin_list = []
+            with open("loadorder.txt", "r", errors="ignore") as loadorder_check:
+                plugin_format = loadorder_check.readlines()
+                for line in plugin_format:
+                    line = "[LO] " + line.strip()
+                    plugin_list.append(line)
 
-    # BUFFOUT VERSION CHECK
-    buff_latest = "Buffout 4 v1.26.2"
-    output.writelines([f"Main Error: {buff_error}",
-                       "====================================================",
-                       f"Detected Buffout Version: {buff_ver.strip()}",
-                       f"Latest Buffout Version: {buff_latest.strip()}"])
+        # BUFFOUT VERSION CHECK
+        buff_latest = "Buffout 4 v1.26.2"
+        output.write(f"Main Error: {buff_error}")
+        output.write("====================================================")
+        output.write(f"Detected Buffout Version: {buff_ver.strip()}")
+        output.write(f"Latest Buffout Version: {buff_latest.strip()}")
 
-    if buff_ver.casefold() == buff_latest.casefold():
-        output.write("You have the lastest version of Buffout 4!")
-    else:
-        output.writelines(["REPORTED BUFFOUT VERSION DOES NOT MATCH THE BUFFOUT VERSION USED BY AUTOSCAN",
-                           "UPDATE BUFFOUT 4 IF NECESSARY: https://www.nexusmods.com/fallout4/mods/47359"
-                           ])
+        if buff_ver.casefold() == buff_latest.casefold():
+            output.write("You have the lastest version of Buffout 4!")
+        else:
+            output.write("REPORTED BUFFOUT VERSION DOES NOT MATCH THE BUFFOUT VERSION USED BY AUTOSCAN")
+            output.write("UPDATE BUFFOUT 4 IF NECESSARY: https://www.nexusmods.com/fallout4/mods/47359")
 
-    if "v1." not in buff_ver:
-        statL_veryold += 1
-        statL_scanned -= 1
+        if "v1." not in buff_ver:
+            statL_veryold += 1
+            statL_scanned -= 1
 
-    output.writelines(["====================================================",
-                       "CHECKING IF BUFFOUT 4 FILES/SETTINGS ARE CORRECT...",
-                       "===================================================="
-                       ])
+        output.write("====================================================")
+        output.write("CHECKING IF BUFFOUT 4 FILES/SETTINGS ARE CORRECT...")
+        output.write("====================================================")
 
-    ALIB_Load = BUFF_Load = False
+        ALIB_Load= BUFF_Load = False
 
-    # CHECK IF F4SE.LOG EXISTS AND REPORTS ANY ERRORS
-    if CLAS_config.getboolean("MAIN", "FCX Mode") == True:
-        output.writelines(["* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *",
+        # CHECK IF F4SE.LOG EXISTS AND REPORTS ANY ERRORS
+        if CLAS_config.getboolean("MAIN", "FCX Mode") == True:
+            output.writelines(["* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *",
                            "[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]",
                            "-----"
                            ])
-        Error_List = []
-        F4SE_Error = F4SE_Version = F4SE_Buffout = 0
-        with open(info.FO4_F4SE_Path, "r") as LOG_Check:
-            Error_Check = LOG_Check.readlines()
-            for line in Error_Check:
-                if "0.6.23" in line:
-                    F4SE_Version = 1
-                if "Error" in line:
-                    F4SE_Error = 1
-                    Error_List.append(line)
-                if "Buffout4.dll" in line and "loaded correctly" in line:
-                    F4SE_Buffout = 1
+            Error_List= []
+            F4SE_Error= F4SE_Version = F4SE_Buffout = 0
+            with open(info.FO4_F4SE_Path, "r") as LOG_Check:
+                Error_Check= LOG_Check.readlines()
+                for line in Error_Check:
+                    if "0.6.23" in line:
+                        F4SE_Version= 1
+                    if "Error" in line:
+                        F4SE_Error= 1
+                        Error_List.append(line)
+                    if "Buffout4.dll" in line and "loaded correctly" in line:
+                        F4SE_Buffout= 1
 
-        if F4SE_Version == 1:
-            output.write("You have the latest version of Fallout 4 Script Extender (F4SE). \n-----")
-        else:
-            output.writelines(["# REPORTED F4SE VERSION DOES NOT MATCH THE F4SE VERSION USED BY AUTOSCAN #",
-                               "UPDATE FALLOUT 4 SCRIPT EXTENDER IF NECESSARY: https://f4se.silverlock.org",
-                               "-----"
-                               ])
+            if F4SE_Version == 1:
+                output.write("You have the latest version of Fallout 4 Script Extender (F4SE). \n-----")
+            else:
+                output.write("# REPORTED F4SE VERSION DOES NOT MATCH THE F4SE VERSION USED BY AUTOSCAN #")
+                output.write("UPDATE FALLOUT 4 SCRIPT EXTENDER IF NECESSARY: https://f4se.silverlock.org")
+                output.write("-----")
 
-        if F4SE_Error == 1:
-            output.write("# SCRIPT EXTENDER REPORTS THAT THE FOLLOWING PLUGINS FAILED TO LOAD! #")
-            for elem in Error_List:
-                output.write(f"{elem}\n-----")
-        else:
-            output.write("Script Extender reports that all DLL mod plugins have loaded correctly. \n-----")
+            if F4SE_Error == 1:
+                output.write("# SCRIPT EXTENDER REPORTS THAT THE FOLLOWING PLUGINS FAILED TO LOAD! #")
+                for elem in Error_List:
+                    output.write(f"{elem}\n-----")
+            else:
+                output.write("Script Extender reports that all DLL mod plugins have loaded correctly. \n-----")
 
-        if F4SE_Buffout == 1:
-            output.write("Script Extender reports that Buffout 4.dll was found and loaded correctly. \n-----")
-            ALIB_Load = BUFF_Load = True
-        else:
-            output.writelines(["# SCRIPT EXTENDER REPORTS THAT BUFFOUT 4.DLL FAILED TO LOAD OR IS MISSING! #",
+            if F4SE_Buffout == 1:
+                output.write("Script Extender reports that Buffout 4.dll was found and loaded correctly. \n-----")
+                ALIB_Load= BUFF_Load = True
+            else:
+                output.writelines(["# SCRIPT EXTENDER REPORTS THAT BUFFOUT 4.DLL FAILED TO LOAD OR IS MISSING! #",
                                "Follow Buffout 4 installation steps here: https://www.nexusmods.com/fallout4/articles/3115",
                                "Buffout 4: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47359",
                                "-----"
                                ])
 
-        list_ERRORLOG = []
-        for file in info.FO4_F4SE_Logs:
-            if fnmatch.fnmatch(file, ".log"):
-                with open(file, "r+") as LOG_Check:
-                    Log_Errors = LOG_Check.read()
-                    if "error" in Log_Errors.lower():
-                        logname = str(file)
-                        if not logname == "f4se.log":
-                            list_ERRORLOG.append(logname)
+            list_ERRORLOG= []
+            for file in info.FO4_F4SE_Logs:
+                if fnmatch.fnmatch(file, ".log"):
+                    with open(file, "r+") as LOG_Check:
+                        Log_Errors= LOG_Check.read()
+                        if "error" in Log_Errors.lower():
+                            logname= str(file)
+                            if not logname == "f4se.log":
+                                list_ERRORLOG.append(logname)
 
-        if len(list_ERRORLOG) >= 1:
-            output.writelines(["# CAUTION: THE FOLLOWING DLL LOGS ALSO REPORT ONE OR MORE ERRORS : #",
+            if len(list_ERRORLOG) >= 1:
+                output.writelines(["# CAUTION: THE FOLLOWING DLL LOGS ALSO REPORT ONE OR MORE ERRORS : #",
                                "[These are located in your Documents/My Games/Fallout4/F4SE folder.]"
                                ])
-            for elem in list_ERRORLOG:
-                output.write(f"{elem}\n-----")
-        else:
-            output.write("Available DLL logs do not report any additional errors, all is well. \n-----")
+                for elem in list_ERRORLOG:
+                    output.write(f"{elem}\n-----")
+            else:
+                output.write("Available DLL logs do not report any additional errors, all is well. \n-----")
 
-    # CHECK BUFFOUT 4 REQUIREMENTS AND TOML SETTINGS
-        if info.Preloader_XML.is_file() and info.Preloader_DLL.is_file():
-            output.writelines(['OPTIONAL: Plugin Preloader is (manually) installed.\n',
+        # CHECK BUFFOUT 4 REQUIREMENTS AND TOML SETTINGS
+            if info.Preloader_XML.is_file() and info.Preloader_DLL.is_file():
+                output.writelines(['OPTIONAL: Plugin Preloader is (manually) installed.\n',
                                'NOTICE: If the game fails to start after installing this mod, open xSE PluginPreloader.xml with a text editor and CHANGE',
                                '<LoadMethod Name="ImportAddressHook"> TO <LoadMethod Name="OnThreadAttach"> OR <LoadMethod Name="OnProcessAttach">',
                                'IF THE GAME STILL REFUSES TO START, COMPLETELY REMOVE xSE PluginPreloader.xml AND IpHlpAPI.dll FROM YOUR FO4 GAME FOLDER',
                                "-----"
                                ])
-        else:
-            output.write('OPTIONAL: Plugin Preloader is not (manually) installed.\n-----')
+            else:
+                output.write('OPTIONAL: Plugin Preloader is not (manually) installed.\n-----')
 
-        if info.F4SE_Loader.is_file() and info.F4SE_DLL.is_file() and info.F4SE_SDLL.is_file():
-            output.write("REQUIRED: Fallout 4 Script Extender is (manually) installed. \n-----")
-        else:
-            output.writelines(["# CAUTION: Auto-Scanner cannot find Script Extender files or they aren't (manually) installed! #",
+            if info.F4SE_Loader.is_file() and info.F4SE_DLL.is_file() and info.F4SE_SDLL.is_file():
+                output.write("REQUIRED: Fallout 4 Script Extender is (manually) installed. \n-----")
+            else:
+                output.writelines(["# CAUTION: Auto-Scanner cannot find Script Extender files or they aren't (manually) installed! #",
                                "FIX: Extract all files inside *f4se_0_06_21* folder into your Fallout 4 game folder.",
                                "FALLOUT 4 SCRIPT EXTENDER: (Download Build 0.6.23) https://f4se.silverlock.org",
                                "-----"
                                ])
 
-        if info.Address_Library.is_file() or ALIB_Load == True:
-            output.write("REQUIRED: Address Library is (manually) installed. \n-----")
-        else:
-            output.writelines(["# CAUTION: Auto-Scanner cannot find the Adress Library file or it isn't (manually) installed! #",
+            if info.Address_Library.is_file() or ALIB_Load == True:
+                output.write("REQUIRED: Address Library is (manually) installed. \n-----")
+            else:
+                output.writelines(["# CAUTION: Auto-Scanner cannot find the Adress Library file or it isn't (manually) installed! #",
                                "FIX: Place the *version-1-10-163-0.bin* file manually into Fallout 4/Data/F4SE/Plugins folder.",
                                "ADDRESS LIBRARY: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47327?tab=files",
                                "-----"
                                ])
 
-        if info.Buffout_INI.is_file() and info.Buffout_DLL.is_file() or BUFF_Load == True:
-            with open(info.Buffout_INI, "r+") as BUFF_Custom:
-                BUFF_config = BUFF_Custom.read()
-                output.write("REQUIRED: Buffout 4 is (manually) installed. Checking configuration...\n-----")
-                if ("achievements.dll" or "UnlimitedSurvivalMode.dll") in logtext and "Achievements = true" in BUFF_config:
-                    output.writelines(["# CAUTION: Achievements Mod and/or Unlimited Survival Mode is installed, but Achievements parameter is set to TRUE #",
+            if info.Buffout_INI.is_file() and info.Buffout_DLL.is_file() or BUFF_Load == True:
+                with open(info.Buffout_INI, "r+") as BUFF_Custom:
+                    BUFF_config= BUFF_Custom.read()
+                    output.write("REQUIRED: Buffout 4 is (manually) installed. Checking configuration...\n-----")
+                    if ("achievements.dll" or "UnlimitedSurvivalMode.dll") in logtext and "Achievements = true" in BUFF_config:
+                        output.writelines(["# CAUTION: Achievements Mod and/or Unlimited Survival Mode is installed, but Achievements parameter is set to TRUE #",
                                        "Auto-Scanner will change this parameter to FALSE to prevent conflicts with Buffout 4.",
                                        "-----"
                                        ])
-                    BUFF_config = BUFF_config.replace("Achievements = true", "Achievements = false")
-                else:
-                    output.write("Achievements parameter in *Buffout4.toml* is correctly configured. \n-----")
+                        BUFF_config= BUFF_config.replace("Achievements = true", "Achievements = false")
+                    else:
+                        output.write("Achievements parameter in *Buffout4.toml* is correctly configured. \n-----")
 
-                if "BakaScrapHeap.dll" in logtext and "MemoryManager = true" in BUFF_config:
-                    output.writelines(["# CAUTION: Baka ScrapHeap is installed, but MemoryManager parameter is set to TRUE #",
+                    if "BakaScrapHeap.dll" in logtext and "MemoryManager = true" in BUFF_config:
+                        output.writelines(["# CAUTION: Baka ScrapHeap is installed, but MemoryManager parameter is set to TRUE #",
                                        "Auto-Scanner will change this parameter to FALSE to prevent conflicts with Buffout 4.",
                                        "-----"])
-                    BUFF_config = BUFF_config.replace("MemoryManager = true", "MemoryManager = false")
-                else:
-                    output.write("Memory Manager parameter in *Buffout4.toml* is correctly configured. \n-----")
+                        BUFF_config= BUFF_config.replace("MemoryManager = true", "MemoryManager = false")
+                    else:
+                        output.write("Memory Manager parameter in *Buffout4.toml* is correctly configured. \n-----")
 
-                if "f4ee.dll" in logtext and "F4EE = false" in BUFF_config:
-                    output.writelines(["# CAUTION: Looks Menu is installed, but F4EE parameter under [Compatibility] is set to FALSE #",
+                    if "f4ee.dll" in logtext and "F4EE = false" in BUFF_config:
+                        output.writelines(["# CAUTION: Looks Menu is installed, but F4EE parameter under [Compatibility] is set to FALSE #",
                                        "Auto-Scanner will change this parameter to TRUE to prevent bugs and crashes from Looks Menu.",
                                        "-----"
                                        ])
-                    BUFF_config = BUFF_config.replace("F4EE = false", "F4EE = true")
-                else:
-                    output.write("Looks Menu (F4EE) parameter in *Buffout4.toml* is correctly configured. \n-----")
-            with open(info.Buffout_INI, "w+") as BUFF_Custom:
-                BUFF_Custom.write(BUFF_config)
-        else:
-            output.writelines(["# CAUTION: Auto-Scanner cannot find Buffout 4 files or they aren't (manually) installed! #",
+                        BUFF_config= BUFF_config.replace("F4EE = false", "F4EE = true")
+                    else:
+                        output.write("Looks Menu (F4EE) parameter in *Buffout4.toml* is correctly configured. \n-----")
+                with open(info.Buffout_INI, "w+") as BUFF_Custom:
+                    BUFF_Custom.write(BUFF_config)
+            else:
+                output.writelines(["# CAUTION: Auto-Scanner cannot find Buffout 4 files or they aren't (manually) installed! #",
                                "FIX: Follow Buffout 4 installation steps here: https://www.nexusmods.com/fallout4/articles/3115",
                                "BUFFOUT 4: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47359?tab=files",
                                "-----"
                                ])
 
-    else:  # INSTRUCTIONS FOR MANUAL FIXING WHEN FCX MODE IS FALSE
-        if ("Achievements: true" in logtext and "achievements.dll" in logtext) or ("Achievements: true" in logtext and "UnlimitedSurvivalMode.dll" in logtext):
-            output.writelines(["# CAUTION: Achievements Mod and/or Unlimited Survival Mode is installed, but Achievements parameter is set to TRUE #",
+        else:  # INSTRUCTIONS FOR MANUAL FIXING WHEN FCX MODE IS FALSE
+            if ("Achievements: true" in logtext and "achievements.dll" in logtext) or ("Achievements: true" in logtext and "UnlimitedSurvivalMode.dll" in logtext):
+                output.writelines(["# CAUTION: Achievements Mod and/or Unlimited Survival Mode is installed, but Achievements parameter is set to TRUE #",
                                "FIX: Open *Buffout4.toml* and change Achievements parameter to FALSE, this prevents conflicts with Buffout 4.",
                                "-----"
                                ])
-        else:
-            output.write("Achievements parameter in *Buffout4.toml* is correctly configured. \n-----")
+            else:
+                output.write("Achievements parameter in *Buffout4.toml* is correctly configured. \n-----")
 
-        if "MemoryManager: true" in logtext and "BakaScrapHeap.dll" in logtext:
-            output.writelines(["# CAUTION: Baka ScrapHeap is installed, but MemoryManager parameter is set to TRUE #",
+            if "MemoryManager: true" in logtext and "BakaScrapHeap.dll" in logtext:
+                output.writelines(["# CAUTION: Baka ScrapHeap is installed, but MemoryManager parameter is set to TRUE #",
                                "FIX: Open *Buffout4.toml* and change MemoryManager parameter to FALSE, this prevents conflicts with Buffout 4.",
                                "-----"])
-        else:
-            output.write("Memory Manager parameter in *Buffout4.toml* is correctly configured. \n-----")
+            else:
+                output.write("Memory Manager parameter in *Buffout4.toml* is correctly configured. \n-----")
 
         if "F4EE: false" in logtext and "f4ee.dll" in logtext:
             output.writelines(["# CAUTION: Looks Menu is installed, but F4EE parameter under [Compatibility] is set to FALSE #",
@@ -477,43 +472,43 @@ for file in logs:
         else:
             output.write("Looks Menu (F4EE) parameter in *Buffout4.toml* is correctly configured. \n-----")
 
-    output.writelines(["====================================================",
+        output.writelines(["====================================================",
                        "CHECKING IF LOG MATCHES ANY KNOWN CRASH MESSAGES...",
                        "===================================================="
                        ])
-    Buffout_Trap = False  # RETURN TRUE IF KNOWN CRASH MESSAGE WAS FOUND
+        Buffout_Trap= False  # RETURN TRUE IF KNOWN CRASH MESSAGE WAS FOUND
 
     # ====================== HEADER ERRORS ======================
 
-    if ".dll" in buff_error and "tbbmalloc" not in buff_error:
-        output.write("# MAIN ERROR REPORTS A DLL WAS INVLOVED IN THIS CRASH! # \n-----")
+        if ".dll" in buff_error and "tbbmalloc" not in buff_error:
+            output.write("# MAIN ERROR REPORTS A DLL WAS INVLOVED IN THIS CRASH! # \n-----")
 
-    if "EXCEPTION_STACK_OVERFLOW" in buff_error:
-        output.writelines(["# Checking for Stack Overflow Crash.........CULPRIT FOUND! #",
+        if "EXCEPTION_STACK_OVERFLOW" in buff_error:
+            output.writelines(["# Checking for Stack Overflow Crash.........CULPRIT FOUND! #",
                            "> Priority : [5]"
                            ])
-        Buffout_Trap = True
-        statC_Overflow += 1
+            Buffout_Trap= True
+            statC_Overflow += 1
 
-    if "0x000100000000" in buff_error:
-        output.writelines(["# Checking for Active Effects Crash.........CULPRIT FOUND! #",
+        if "0x000100000000" in buff_error:
+            output.writelines(["# Checking for Active Effects Crash.........CULPRIT FOUND! #",
                            "> Priority : [5]"
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_ActiveEffect += 1
 
     if "EXCEPTION_INT_DIVIDE_BY_ZERO" in buff_error:
         output.writelines(["# Checking for Bad Math Crash...............CULPRIT FOUND! #",
                            "> Priority : [5]"
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_BadMath += 1
 
     if "0x000000000000" in buff_error:
         output.writelines(["# Checking for Null Crash...................CULPRIT FOUND! #",
                            "> Priority : [5]"
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_Null += 1
 
     # ======================= MAIN ERRORS =======================
@@ -529,70 +524,70 @@ for file in logs:
         output.writelines(["# Checking for DLL Crash....................CULPRIT FOUND! #",
                            f'> Priority : [5] | DLCBannerDLC01.dds : {logtext.count("DLCBannerDLC01.dds")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_DLL += 1
     # ===========================================================
     if "BGSLocation" in logtext and "BGSQueuedTerrainInitialLoad" in logtext:
         output.writelines(['# Checking for LOD Crash....................CULPRIT FOUND! #',
                            f'> Priority : [5] | BGSLocation : {logtext.count("BGSLocation")} | BGSQueuedTerrainInitialLoad : {logtext.count("BGSQueuedTerrainInitialLoad")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_LOD += 1
     # ===========================================================
     if ("FaderData" or "FaderMenu" or "UIMessage") in logtext:
         output.writelines(["# Checking for MCM Crash....................CULPRIT FOUND! #",
                            f'> Priority : [3] | FaderData : {logtext.count("FaderData")} | FaderMenu : {logtext.count("FaderMenu")} | UIMessage : {logtext.count("UIMessage")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_MCM += 1
     # ===========================================================
     if ("BGSDecalManager" or "BSTempEffectGeometryDecal") in logtext:
         output.writelines(["# Checking for Decal Crash..................CULPRIT FOUND! #",
                            f'> Priority : [5] | BGSDecalManager : {logtext.count("BGSDecalManager")} | BSTempEffectGeometryDecal : {logtext.count("BSTempEffectGeometryDecal")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_Decal += 1
     # ===========================================================
     if logtext.count("PipboyMapData") >= 2:
         output.writelines(["# Checking for Equip Crash..................CULPRIT FOUND! #",
                            f'> Priority : [2] | PipboyMapData : {logtext.count("PipboyMapData")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_Equip += 1
     # ===========================================================
     if (logtext.count("Papyrus") or logtext.count("VirtualMachine")) >= 2:
         output.writelines(["# Checking for Script Crash.................CULPRIT FOUND! #",
                            f'> Priority : [3] | Papyrus : {logtext.count("Papyrus")} | VirtualMachine : {logtext.count("VirtualMachine")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_Papyrus += 1
     # ===========================================================
     if logtext.count("tbbmalloc.dll") >= 3 or "tbbmalloc" in buff_error:
         output.writelines(["# Checking for Generic Crash................CULPRIT FOUND! #",
                            f'> Priority : [2] | tbbmalloc.dll : {logtext.count("tbbmalloc.dll")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_Generic += 1
     # ===========================================================
     if "LooseFileAsyncStream" in logtext:
         output.writelines(["# Checking for BA2 Limit Crash..............CULPRIT FOUND! #",
                            f'> Priority : [5] | LooseFileAsyncStream : {logtext.count("LooseFileAsyncStream")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_BA2Limit += 1
     # ===========================================================
     if logtext.count("d3d11.dll") >= 3 or "d3d11" in buff_error:
         output.writelines(["# Checking for Rendering Crash..............CULPRIT FOUND! #",
                            f'> Priority : [4] | d3d11.dll : {logtext.count("d3d11.dll")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_Rendering += 1
     # ===========================================================
     if ("GridAdjacencyMapNode" or "PowerUtils") in logtext:
         output.writelines(["# Checking for Grid Scrap Crash.............CULPRIT FOUND! #",
                            f'> Priority : [5] | GridAdjacencyMapNode : {logtext.count("GridAdjacencyMapNode")} | PowerUtils : {logtext.count("PowerUtils")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_GridScrap += 1
     # ===========================================================
     if ("LooseFileStream" or "BSFadeNode" or "BSMultiBoundNode") in logtext and logtext.count("LooseFileAsyncStream") == 0:
@@ -600,28 +595,28 @@ for file in logs:
                            f'> Priority : [4] | LooseFileStream : {logtext.count("LooseFileStream")} | BSFadeNode : {logtext.count("BSFadeNode")}',
                            f'                   BSMultiBoundNode : {logtext.count("BSMultiBoundNode")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_NIF += 1
     # ===========================================================
     if ("Create2DTexture" or "DefaultTexture") in logtext:
         output.writelines(["# Checking for Texture (DDS) Crash..........CULPRIT FOUND! #",
                            f'> Priority : [3] | Create2DTexture : {logtext.count("Create2DTexture")} | DefaultTexture : {logtext.count("DefaultTexture")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statlogtexture += 1
     # ===========================================================
     if ("DefaultTexture_Black" or "NiAlphaProperty") in logtext:
         output.writelines(["# Checking for Material (BGSM) Crash........CULPRIT FOUND! #",
                            f'> Priority : [3] | DefaultTexture_Black : {logtext.count("DefaultTexture_Black")} | NiAlphaProperty : {logtext.count("NiAlphaProperty")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_BGSM += 1
     # ===========================================================
     if (logtext.count("bdhkm64.dll") or logtext.count("usvfs::hook_DeleteFileW")) >= 2:
         output.writelines(["# Checking for BitDefender Crash............CULPRIT FOUND! #",
                            f'> Priority : [5] | bdhkm64.dll : {logtext.count("bdhkm64.dll")} | usvfs::hook_DeleteFileW : {logtext.count("usvfs::hook_DeleteFileW")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_BitDefender += 1
     # ===========================================================
     if ("PathingCell" or "BSPathBuilder" or "PathManagerServer") in logtext:
@@ -629,62 +624,62 @@ for file in logs:
                            f'> Priority : [3] | PathingCell : {logtext.count("PathingCell")} | BSPathBuilder : {logtext.count("BSPathBuilder")}',
                            f'                   PathManagerServer : {logtext.count("PathManagerServer")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_NPCPathing += 1
     elif ("NavMesh" or "BSNavmeshObstacleData" or "DynamicNavmesh") in logtext:
         output.writelines(["# Checking for NPC Pathing Crash............CULPRIT FOUND! #",
                            f'> Priority : [3] | NavMesh : {logtext.count("NavMesh")} | BSNavmeshObstacleData : {logtext.count("BSNavmeshObstacleData")}',
                            f'                   DynamicNavmesh : {logtext.count("DynamicNavmesh")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_NPCPathing += 1
     # ===========================================================
     if logtext.count("X3DAudio1_7.dll") >= 3 or logtext.count("XAudio2_7.dll") >= 3 or ("X3DAudio1_7" or "XAudio2_7") in buff_error:
         output.writelines(["# Checking for Audio Driver Crash...........CULPRIT FOUND! #",
                            f'> Priority : [5] | X3DAudio1_7.dll : {logtext.count("X3DAudio1_7.dll")} | XAudio2_7.dll : {logtext.count("XAudio2_7.dll")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_Audio += 1
     # ===========================================================
     if logtext.count("cbp.dll") >= 3 or "skeleton.nif" in logtext or "cbp.dll" in buff_error:
         output.writelines(["# Checking for Body Physics Crash...........CULPRIT FOUND! #",
                            f'> Priority : [4] | cbp.dll : {logtext.count("cbp.dll")} | skeleton.nif : {logtext.count("skeleton.nif")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_BodyPhysics += 1
     # ===========================================================
     if ("BSMemStorage" or "DataFileHandleReaderWriter") in logtext:
         output.writelines(["# Checking for Plugin Limit Crash...........CULPRIT FOUND! #",
                            f'> Priority : [5] | BSMemStorage : {logtext.count("BSMemStorage")} | DataFileHandleReaderWriter : {logtext.count("DataFileHandleReaderWriter")}'])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_PluginLimit += 1
     # ===========================================================
     if "GamebryoSequenceGenerator" in logtext or "+0DB9300" in buff_error:
         output.writelines(["# Checking for Plugin Order Crash...........CULPRIT FOUND! #",
                            f'> Priority : [5] | GamebryoSequenceGenerator : {logtext.count("GamebryoSequenceGenerator")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_LoadOrder += 1
     # ===========================================================
     if logtext.count("BSD3DResourceCreator") == 3 or logtext.count("BSD3DResourceCreator") == 6:
         output.writelines(["# Checking for MO2 Extractor Crash..........CULPRIT FOUND! #",
                            f'> Priority : [5] | BSD3DResourceCreator : {logtext.count("BSD3DResourceCreator")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_MO2Unp += 1
     # ===========================================================
     if logtext.count("flexRelease_x64.dll") >= 2 or "flexRelease_x64" in buff_error:
         output.writelines(["# Checking for Nvidia Debris Crash..........CULPRIT FOUND! #",
                            f'> Priority : [5] | flexRelease_x64.dll : {logtext.count("flexRelease_x64.dll")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_NVDebris += 1
     # ===========================================================
     if logtext.count("nvwgf2umx.dll") >= 10 or ("nvwgf2umx" or "USER32.dll") in buff_error:
         output.writelines(["# Checking for Nvidia Driver Crash..........CULPRIT FOUND! #",
                            f'> Priority : [5] | nvwgf2umx.dll : {logtext.count("nvwgf2umx.dll")} | USER32.dll : {logtext.count("USER32.dll")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_NVDriver += 1
     # ===========================================================
     if (logtext.count("KERNELBASE.dll") or logtext.count("MSVCP140.dll")) >= 3 and "DxvkSubmissionQueue" in logtext:
@@ -692,28 +687,28 @@ for file in logs:
                            f'> Priority : [5] | KERNELBASE.dll : {logtext.count("KERNELBASE.dll")} | MSVCP140.dll : {logtext.count("MSVCP140.dll")}',
                            f'                   DxvkSubmissionQueue : {logtext.count("DxvkSubmissionQueue")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_VulkanMem += 1
     # ===========================================================
     if ("dxvk::DXGIAdapter" or "dxvk::DXGIFactory") in logtext:
         output.writelines(["# Checking for Vulkan Settings Crash........CULPRIT FOUND! #",
                            f'> Priority : [5] | dxvk::DXGIAdapter : {logtext.count("dxvk::DXGIAdapter")} | dxvk::DXGIFactory : {logtext.count("dxvk::DXGIFactory")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_VulkanSet += 1
     # ===========================================================
     if ("BSXAudio2DataSrc" or "BSXAudio2GameSound") in logtext:
         output.writelines(["# Checking for Corrupted Audio Crash........CULPRIT FOUND! #",
                            f'> Priority : [4] | BSXAudio2DataSrc : {logtext.count("BSXAudio2DataSrc")} | BSXAudio2GameSound : {logtext.count("BSXAudio2GameSound")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_CorruptedAudio += 1
     # ===========================================================
     if ("SysWindowCompileAndRun" or "ConsoleLogPrinter") in logtext:
         output.writelines(["# Checking for Console Command Crash........CULPRIT FOUND! #",
                            f'> Priority : [1] | SysWindowCompileAndRun : {logtext.count("SysWindowCompileAndRun")} | ConsoleLogPrinter : {logtext.count("ConsoleLogPrinter")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_ConsoleCommands += 1
     # ===========================================================
     if "BGSWaterCollisionManager" in logtext:
@@ -721,14 +716,14 @@ for file in logs:
                            "PLEASE CONTACT ME AS SOON AS POSSIBLE! (CONTACT INFO BELOW)",
                            f'> Priority : [6] | BGSWaterCollisionManager : {logtext.count("BGSWaterCollisionManager")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_Water += 1
     # ===========================================================
     if "ParticleSystem" in logtext:
         output.writelines(["# Checking for Particle Effects Crash.......CULPRIT FOUND! #",
                            f'> Priority : [4] | ParticleSystem : {logtext.count("ParticleSystem")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_Particles += 1
     # ===========================================================
     if ("hkbVariableBindingSet" or "hkbHandIkControlsModifier" or "hkbBehaviorGraph" or "hkbModifierList") in logtext:
@@ -736,14 +731,14 @@ for file in logs:
                            f'> Priority : [5] | hkbVariableBindingSet : {logtext.count("hkbVariableBindingSet")} | hkbHandIkControlsModifier : {logtext.count("hkbHandIkControlsModifier")}',
                            f'                   hkbBehaviorGraph : {logtext.count("hkbBehaviorGraph")} | hkbModifierList : {logtext.count("hkbModifierList")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_AnimationPhysics += 1
     # ===========================================================
     if "DLCBanner05.dds" in logtext:
         output.writelines(["# Checking for Archive Invalidation Crash...CULPRIT FOUND! #",
                            f'> Priority : [5] | DLCBanner05.dds : {logtext.count("DLCBanner05.dds")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statC_Invalidation += 1
 
     # ===========================================================
@@ -753,7 +748,7 @@ for file in logs:
         output.writelines(["Checking for *[Creation Club Crash].......DETECTED!",
                            "> Priority : [5]"
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statU_CClub += 1
 
     if ("BGSMod::Attachment" or "BGSMod::Template" or "BGSMod::Template::Item") in logtext:
@@ -761,14 +756,14 @@ for file in logs:
                            f'> Priority : [5] | BGSMod::Attachment : {logtext.count("BGSMod::Attachment")} | BGSMod::Template : {logtext.count("BGSMod::Template")}',
                            f'                        BGSMod::Template::Item : {logtext.count("BGSMod::Template::Item")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statU_Item += 1
     # ===========================================================
     if logtext.count("BGSSaveFormBuffer") >= 2:
         output.writelines(["Checking for *[Save Crash]................DETECTED!",
                            f'> Priority : [5] | BGSSaveFormBuffer : {logtext.count("BGSSaveFormBuffer")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statU_Save += 1
     # ===========================================================
     if ("ButtonEvent" or "MenuControls" or "MenuOpenCloseHandler" or "PlayerControls" or "DXGISwapChain") in logtext:
@@ -777,7 +772,7 @@ for file in logs:
                            f'                        MenuOpenCloseHandler : {logtext.count("MenuOpenCloseHandler")} | PlayerControls : {logtext.count("PlayerControls")}',
                            f'                        DXGISwapChain : {logtext.count("DXGISwapChain")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statU_Input += 1
     # ===========================================================
     if ("BGSSaveLoadManager" or "BGSSaveLoadThread" or "BGSSaveFormBuffer") in logtext or ("+0CDAD30" or "+0D09AB7") in buff_error:
@@ -785,7 +780,7 @@ for file in logs:
                            f'> Priority : [5] | BGSSaveLoadManager : {logtext.count("BGSSaveLoadManager")} | BGSSaveLoadThread : {logtext.count("BGSSaveLoadThread")}',
                            f'                        BGSSaveFormBuffer : {logtext.count("BGSSaveFormBuffer")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statU_INI += 1
     # ===========================================================
     if ("BGSProcedurePatrol" or "BGSProcedurePatrolExecState" or "PatrolActorPackageData") in logtext:
@@ -793,7 +788,7 @@ for file in logs:
                            f'> Priority : [5] | BGSProcedurePatrol : {logtext.count("BGSProcedurePatrol")} | BGSProcedurePatrolExecStatel : {logtext.count("BGSProcedurePatrolExecState")}',
                            f'                        PatrolActorPackageData : {logtext.count("PatrolActorPackageData")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statU_Patrol += 1
     # ===========================================================
     if ("BSPackedCombinedGeomDataExtra" or "BGSCombinedCellGeometryDB" or "BGSStaticCollection" or "TESObjectCELL") in logtext:
@@ -801,21 +796,21 @@ for file in logs:
                            f'> Priority : [5] | BGSStaticCollection : {logtext.count("BGSStaticCollection")} | BGSCombinedCellGeometryDB : {logtext.count("BGSCombinedCellGeometryDB")}',
                            f'                        BSPackedCombinedGeomDataExtra : {logtext.count("BSPackedCombinedGeomDataExtra")} | TESObjectCELL : {logtext.count("TESObjectCELL")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statU_Precomb += 1
     # ===========================================================
     if "HUDAmmoCounter" in logtext:
         output.writelines(["Checking for *[Ammo Counter Crash]........DETECTED!",
                            f'> Priority : [5] | HUDAmmoCounter : {logtext.count("HUDAmmoCounter")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statU_HUDAmmo += 1
     # ===========================================================
     if ("BGSProjectile" or "CombatProjectileAimController") in logtext:
         output.writelines(["Checking for *[NPC Projectile Crash].....DETECTED!",
                            f'> Priority : [5] | BGSProjectile : {logtext.count("BGSProjectile")} | CombatProjectileAimController : {logtext.count("CombatProjectileAimController")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
     # ===========================================================
     if logtext.count("PlayerCharacter") >= 1 and (logtext.count("0x00000007") or logtext.count("0x00000014") or logtext.count("0x00000008")) >= 3:
         output.write("Checking for *[Player Character Crash]....DETECTED!")
@@ -825,7 +820,7 @@ for file in logs:
                            f'> Priority : [5] | PlayerCharacter : {logtext.count("PlayerCharacter")} | 0x00000007 : {logtext.count("0x00000007")}',
                            f'                        0x00000008 : {logtext.count("0x00000008")} | 0x000000014 : {logtext.count("0x00000014")}'
                            ])
-        Buffout_Trap = True
+        Buffout_Trap= True
         statU_Player += 1
 
     # ===========================================================
@@ -850,12 +845,12 @@ for file in logs:
         "CHECKING FOR MODS THAT CAN CAUSE FREQUENT CRASHES...",
         "===================================================="
     ])
-    Mod_Trap1 = 1
+    Mod_Trap1= 1
 
     # Why lists and not dictionaries? So I can preserve alphabetical order in code and
     # numerical order in output without having to rename a bunch of variables.
     # Needs 1 empty space as prefix to prevent duplicates.
-    List_Mods1 = [" DamageThresholdFramework.esm",
+    List_Mods1= [" DamageThresholdFramework.esm",
                   " Endless Warfare.esm",
                   " ExtendedWeaponSystem.esm",
                   " EPO",
@@ -873,7 +868,7 @@ for file in logs:
                   " WeaponsFramework",
                   " WOTC.esp"]
 
-    List_Warn1 = ["DAMAGE THRESHOLD FRAMEWORK \n"
+    List_Warn1= ["DAMAGE THRESHOLD FRAMEWORK \n"
                   "- Can cause crashes in combat on some occasions due to how damage calculations are done.",
 
                   "ENDLESS WARFARE \n"
@@ -930,15 +925,15 @@ for file in logs:
         for line in plugin_list:
             for elem in List_Mods1:
                 if "File:" not in line and "[FE" not in line and elem in line:
-                    order_elem = List_Mods1.index(elem)
+                    order_elem= List_Mods1.index(elem)
                     output.writelines([f"[!] Found:{line[0:5].strip()} {List_Warn1[order_elem]}",
                                        "-----"])
-                    Mod_Trap1 = 0
+                    Mod_Trap1= 0
                 elif "File:" not in line and "[FE" in line and elem in line:
-                    order_elem = List_Mods1.index(elem)
+                    order_elem= List_Mods1.index(elem)
                     output.writelines([f"[!] Found:{line[0:9].strip()} {List_Warn1[order_elem]}",
                     "-----"])
-                    Mod_Trap1 = 0
+                    Mod_Trap1= 0
 
         if logtext.count("ClassicHolsteredWeapons") >= 3 or "ClassicHolsteredWeapons" in buff_error:
             output.writelines(["[!] Found: CLASSIC HOLSTERED WEAPONS",
@@ -948,8 +943,8 @@ for file in logs:
                                "-----"
                                ])
             statM_CHW += 1
-            Mod_Trap1 = 0
-            Buffout_Trap = True
+            Mod_Trap1= 0
+            Buffout_Trap= True
         elif logtext.count("ClassicHolsteredWeapons") >= 2 and ("UniquePlayer.esp" or "HHS.dll" or "cbp.dll" or "Body.nif") in logtext:
             output.writelines(["[!] Found: CLASSIC HOLSTERED WEAPONS",
                                "AUTOSCAN ALSO DETECTED ONE OR SEVERAL MODS THAT WILL CRASH WITH CHW.",
@@ -958,8 +953,8 @@ for file in logs:
                                "-----"
                                ])
             statM_CHW += 1
-            Mod_Trap1 = 0
-            Buffout_Trap = True
+            Mod_Trap1= 0
+            Buffout_Trap= True
         elif "ClassicHolsteredWeapons" in logtext and "d3d11" in buff_error:
             output.writelines(["[!] Found: CLASSIC HOLSTERED WEAPONS, BUT...",
                                "AUTOSCAN CANNOT ACCURATELY DETERMINE IF CHW CAUSED THIS CRASH OR NOT.",
@@ -967,7 +962,7 @@ for file in logs:
                                "This usually prevents most common crashes with Classic Holstered Weapons.",
                                "-----"
                                ])
-            Mod_Trap1 = 0
+            Mod_Trap1= 0
     if "[00]" in logtext and Mod_Trap1 == 0:
         output.writelines(["# CAUTION: ANY ABOVE DETECTED MODS HAVE A MUCH HIGHER CHANCE TO CRASH YOUR GAME! #",
                            "You can disable any/all of them temporarily to confirm they caused this crash.",
@@ -982,19 +977,20 @@ for file in logs:
                            ])
         statL_scanned += 1
     elif not "[00]" in logtext:
-        output.writelines(["# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #",
-                           "Autoscan cannot continue. Try scanning a different crash log.",
+        output.writelines(["# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #\n",
+                           "Autoscan cannot continue. Try scanning a different crash log.\n",
                            "-----"
                            ])
         statL_incomplete += 1
 
-    print("====================================================")
-    print("CHECKING FOR MODS WITH SOLUTIONS & COMMUNITY PATCHES")
-    print("====================================================")
-    Mod_Trap2 = no_repeat1 = no_repeat2 = 1  # MOD TRAP 2 | NEED 8 SPACES FOR ESL [FE:XXX]
+    output.writelines(["====================================================",
+                       "CHECKING FOR MODS WITH SOLUTIONS & COMMUNITY PATCHES",
+                       "===================================================="
+                       ])
+    Mod_Trap2= no_repeat1 = no_repeat2 = 1  # MOD TRAP 2 | NEED 8 SPACES FOR ESL [FE:XXX]
 
     # Needs 1 empty space as prefix to prevent duplicates.
-    List_Mods2 = [" DLCUltraHighResolution.esm",
+    List_Mods2= [" DLCUltraHighResolution.esm",
                   " AAF.esm",
                   " ArmorKeywords.esm",
                   " BTInteriors_Project.esp",
@@ -1028,7 +1024,7 @@ for file in logs:
                   " Creatures and Monsters.esp",
                   " ZombieWalkers"]
 
-    List_Warn2 = ["HIGH RESOLUTION DLC. I STRONGLY ADVISE NOT USING IT! \n"
+    List_Warn2= ["HIGH RESOLUTION DLC. I STRONGLY ADVISE NOT USING IT! \n"
                   "Right click on Fallout 4 in your Steam Library folder, then select Properties \n"
                   "Switch to the DLC tab and uncheck / disable the High Resolution Texture Pack",
                   #
@@ -1171,17 +1167,17 @@ for file in logs:
         for line in plugin_list:
             for elem in List_Mods2:
                 if "File:" not in line and "[FE" not in line and elem in line:
-                    order_elem = List_Mods2.index(elem)
+                    order_elem= List_Mods2.index(elem)
                     output.writelines([f"[!] Found:{line[0:5].strip()} {List_Warn2[order_elem]}",
                                        "-----"
                                        ])
-                    Mod_Trap2 = 0
+                    Mod_Trap2= 0
                 elif "File:" not in line and "[FE" in line and elem in line:
-                    order_elem = List_Mods2.index(elem)
+                    order_elem= List_Mods2.index(elem)
                     output.writelines([f"[!] Found:{line[0:9].strip()} {List_Warn2[order_elem]}",
                                       "-----"
                                       ])
-                    Mod_Trap2 = 0
+                    Mod_Trap2= 0
             if no_repeat1 == 1 and "File:" not in line and ("Depravity" or "FusionCityRising" or "HotC" or "OutcastsAndRemnants" or "ProjectValkyrie") in line:
                 output.writelines([f"[!] Found:{line[0:9].strip()} THUGGYSMURF QUEST MOD",
                                    "If you have Depravity, Fusion City Rising, HOTC, Outcasts and Remnants and/or Project Valkyrie",
@@ -1189,13 +1185,13 @@ for file in logs:
                                    "Patch Link: https://www.nexusmods.com/fallout4/mods/56876?tab=files",
                                    "-----"
                                    ])
-                no_repeat1 = Mod_Trap2 = 0
+                no_repeat1= Mod_Trap2 = 0
             if no_repeat1 == 1 and "File:" not in line and ("CaN.esm" or "AnimeRace_Nanako.esp") in line:
                 output.writelines([f"[!] Found:{line[0:9].strip()} CUSTOM RACE SKELETON MOD",
                                    "If you have AnimeRace NanakoChan or Crimes Against Nature, install the Race Skeleton Fixes.",
                                    "Skeleton Fixes Link (READ THE DESCRIPTION): https://www.nexusmods.com/fallout4/mods/56101"
                                    ])
-                no_repeat2 = Mod_Trap2 = 0
+                no_repeat2= Mod_Trap2 = 0
 
         if "FallSouls.dll" in logtext:
             output.writelines(["[!] Found: FALLSOULS UNPAUSED GAME MENUS",
@@ -1203,13 +1199,13 @@ for file in logs:
                                "Advised Fix: Toggle PipboyMenu in FallSouls MCM settings or completely reinstall the mod.",
                                "-----"
                                ])
-            Mod_Trap2 = 0
-    
-    inherentlimitations = ["[Due to inherent limitations, Auto-Scan will continue detecting certain mods,",
+            Mod_Trap2= 0
+
+    inherentlimitations= ["[Due to inherent limitations, Auto-Scan will continue detecting certain mods,",
                            " even if fixes or patches for them are already installed. You can ignore these.]",
                            "-----"
                            ]
-    nopluginlist = ["# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #",
+    nopluginlist= ["# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #",
                     "Autoscan cannot continue. Try scanning a different crash log.",
                     "-----"
                     ]
@@ -1453,10 +1449,10 @@ for file in logs:
                                ])
     else:
         output.writelines(nopluginlist)
-
-    print("====================================================")
-    print("SCANNING THE LOG FOR SPECIFIC (POSSIBLE) CUPLRITS...")
-    print("====================================================")
+    output.writelines(["====================================================",
+                       "SCANNING THE LOG FOR SPECIFIC (POSSIBLE) CUPLRITS...",
+                       "===================================================="
+                       ])
 
     list_DETPLUGINS = []
     list_DETFORMIDS = []
@@ -1464,10 +1460,6 @@ for file in logs:
     list_ALLPLUGINS = []
 
     if not "f4se_1_10_163.dll" in logtext and "steam_api64.dll" in logtext:
-        print("AUTOSCAN CANNOT FIND FALLOUT 4 SCRIPT EXTENDER DLL!")
-        print("MAKE SURE THAT F4SE IS CORRECTLY INSTALLED!")
-        print("Link: https://f4se.silverlock.org")
-        print("-----")
         output.writelines(["AUTOSCAN CANNOT FIND FALLOUT 4 SCRIPT EXTENDER DLL!",
                            "MAKE SURE THAT F4SE IS CORRECTLY INSTALLED!",
                            "Link: https://f4se.silverlock.org",
@@ -1515,10 +1507,6 @@ for file in logs:
                            "-----"
                            ])
     else:
-        print("-----")
-        print("These Plugins were caught by Buffout 4 and some of them might be responsible for this crash.")
-        print("You can try disabling these plugins and recheck your game, though this method can be unreliable.")
-        print("-----")
         output.writelines(["-----",
                            "These Plugins were caught by Buffout 4 and some of them might be responsible for this crash.",
                            "You can try disabling these plugins and recheck your game, though this method can be unreliable.",
@@ -1527,7 +1515,7 @@ for file in logs:
 
     # ===========================================================
 
-    print("LIST OF (POSSIBLE) FORM ID CULRIPTS:")
+    output.write("LIST OF (POSSIBLE) FORM ID CULRIPTS:")
     for line in loglines:
         if "Form ID:" in line and not "0xFF" in line:
             line = line.replace("0x", "")
@@ -1591,10 +1579,6 @@ for file in logs:
                            "-----"
                            ])
 
-    print("FOR FULL LIST OF MODS THAT CAUSE PROBLEMS, THEIR ALTERNATIVES AND DETAILED SOLUTIONS,")
-    print("VISIT THE BUFFOUT 4 CRASH ARTICLE: https://www.nexusmods.com/fallout4/articles/3115")
-    print("===============================================================================")
-    print("END OF AUTOSCAN | Author/Made By: Poet#9800 (DISCORD) |", CLAS_Date)
     output.writelines(["FOR FULL LIST OF MODS THAT CAUSE PROBLEMS, THEIR ALTERNATIVES AND DETAILED SOLUTIONS,",
                        "VISIT THE BUFFOUT 4 CRASH ARTICLE: https://www.nexusmods.com/fallout4/articles/3115",
                        "===============================================================================",

--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -106,7 +106,7 @@ statL_scanned = statL_incomplete = statL_failed = statL_veryold = 0
 # KNOWN CRASH MESSAGES
 statC_ActiveEffect = statC_AnimationPhysics = statC_Audio = statC_BA2Limit = statC_BGSM = statC_BitDefender = statC_BodyPhysics = statC_ConsoleCommands = statC_CorruptedTex = 0
 statC_DLL = statC_Equip = statC_Generic = statC_GridScrap = statC_Invalidation = statC_LoadOrder = statC_MCM = statC_BadMath = statC_NIF = statC_NPCPathing = statC_NVDebris = 0
-statC_NVDriver = statC_Null = statC_Overflow = statC_Papyrus = statC_Particles = statC_PluginLimit = statC_Rendering = statlogtexture = statC_CorruptedAudio = statC_LOD = 0
+statC_NVDriver = statC_Null = statC_Overflow = statC_Papyrus = statC_Particles = statC_PluginLimit = statC_Rendering = statC_Texture = statC_CorruptedAudio = statC_LOD = 0
 statC_Decal = statC_MO2Unp = statC_VulkanMem = statC_VulkanSet = statC_Water = 0
 # UNSOLVED CRASH MESSAGES
 statU_Precomb = statU_Player = statU_Save = statU_HUDAmmo = statU_Patrol = statU_Projectile = statU_Item = statU_Input = statU_INI = statU_CClub = 0
@@ -577,7 +577,7 @@ for file in logs:
             output.write("# Checking for Texture (DDS) Crash..........CULPRIT FOUND! #\n")
             output.write(f'> Priority : [3] | Create2DTexture : {logtext.count("Create2DTexture")} | DefaultTexture : {logtext.count("DefaultTexture")}\n')
             Buffout_Trap = True
-            statlogtexture += 1
+            statC_Texture += 1
         # ===========================================================
         if ("DefaultTexture_Black" or "NiAlphaProperty") in logtext:
             output.write("# Checking for Material (BGSM) Crash........CULPRIT FOUND! #\n")
@@ -1566,7 +1566,7 @@ if CLAS_config.getboolean("MAIN", "Stat Logging") == True:
     print("Logs with Rendering Crash................", statC_Rendering)
     print("Logs with Grid Scrap Crash...............", statC_GridScrap)
     print("Logs with Mesh (NIF) Crash...............", statC_NIF)
-    print("Logs with Texture (DDS) Crash............", statlogtexture)
+    print("Logs with Texture (DDS) Crash............", statC_Texture)
     print("Logs with Material (BGSM) Crash..........", statC_BGSM)
     print("Logs with BitDefender Crash..............", statC_BitDefender)
     print("Logs with NPC Pathing Crash..............", statC_NPCPathing)

--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -474,30 +474,26 @@ for file in logs:
             output.write("# MAIN ERROR REPORTS A DLL WAS INVLOVED IN THIS CRASH! # \n-----")
 
         if "EXCEPTION_STACK_OVERFLOW" in buff_error:
-            output.writelines(["# Checking for Stack Overflow Crash.........CULPRIT FOUND! #",
-                               "> Priority : [5]"
-                               ])
+            output.write("# Checking for Stack Overflow Crash.........CULPRIT FOUND! #")
+            output.write("> Priority : [5]")
             Buffout_Trap = True
             statC_Overflow += 1
 
         if "0x000100000000" in buff_error:
-            output.writelines(["# Checking for Active Effects Crash.........CULPRIT FOUND! #",
-                               "> Priority : [5]"
-                               ])
-        Buffout_Trap = True
-        statC_ActiveEffect += 1
+            output.write("# Checking for Active Effects Crash.........CULPRIT FOUND! #")
+            output.write("> Priority : [5]")
+            Buffout_Trap = True
+            statC_ActiveEffect += 1
 
         if "EXCEPTION_INT_DIVIDE_BY_ZERO" in buff_error:
-            output.writelines(["# Checking for Bad Math Crash...............CULPRIT FOUND! #",
-                               "> Priority : [5]"
-                               ])
+            output.write("# Checking for Bad Math Crash...............CULPRIT FOUND! #")
+            output.write("> Priority : [5]")
             Buffout_Trap = True
             statC_BadMath += 1
 
         if "0x000000000000" in buff_error:
-            output.writelines(["# Checking for Null Crash...................CULPRIT FOUND! #",
-                               "> Priority : [5]"
-                               ])
+            output.write("# Checking for Null Crash...................CULPRIT FOUND! #")
+            output.write("> Priority : [5]")
             Buffout_Trap = True
             statC_Null += 1
 
@@ -511,223 +507,193 @@ for file in logs:
 
         # ===========================================================
         if "DLCBannerDLC01.dds" in logtext:
-            output.writelines(["# Checking for DLL Crash....................CULPRIT FOUND! #",
-                               f'> Priority : [5] | DLCBannerDLC01.dds : {logtext.count("DLCBannerDLC01.dds")}'
-                               ])
+            output.write("# Checking for DLL Crash....................CULPRIT FOUND! #")
+            output.write(f'> Priority : [5] | DLCBannerDLC01.dds : {logtext.count("DLCBannerDLC01.dds")}')
             Buffout_Trap = True
             statC_DLL += 1
         # ===========================================================
         if "BGSLocation" in logtext and "BGSQueuedTerrainInitialLoad" in logtext:
-            output.writelines(['# Checking for LOD Crash....................CULPRIT FOUND! #',
-                               f'> Priority : [5] | BGSLocation : {logtext.count("BGSLocation")} | BGSQueuedTerrainInitialLoad : {logtext.count("BGSQueuedTerrainInitialLoad")}'
-                               ])
+            output.write('# Checking for LOD Crash....................CULPRIT FOUND! #')
+            output.write(f'> Priority : [5] | BGSLocation : {logtext.count("BGSLocation")} | BGSQueuedTerrainInitialLoad : {logtext.count("BGSQueuedTerrainInitialLoad")}')
             Buffout_Trap = True
             statC_LOD += 1
         # ===========================================================
         if ("FaderData" or "FaderMenu" or "UIMessage") in logtext:
-            output.writelines(["# Checking for MCM Crash....................CULPRIT FOUND! #",
-                               f'> Priority : [3] | FaderData : {logtext.count("FaderData")} | FaderMenu : {logtext.count("FaderMenu")} | UIMessage : {logtext.count("UIMessage")}'
-                               ])
+            output.write("# Checking for MCM Crash....................CULPRIT FOUND! #")
+            output.write(f'> Priority : [3] | FaderData : {logtext.count("FaderData")} | FaderMenu : {logtext.count("FaderMenu")} | UIMessage : {logtext.count("UIMessage")}')
             Buffout_Trap = True
             statC_MCM += 1
         # ===========================================================
         if ("BGSDecalManager" or "BSTempEffectGeometryDecal") in logtext:
-            output.writelines(["# Checking for Decal Crash..................CULPRIT FOUND! #",
-                               f'> Priority : [5] | BGSDecalManager : {logtext.count("BGSDecalManager")} | BSTempEffectGeometryDecal : {logtext.count("BSTempEffectGeometryDecal")}'
-                               ])
+            output.write("# Checking for Decal Crash..................CULPRIT FOUND! #")
+            output.write(f'> Priority : [5] | BGSDecalManager : {logtext.count("BGSDecalManager")} | BSTempEffectGeometryDecal : {logtext.count("BSTempEffectGeometryDecal")}')
             Buffout_Trap = True
             statC_Decal += 1
         # ===========================================================
         if logtext.count("PipboyMapData") >= 2:
-            output.writelines(["# Checking for Equip Crash..................CULPRIT FOUND! #",
-                               f'> Priority : [2] | PipboyMapData : {logtext.count("PipboyMapData")}'
-                               ])
+            output.write("# Checking for Equip Crash..................CULPRIT FOUND! #")
+            output.write(f'> Priority : [2] | PipboyMapData : {logtext.count("PipboyMapData")}')
             Buffout_Trap = True
             statC_Equip += 1
         # ===========================================================
         if (logtext.count("Papyrus") or logtext.count("VirtualMachine")) >= 2:
-            output.writelines(["# Checking for Script Crash.................CULPRIT FOUND! #",
-                               f'> Priority : [3] | Papyrus : {logtext.count("Papyrus")} | VirtualMachine : {logtext.count("VirtualMachine")}'
-                               ])
+            output.writelines("# Checking for Script Crash.................CULPRIT FOUND! #")
+            output.write(f'> Priority : [3] | Papyrus : {logtext.count("Papyrus")} | VirtualMachine : {logtext.count("VirtualMachine")}')                               
             Buffout_Trap = True
             statC_Papyrus += 1
         # ===========================================================
         if logtext.count("tbbmalloc.dll") >= 3 or "tbbmalloc" in buff_error:
-            output.writelines(["# Checking for Generic Crash................CULPRIT FOUND! #",
-                               f'> Priority : [2] | tbbmalloc.dll : {logtext.count("tbbmalloc.dll")}'
-                               ])
+            output.write("# Checking for Generic Crash................CULPRIT FOUND! #")
+            output.write(f'> Priority : [2] | tbbmalloc.dll : {logtext.count("tbbmalloc.dll")}')
             Buffout_Trap = True
             statC_Generic += 1
         # ===========================================================
         if "LooseFileAsyncStream" in logtext:
-            output.writelines(["# Checking for BA2 Limit Crash..............CULPRIT FOUND! #",
-                               f'> Priority : [5] | LooseFileAsyncStream : {logtext.count("LooseFileAsyncStream")}'
-                               ])
+            output.write("# Checking for BA2 Limit Crash..............CULPRIT FOUND! #")
+            output.write(f'> Priority : [5] | LooseFileAsyncStream : {logtext.count("LooseFileAsyncStream")}')
             Buffout_Trap = True
             statC_BA2Limit += 1
         # ===========================================================
         if logtext.count("d3d11.dll") >= 3 or "d3d11" in buff_error:
-            output.writelines(["# Checking for Rendering Crash..............CULPRIT FOUND! #",
-                               f'> Priority : [4] | d3d11.dll : {logtext.count("d3d11.dll")}'
-                               ])
+            output.write("# Checking for Rendering Crash..............CULPRIT FOUND! #")
+            output.write(f'> Priority : [4] | d3d11.dll : {logtext.count("d3d11.dll")}')
             Buffout_Trap = True
             statC_Rendering += 1
         # ===========================================================
         if ("GridAdjacencyMapNode" or "PowerUtils") in logtext:
-            output.writelines(["# Checking for Grid Scrap Crash.............CULPRIT FOUND! #",
-                               f'> Priority : [5] | GridAdjacencyMapNode : {logtext.count("GridAdjacencyMapNode")} | PowerUtils : {logtext.count("PowerUtils")}'
-                               ])
+            output.write("# Checking for Grid Scrap Crash.............CULPRIT FOUND! #")
+            output.write(f'> Priority : [5] | GridAdjacencyMapNode : {logtext.count("GridAdjacencyMapNode")} | PowerUtils : {logtext.count("PowerUtils")}')
             Buffout_Trap = True
             statC_GridScrap += 1
         # ===========================================================
         if ("LooseFileStream" or "BSFadeNode" or "BSMultiBoundNode") in logtext and logtext.count("LooseFileAsyncStream") == 0:
-            output.writelines(["# Checking for Mesh (NIF) Crash.............CULPRIT FOUND! #",
-                               f'> Priority : [4] | LooseFileStream : {logtext.count("LooseFileStream")} | BSFadeNode : {logtext.count("BSFadeNode")}',
-                               f'                   BSMultiBoundNode : {logtext.count("BSMultiBoundNode")}'
-                               ])
+            output.write("# Checking for Mesh (NIF) Crash.............CULPRIT FOUND! #")
+            output.write(f'> Priority : [4] | LooseFileStream : {logtext.count("LooseFileStream")} | BSFadeNode : {logtext.count("BSFadeNode")}')
+            output.write(f'                   BSMultiBoundNode : {logtext.count("BSMultiBoundNode")}')
             Buffout_Trap = True
             statC_NIF += 1
         # ===========================================================
         if ("Create2DTexture" or "DefaultTexture") in logtext:
-            output.writelines(["# Checking for Texture (DDS) Crash..........CULPRIT FOUND! #",
-                               f'> Priority : [3] | Create2DTexture : {logtext.count("Create2DTexture")} | DefaultTexture : {logtext.count("DefaultTexture")}'
-                               ])
+            output.write("# Checking for Texture (DDS) Crash..........CULPRIT FOUND! #")
+            output.write(f'> Priority : [3] | Create2DTexture : {logtext.count("Create2DTexture")} | DefaultTexture : {logtext.count("DefaultTexture")}')
             Buffout_Trap = True
             statlogtexture += 1
         # ===========================================================
         if ("DefaultTexture_Black" or "NiAlphaProperty") in logtext:
-            output.writelines(["# Checking for Material (BGSM) Crash........CULPRIT FOUND! #",
-                               f'> Priority : [3] | DefaultTexture_Black : {logtext.count("DefaultTexture_Black")} | NiAlphaProperty : {logtext.count("NiAlphaProperty")}'
-                               ])
+            output.write("# Checking for Material (BGSM) Crash........CULPRIT FOUND! #")
+            output.write(f'> Priority : [3] | DefaultTexture_Black : {logtext.count("DefaultTexture_Black")} | NiAlphaProperty : {logtext.count("NiAlphaProperty")}')
             Buffout_Trap = True
             statC_BGSM += 1
         # ===========================================================
         if (logtext.count("bdhkm64.dll") or logtext.count("usvfs::hook_DeleteFileW")) >= 2:
-            output.writelines(["# Checking for BitDefender Crash............CULPRIT FOUND! #",
-                               f'> Priority : [5] | bdhkm64.dll : {logtext.count("bdhkm64.dll")} | usvfs::hook_DeleteFileW : {logtext.count("usvfs::hook_DeleteFileW")}'
-                               ])
+            output.write("# Checking for BitDefender Crash............CULPRIT FOUND! #")
+            output.write(f'> Priority : [5] | bdhkm64.dll : {logtext.count("bdhkm64.dll")} | usvfs::hook_DeleteFileW : {logtext.count("usvfs::hook_DeleteFileW")}')
             Buffout_Trap = True
             statC_BitDefender += 1
         # ===========================================================
         if ("PathingCell" or "BSPathBuilder" or "PathManagerServer") in logtext:
-            output.writelines(["# Checking for NPC Pathing Crash............CULPRIT FOUND! #",
-                               f'> Priority : [3] | PathingCell : {logtext.count("PathingCell")} | BSPathBuilder : {logtext.count("BSPathBuilder")}',
-                               f'                   PathManagerServer : {logtext.count("PathManagerServer")}'
-                               ])
+            output.write("# Checking for NPC Pathing Crash............CULPRIT FOUND! #")
+            output.write(f'> Priority : [3] | PathingCell : {logtext.count("PathingCell")} | BSPathBuilder : {logtext.count("BSPathBuilder")}')
+            output.write(f'                   PathManagerServer : {logtext.count("PathManagerServer")}')
             Buffout_Trap = True
             statC_NPCPathing += 1
         elif ("NavMesh" or "BSNavmeshObstacleData" or "DynamicNavmesh") in logtext:
-            output.writelines(["# Checking for NPC Pathing Crash............CULPRIT FOUND! #",
-                               f'> Priority : [3] | NavMesh : {logtext.count("NavMesh")} | BSNavmeshObstacleData : {logtext.count("BSNavmeshObstacleData")}',
-                               f'                   DynamicNavmesh : {logtext.count("DynamicNavmesh")}'
-                               ])
+            output.write("# Checking for NPC Pathing Crash............CULPRIT FOUND! #")
+            output.write(f'> Priority : [3] | NavMesh : {logtext.count("NavMesh")} | BSNavmeshObstacleData : {logtext.count("BSNavmeshObstacleData")}')
+            output.write(f'                   DynamicNavmesh : {logtext.count("DynamicNavmesh")}')
             Buffout_Trap = True
             statC_NPCPathing += 1
         # ===========================================================
         if logtext.count("X3DAudio1_7.dll") >= 3 or logtext.count("XAudio2_7.dll") >= 3 or ("X3DAudio1_7" or "XAudio2_7") in buff_error:
-            output.writelines(["# Checking for Audio Driver Crash...........CULPRIT FOUND! #",
-                               f'> Priority : [5] | X3DAudio1_7.dll : {logtext.count("X3DAudio1_7.dll")} | XAudio2_7.dll : {logtext.count("XAudio2_7.dll")}'
-                               ])
+            output.write("# Checking for Audio Driver Crash...........CULPRIT FOUND! #")
+            output.write(f'> Priority : [5] | X3DAudio1_7.dll : {logtext.count("X3DAudio1_7.dll")} | XAudio2_7.dll : {logtext.count("XAudio2_7.dll")}')
             Buffout_Trap = True
             statC_Audio += 1
         # ===========================================================
         if logtext.count("cbp.dll") >= 3 or "skeleton.nif" in logtext or "cbp.dll" in buff_error:
-            output.writelines(["# Checking for Body Physics Crash...........CULPRIT FOUND! #",
-                               f'> Priority : [4] | cbp.dll : {logtext.count("cbp.dll")} | skeleton.nif : {logtext.count("skeleton.nif")}'
-                               ])
+            output.write("# Checking for Body Physics Crash...........CULPRIT FOUND! #")
+            output.write(f'> Priority : [4] | cbp.dll : {logtext.count("cbp.dll")} | skeleton.nif : {logtext.count("skeleton.nif")}')
             Buffout_Trap = True
             statC_BodyPhysics += 1
         # ===========================================================
         if ("BSMemStorage" or "DataFileHandleReaderWriter") in logtext:
-            output.writelines(["# Checking for Plugin Limit Crash...........CULPRIT FOUND! #",
-                               f'> Priority : [5] | BSMemStorage : {logtext.count("BSMemStorage")} | DataFileHandleReaderWriter : {logtext.count("DataFileHandleReaderWriter")}'])
+            output.write("# Checking for Plugin Limit Crash...........CULPRIT FOUND! #")
+            output.write(f'> Priority : [5] | BSMemStorage : {logtext.count("BSMemStorage")} | DataFileHandleReaderWriter : {logtext.count("DataFileHandleReaderWriter")}')
             Buffout_Trap = True
             statC_PluginLimit += 1
         # ===========================================================
         if "GamebryoSequenceGenerator" in logtext or "+0DB9300" in buff_error:
-            output.writelines(["# Checking for Plugin Order Crash...........CULPRIT FOUND! #",
-                               f'> Priority : [5] | GamebryoSequenceGenerator : {logtext.count("GamebryoSequenceGenerator")}'
-                               ])
+            output.write("# Checking for Plugin Order Crash...........CULPRIT FOUND! #")
+            output.write(f'> Priority : [5] | GamebryoSequenceGenerator : {logtext.count("GamebryoSequenceGenerator")}')
             Buffout_Trap = True
             statC_LoadOrder += 1
         # ===========================================================
         if logtext.count("BSD3DResourceCreator") == 3 or logtext.count("BSD3DResourceCreator") == 6:
-            output.writelines(["# Checking for MO2 Extractor Crash..........CULPRIT FOUND! #",
-                               f'> Priority : [5] | BSD3DResourceCreator : {logtext.count("BSD3DResourceCreator")}'
-                               ])
+            output.write("# Checking for MO2 Extractor Crash..........CULPRIT FOUND! #")
+            output.write(f'> Priority : [5] | BSD3DResourceCreator : {logtext.count("BSD3DResourceCreator")}')
             Buffout_Trap = True
             statC_MO2Unp += 1
         # ===========================================================
         if logtext.count("flexRelease_x64.dll") >= 2 or "flexRelease_x64" in buff_error:
-            output.writelines(["# Checking for Nvidia Debris Crash..........CULPRIT FOUND! #",
-                               f'> Priority : [5] | flexRelease_x64.dll : {logtext.count("flexRelease_x64.dll")}'
-                               ])
+            output.write("# Checking for Nvidia Debris Crash..........CULPRIT FOUND! #")
+            output.write(f'> Priority : [5] | flexRelease_x64.dll : {logtext.count("flexRelease_x64.dll")}')
             Buffout_Trap = True
             statC_NVDebris += 1
         # ===========================================================
         if logtext.count("nvwgf2umx.dll") >= 10 or ("nvwgf2umx" or "USER32.dll") in buff_error:
-            output.writelines(["# Checking for Nvidia Driver Crash..........CULPRIT FOUND! #",
-                               f'> Priority : [5] | nvwgf2umx.dll : {logtext.count("nvwgf2umx.dll")} | USER32.dll : {logtext.count("USER32.dll")}'
-                               ])
+            output.write("# Checking for Nvidia Driver Crash..........CULPRIT FOUND! #")
+            output.write(f'> Priority : [5] | nvwgf2umx.dll : {logtext.count("nvwgf2umx.dll")} | USER32.dll : {logtext.count("USER32.dll")}')
             Buffout_Trap = True
             statC_NVDriver += 1
         # ===========================================================
         if (logtext.count("KERNELBASE.dll") or logtext.count("MSVCP140.dll")) >= 3 and "DxvkSubmissionQueue" in logtext:
-            output.writelines(["# Checking for Vulkan Memory Crash..........CULPRIT FOUND! #",
-                               f'> Priority : [5] | KERNELBASE.dll : {logtext.count("KERNELBASE.dll")} | MSVCP140.dll : {logtext.count("MSVCP140.dll")}',
-                               f'                   DxvkSubmissionQueue : {logtext.count("DxvkSubmissionQueue")}'
-                               ])
+            output.write("# Checking for Vulkan Memory Crash..........CULPRIT FOUND! #")
+            output.write(f'> Priority : [5] | KERNELBASE.dll : {logtext.count("KERNELBASE.dll")} | MSVCP140.dll : {logtext.count("MSVCP140.dll")}')
+            output.write(f'                   DxvkSubmissionQueue : {logtext.count("DxvkSubmissionQueue")}')
             Buffout_Trap = True
             statC_VulkanMem += 1
         # ===========================================================
         if ("dxvk::DXGIAdapter" or "dxvk::DXGIFactory") in logtext:
-            output.writelines(["# Checking for Vulkan Settings Crash........CULPRIT FOUND! #",
-                               f'> Priority : [5] | dxvk::DXGIAdapter : {logtext.count("dxvk::DXGIAdapter")} | dxvk::DXGIFactory : {logtext.count("dxvk::DXGIFactory")}'
-                               ])
+            output.write("# Checking for Vulkan Settings Crash........CULPRIT FOUND! #")
+            output.write(f'> Priority : [5] | dxvk::DXGIAdapter : {logtext.count("dxvk::DXGIAdapter")} | dxvk::DXGIFactory : {logtext.count("dxvk::DXGIFactory")}')
             Buffout_Trap = True
             statC_VulkanSet += 1
         # ===========================================================
         if ("BSXAudio2DataSrc" or "BSXAudio2GameSound") in logtext:
-            output.writelines(["# Checking for Corrupted Audio Crash........CULPRIT FOUND! #",
-                               f'> Priority : [4] | BSXAudio2DataSrc : {logtext.count("BSXAudio2DataSrc")} | BSXAudio2GameSound : {logtext.count("BSXAudio2GameSound")}'
-                               ])
+            output.write("# Checking for Corrupted Audio Crash........CULPRIT FOUND! #")
+            output.write(f'> Priority : [4] | BSXAudio2DataSrc : {logtext.count("BSXAudio2DataSrc")} | BSXAudio2GameSound : {logtext.count("BSXAudio2GameSound")}')
             Buffout_Trap = True
             statC_CorruptedAudio += 1
         # ===========================================================
         if ("SysWindowCompileAndRun" or "ConsoleLogPrinter") in logtext:
-            output.writelines(["# Checking for Console Command Crash........CULPRIT FOUND! #",
-                               f'> Priority : [1] | SysWindowCompileAndRun : {logtext.count("SysWindowCompileAndRun")} | ConsoleLogPrinter : {logtext.count("ConsoleLogPrinter")}'
-                               ])
+            output.write("# Checking for Console Command Crash........CULPRIT FOUND! #")
+            output.write(f'> Priority : [1] | SysWindowCompileAndRun : {logtext.count("SysWindowCompileAndRun")} | ConsoleLogPrinter : {logtext.count("ConsoleLogPrinter")}')
             Buffout_Trap = True
             statC_ConsoleCommands += 1
         # ===========================================================
         if "BGSWaterCollisionManager" in logtext:
-            output.writelines(["# Checking for Water Collision Crash........CULPRIT FOUND! #",
-                               "PLEASE CONTACT ME AS SOON AS POSSIBLE! (CONTACT INFO BELOW)",
-                               f'> Priority : [6] | BGSWaterCollisionManager : {logtext.count("BGSWaterCollisionManager")}'
-                               ])
+            output.write("# Checking for Water Collision Crash........CULPRIT FOUND! #")
+            output.write("PLEASE CONTACT ME AS SOON AS POSSIBLE! (CONTACT INFO BELOW)")
+            output.write(f'> Priority : [6] | BGSWaterCollisionManager : {logtext.count("BGSWaterCollisionManager")}')
             Buffout_Trap = True
             statC_Water += 1
         # ===========================================================
         if "ParticleSystem" in logtext:
-            output.writelines(["# Checking for Particle Effects Crash.......CULPRIT FOUND! #",
-                               f'> Priority : [4] | ParticleSystem : {logtext.count("ParticleSystem")}'
-                               ])
+            output.write("# Checking for Particle Effects Crash.......CULPRIT FOUND! #")
+            output.write(f'> Priority : [4] | ParticleSystem : {logtext.count("ParticleSystem")}')
             Buffout_Trap = True
             statC_Particles += 1
         # ===========================================================
         if ("hkbVariableBindingSet" or "hkbHandIkControlsModifier" or "hkbBehaviorGraph" or "hkbModifierList") in logtext:
-            output.writelines(["# Checking for Animation / Physics Crash....CULPRIT FOUND! #",
-                               f'> Priority : [5] | hkbVariableBindingSet : {logtext.count("hkbVariableBindingSet")} | hkbHandIkControlsModifier : {logtext.count("hkbHandIkControlsModifier")}',
-                               f'                   hkbBehaviorGraph : {logtext.count("hkbBehaviorGraph")} | hkbModifierList : {logtext.count("hkbModifierList")}'
-                               ])
+            output.write("# Checking for Animation / Physics Crash....CULPRIT FOUND! #")
+            output.write(f'> Priority : [5] | hkbVariableBindingSet : {logtext.count("hkbVariableBindingSet")} | hkbHandIkControlsModifier : {logtext.count("hkbHandIkControlsModifier")}')
+            output.write(f'                   hkbBehaviorGraph : {logtext.count("hkbBehaviorGraph")} | hkbModifierList : {logtext.count("hkbModifierList")}')
             Buffout_Trap = True
             statC_AnimationPhysics += 1
         # ===========================================================
         if "DLCBanner05.dds" in logtext:
-            output.writelines(["# Checking for Archive Invalidation Crash...CULPRIT FOUND! #",
-                               f'> Priority : [5] | DLCBanner05.dds : {logtext.count("DLCBanner05.dds")}'
-                               ])
+            output.write("# Checking for Archive Invalidation Crash...CULPRIT FOUND! #")
+            output.write(f'> Priority : [5] | DLCBanner05.dds : {logtext.count("DLCBanner05.dds")}')
             Buffout_Trap = True
             statC_Invalidation += 1
 
@@ -735,106 +701,88 @@ for file in logs:
         output.write("---------- Unsolved Crash Messages Below ----------")
 
         if "+01B59A4" in buff_error:
-            output.writelines(["Checking for *[Creation Club Crash].......DETECTED!",
-                               "> Priority : [5]"
-                               ])
+            output.write("Checking for *[Creation Club Crash].......DETECTED!")
+            output.write("> Priority : [5]")
             Buffout_Trap = True
             statU_CClub += 1
 
         if ("BGSMod::Attachment" or "BGSMod::Template" or "BGSMod::Template::Item") in logtext:
-            output.writelines(["Checking for *[Item Crash]................DETECTED!",
-                               f'> Priority : [5] | BGSMod::Attachment : {logtext.count("BGSMod::Attachment")} | BGSMod::Template : {logtext.count("BGSMod::Template")}',
-                               f'                        BGSMod::Template::Item : {logtext.count("BGSMod::Template::Item")}'
-                               ])
+            output.write("Checking for *[Item Crash]................DETECTED!")
+            output.write(f'> Priority : [5] | BGSMod::Attachment : {logtext.count("BGSMod::Attachment")} | BGSMod::Template : {logtext.count("BGSMod::Template")}')
+            output.write(f'                        BGSMod::Template::Item : {logtext.count("BGSMod::Template::Item")}')
             Buffout_Trap = True
             statU_Item += 1
         # ===========================================================
         if logtext.count("BGSSaveFormBuffer") >= 2:
-            output.writelines(["Checking for *[Save Crash]................DETECTED!",
-                               f'> Priority : [5] | BGSSaveFormBuffer : {logtext.count("BGSSaveFormBuffer")}'
-                               ])
+            output.write("Checking for *[Save Crash]................DETECTED!")
+            output.write(f'> Priority : [5] | BGSSaveFormBuffer : {logtext.count("BGSSaveFormBuffer")}')
             Buffout_Trap = True
             statU_Save += 1
         # ===========================================================
         if ("ButtonEvent" or "MenuControls" or "MenuOpenCloseHandler" or "PlayerControls" or "DXGISwapChain") in logtext:
-            output.writelines(["Checking for *[Input Crash]...............DETECTED!",
-                               f'> Priority : [5] | ButtonEvent : {logtext.count("ButtonEvent")} | MenuControls : {logtext.count("MenuControls")}',
-                               f'                        MenuOpenCloseHandler : {logtext.count("MenuOpenCloseHandler")} | PlayerControls : {logtext.count("PlayerControls")}',
-                               f'                        DXGISwapChain : {logtext.count("DXGISwapChain")}'
-                               ])
+            output.write("Checking for *[Input Crash]...............DETECTED!")
+            output.write(f'> Priority : [5] | ButtonEvent : {logtext.count("ButtonEvent")} | MenuControls : {logtext.count("MenuControls")}')
+            output.write(f'                        MenuOpenCloseHandler : {logtext.count("MenuOpenCloseHandler")} | PlayerControls : {logtext.count("PlayerControls")}')
+            output.write(f'                        DXGISwapChain : {logtext.count("DXGISwapChain")}')
             Buffout_Trap = True
             statU_Input += 1
         # ===========================================================
         if ("BGSSaveLoadManager" or "BGSSaveLoadThread" or "BGSSaveFormBuffer") in logtext or ("+0CDAD30" or "+0D09AB7") in buff_error:
-            output.writelines(["Checking for *[Bad INI Crash].............DETECTED!",
-                               f'> Priority : [5] | BGSSaveLoadManager : {logtext.count("BGSSaveLoadManager")} | BGSSaveLoadThread : {logtext.count("BGSSaveLoadThread")}',
-                               f'                        BGSSaveFormBuffer : {logtext.count("BGSSaveFormBuffer")}'
-                               ])
+            output.write("Checking for *[Bad INI Crash].............DETECTED!")
+            output.write(f'> Priority : [5] | BGSSaveLoadManager : {logtext.count("BGSSaveLoadManager")} | BGSSaveLoadThread : {logtext.count("BGSSaveLoadThread")}')
+            output.write(f'                        BGSSaveFormBuffer : {logtext.count("BGSSaveFormBuffer")}')
             Buffout_Trap = True
             statU_INI += 1
         # ===========================================================
         if ("BGSProcedurePatrol" or "BGSProcedurePatrolExecState" or "PatrolActorPackageData") in logtext:
-            output.writelines(["Checking for *[NPC Patrol Crash]..........DETECTED!",
-                               f'> Priority : [5] | BGSProcedurePatrol : {logtext.count("BGSProcedurePatrol")} | BGSProcedurePatrolExecStatel : {logtext.count("BGSProcedurePatrolExecState")}',
-                               f'                        PatrolActorPackageData : {logtext.count("PatrolActorPackageData")}'
-                               ])
+            output.write("Checking for *[NPC Patrol Crash]..........DETECTED!")
+            output.write(f'> Priority : [5] | BGSProcedurePatrol : {logtext.count("BGSProcedurePatrol")} | BGSProcedurePatrolExecStatel : {logtext.count("BGSProcedurePatrolExecState")}')
+            output.write(f'                        PatrolActorPackageData : {logtext.count("PatrolActorPackageData")}')
             Buffout_Trap = True
             statU_Patrol += 1
         # ===========================================================
         if ("BSPackedCombinedGeomDataExtra" or "BGSCombinedCellGeometryDB" or "BGSStaticCollection" or "TESObjectCELL") in logtext:
-            output.writelines(["Checking for *[Precombines Crash].........DETECTED!",
-                               f'> Priority : [5] | BGSStaticCollection : {logtext.count("BGSStaticCollection")} | BGSCombinedCellGeometryDB : {logtext.count("BGSCombinedCellGeometryDB")}',
-                               f'                        BSPackedCombinedGeomDataExtra : {logtext.count("BSPackedCombinedGeomDataExtra")} | TESObjectCELL : {logtext.count("TESObjectCELL")}'
-                               ])
+            output.write("Checking for *[Precombines Crash].........DETECTED!")
+            output.write(f'> Priority : [5] | BGSStaticCollection : {logtext.count("BGSStaticCollection")} | BGSCombinedCellGeometryDB : {logtext.count("BGSCombinedCellGeometryDB")}')
+            output.write(f'                        BSPackedCombinedGeomDataExtra : {logtext.count("BSPackedCombinedGeomDataExtra")} | TESObjectCELL : {logtext.count("TESObjectCELL")}')
             Buffout_Trap = True
             statU_Precomb += 1
         # ===========================================================
         if "HUDAmmoCounter" in logtext:
-            output.writelines(["Checking for *[Ammo Counter Crash]........DETECTED!",
-                               f'> Priority : [5] | HUDAmmoCounter : {logtext.count("HUDAmmoCounter")}'
-                               ])
+            output.write("Checking for *[Ammo Counter Crash]........DETECTED!")
+            output.write(f'> Priority : [5] | HUDAmmoCounter : {logtext.count("HUDAmmoCounter")}')
             Buffout_Trap = True
             statU_HUDAmmo += 1
         # ===========================================================
         if ("BGSProjectile" or "CombatProjectileAimController") in logtext:
-            output.writelines(["Checking for *[NPC Projectile Crash].....DETECTED!",
-                               f'> Priority : [5] | BGSProjectile : {logtext.count("BGSProjectile")} | CombatProjectileAimController : {logtext.count("CombatProjectileAimController")}'
-                               ])
+            output.write("Checking for *[NPC Projectile Crash].....DETECTED!")
+            output.write(f'> Priority : [5] | BGSProjectile : {logtext.count("BGSProjectile")} | CombatProjectileAimController : {logtext.count("CombatProjectileAimController")}')
             Buffout_Trap = True
         # ===========================================================
         if logtext.count("PlayerCharacter") >= 1 and (logtext.count("0x00000007") or logtext.count("0x00000014") or logtext.count("0x00000008")) >= 3:
             output.write("Checking for *[Player Character Crash]....DETECTED!")
             output.write(f'> Priority : [5] | PlayerCharacter : {logtext.count("PlayerCharacter")} | 0x00000007 : {logtext.count("0x00000007")}')
             output.write(f'                        0x00000008 : {logtext.count("0x00000008")} | 0x000000014 : {logtext.count("0x00000014")}')
-            output.writelines(["Checking for *[Player Character Crash]....DETECTED!",
-                               f'> Priority : [5] | PlayerCharacter : {logtext.count("PlayerCharacter")} | 0x00000007 : {logtext.count("0x00000007")}',
-                               f'                        0x00000008 : {logtext.count("0x00000008")} | 0x000000014 : {logtext.count("0x00000014")}'
-                               ])
             Buffout_Trap = True
             statU_Player += 1
 
         # ===========================================================
 
         if Buffout_Trap == False:  # DEFINE CHECK IF NOTHING TRIGGERED BUFFOUT TRAP
-            output.writelines([
-                "-----",
-                "# AUTOSCAN FOUND NO CRASH ERRORS / CULPRITS THAT MATCH THE CURRENT DATABASE #",
-                "Check below for mods that can cause frequent crashes and other problems.",
-                "-----"
-            ])
+            output.write("-----")
+            output.write("# AUTOSCAN FOUND NO CRASH ERRORS / CULPRITS THAT MATCH THE CURRENT DATABASE #")
+            output.write("Check below for mods that can cause frequent crashes and other problems.")
+            output.write("-----")
         else:
-            output.writelines([
-                "-----",
-                "FOR DETAILED DESCRIPTIONS AND POSSIBLE SOLUTIONS TO ANY ABOVE DETECTED CRASH CULPRITS,",
-                "SEE: https://docs.google.com/document/d/17FzeIMJ256xE85XdjoPvv_Zi3C5uHeSTQh6wOZugs4c",
-                "-----"
-            ])
+            output.write("-----")
+            output.write("FOR DETAILED DESCRIPTIONS AND POSSIBLE SOLUTIONS TO ANY ABOVE DETECTED CRASH CULPRITS,")
+            output.write("SEE: https://docs.google.com/document/d/17FzeIMJ256xE85XdjoPvv_Zi3C5uHeSTQh6wOZugs4c")
+            output.write("-----")
 
-        output.writelines([
-            "====================================================",
-            "CHECKING FOR MODS THAT CAN CAUSE FREQUENT CRASHES...",
-            "===================================================="
-        ])
+        
+        output.write("====================================================")
+        output.write("CHECKING FOR MODS THAT CAN CAUSE FREQUENT CRASHES...")
+        output.write("====================================================")
         Mod_Trap1 = 1
 
         # Why lists and not dictionaries? So I can preserve alphabetical order in code and
@@ -916,67 +864,60 @@ for file in logs:
                 for elem in List_Mods1:
                     if "File:" not in line and "[FE" not in line and elem in line:
                         order_elem = List_Mods1.index(elem)
-                        output.writelines([f"[!] Found:{line[0:5].strip()} {List_Warn1[order_elem]}",
-                                           "-----"])
+                        output.write(f"[!] Found:{line[0:5].strip()} {List_Warn1[order_elem]}")
+                        output.write("-----")
                         Mod_Trap1 = 0
                     elif "File:" not in line and "[FE" in line and elem in line:
                         order_elem = List_Mods1.index(elem)
-                        output.writelines([f"[!] Found:{line[0:9].strip()} {List_Warn1[order_elem]}",
-                                           "-----"])
+                        output.write(f"[!] Found:{line[0:9].strip()} {List_Warn1[order_elem]}")
+                        output.write("-----")
                         Mod_Trap1 = 0
 
             if logtext.count("ClassicHolsteredWeapons") >= 3 or "ClassicHolsteredWeapons" in buff_error:
-                output.writelines(["[!] Found: CLASSIC HOLSTERED WEAPONS",
-                                   "AUTOSCAN IS PRETTY CERTAIN THAT CHW CAUSED THIS CRASH!",
-                                   "You should disable CHW to further confirm this.",
-                                   "Visit the main crash logs article for additional solutions.",
-                                   "-----"
-                                   ])
+                output.write("[!] Found: CLASSIC HOLSTERED WEAPONS")
+                output.write("AUTOSCAN IS PRETTY CERTAIN THAT CHW CAUSED THIS CRASH!")
+                output.write("You should disable CHW to further confirm this.")
+                output.write("Visit the main crash logs article for additional solutions.")
+                output.write("-----")
                 statM_CHW += 1
                 Mod_Trap1 = 0
                 Buffout_Trap = True
             elif logtext.count("ClassicHolsteredWeapons") >= 2 and ("UniquePlayer.esp" or "HHS.dll" or "cbp.dll" or "Body.nif") in logtext:
-                output.writelines(["[!] Found: CLASSIC HOLSTERED WEAPONS",
-                                   "AUTOSCAN ALSO DETECTED ONE OR SEVERAL MODS THAT WILL CRASH WITH CHW.",
-                                   "You should disable CHW to further confirm it caused this crash.",
-                                   "Visit the main crash logs article for additional solutions.",
-                                   "-----"
-                                   ])
+                output.write("[!] Found: CLASSIC HOLSTERED WEAPONS")
+                output.write("AUTOSCAN ALSO DETECTED ONE OR SEVERAL MODS THAT WILL CRASH WITH CHW.")
+                output.write("You should disable CHW to further confirm it caused this crash.")
+                output.write("Visit the main crash logs article for additional solutions.")
+                output.write("-----")
                 statM_CHW += 1
                 Mod_Trap1 = 0
                 Buffout_Trap = True
             elif "ClassicHolsteredWeapons" in logtext and "d3d11" in buff_error:
-                output.writelines(["[!] Found: CLASSIC HOLSTERED WEAPONS, BUT...",
-                                   "AUTOSCAN CANNOT ACCURATELY DETERMINE IF CHW CAUSED THIS CRASH OR NOT.",
-                                   "You should open CHW's ini file and change IsHolsterVisibleOnNPCs to 0.",
-                                   "This usually prevents most common crashes with Classic Holstered Weapons.",
-                                   "-----"
-                                   ])
+                output.write("[!] Found: CLASSIC HOLSTERED WEAPONS, BUT...")
+                output.write("AUTOSCAN CANNOT ACCURATELY DETERMINE IF CHW CAUSED THIS CRASH OR NOT.")
+                output.write("You should open CHW's ini file and change IsHolsterVisibleOnNPCs to 0.")
+                output.write("This usually prevents most common crashes with Classic Holstered Weapons.")
+                output.write("-----")
                 Mod_Trap1 = 0
         if "[00]" in logtext and Mod_Trap1 == 0:
-            output.writelines(["# CAUTION: ANY ABOVE DETECTED MODS HAVE A MUCH HIGHER CHANCE TO CRASH YOUR GAME! #",
-                               "You can disable any/all of them temporarily to confirm they caused this crash.",
-                               "-----"
-                               ])
+            output.write("# CAUTION: ANY ABOVE DETECTED MODS HAVE A MUCH HIGHER CHANCE TO CRASH YOUR GAME! #")
+            output.write("You can disable any/all of them temporarily to confirm they caused this crash.")
+            output.write("-----")
             statL_scanned += 1
         elif "[00]" in logtext and Mod_Trap1 == 1:
-            output.writelines(["# AUTOSCAN FOUND NO PROBLEMATIC MODS THAT MATCH THE CURRENT DATABASE FOR THIS LOG #",
-                               "THAT DOESN'T MEAN THERE AREN'T ANY! YOU SHOULD RUN PLUGIN CHECKER IN WRYE BASH.",
-                               "Wrye Bash Link: https://www.nexusmods.com/fallout4/mods/20032?tab=files",
-                               "-----"
-                               ])
+            output.write("# AUTOSCAN FOUND NO PROBLEMATIC MODS THAT MATCH THE CURRENT DATABASE FOR THIS LOG #")
+            output.write("THAT DOESN'T MEAN THERE AREN'T ANY! YOU SHOULD RUN PLUGIN CHECKER IN WRYE BASH.")
+            output.write("Wrye Bash Link: https://www.nexusmods.com/fallout4/mods/20032?tab=files")
+            output.write("-----")
             statL_scanned += 1
         elif not "[00]" in logtext:
-            output.writelines(["# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #\n",
-                               "Autoscan cannot continue. Try scanning a different crash log.\n",
-                               "-----"
-                               ])
+            output.write("# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #")
+            output.write("Autoscan cannot continue. Try scanning a different crash log.")
+            output.write("-----")
             statL_incomplete += 1
 
-        output.writelines(["====================================================",
-                           "CHECKING FOR MODS WITH SOLUTIONS & COMMUNITY PATCHES",
-                           "===================================================="
-                           ])
+        output.write("====================================================")
+        output.write("CHECKING FOR MODS WITH SOLUTIONS & COMMUNITY PATCHES")
+        output.write("====================================================")
         Mod_Trap2 = no_repeat1 = no_repeat2 = 1  # MOD TRAP 2 | NEED 8 SPACES FOR ESL [FE:XXX]
 
         # Needs 1 empty space as prefix to prevent duplicates.
@@ -1158,37 +1099,32 @@ for file in logs:
                 for elem in List_Mods2:
                     if "File:" not in line and "[FE" not in line and elem in line:
                         order_elem = List_Mods2.index(elem)
-                        output.writelines([f"[!] Found:{line[0:5].strip()} {List_Warn2[order_elem]}",
-                                           "-----"
-                                           ])
+                        output.write(f"[!] Found:{line[0:5].strip()} {List_Warn2[order_elem]}")
+                        output.write("-----")
                         Mod_Trap2 = 0
                     elif "File:" not in line and "[FE" in line and elem in line:
                         order_elem = List_Mods2.index(elem)
-                        output.writelines([f"[!] Found:{line[0:9].strip()} {List_Warn2[order_elem]}",
-                                           "-----"
-                                           ])
+                        output.write(f"[!] Found:{line[0:9].strip()} {List_Warn2[order_elem]}")
+                        output.write("-----")
                         Mod_Trap2 = 0
                 if no_repeat1 == 1 and "File:" not in line and ("Depravity" or "FusionCityRising" or "HotC" or "OutcastsAndRemnants" or "ProjectValkyrie") in line:
-                    output.writelines([f"[!] Found:{line[0:9].strip()} THUGGYSMURF QUEST MOD",
-                                       "If you have Depravity, Fusion City Rising, HOTC, Outcasts and Remnants and/or Project Valkyrie",
-                                       "install this patch with facegen data, fully generated precomb/previs data and several tweaks.",
-                                       "Patch Link: https://www.nexusmods.com/fallout4/mods/56876?tab=files",
-                                       "-----"
-                                       ])
+                    output.write(f"[!] Found:{line[0:9].strip()} THUGGYSMURF QUEST MOD")
+                    output.write("If you have Depravity, Fusion City Rising, HOTC, Outcasts and Remnants and/or Project Valkyrie")
+                    output.write("install this patch with facegen data, fully generated precomb/previs data and several tweaks.")
+                    output.write("Patch Link: https://www.nexusmods.com/fallout4/mods/56876?tab=files")
+                    output.write("-----")
                     no_repeat1 = Mod_Trap2 = 0
                 if no_repeat1 == 1 and "File:" not in line and ("CaN.esm" or "AnimeRace_Nanako.esp") in line:
-                    output.writelines([f"[!] Found:{line[0:9].strip()} CUSTOM RACE SKELETON MOD",
-                                       "If you have AnimeRace NanakoChan or Crimes Against Nature, install the Race Skeleton Fixes.",
-                                       "Skeleton Fixes Link (READ THE DESCRIPTION): https://www.nexusmods.com/fallout4/mods/56101"
-                                       ])
+                    output.write(f"[!] Found:{line[0:9].strip()} CUSTOM RACE SKELETON MOD")
+                    output.write("If you have AnimeRace NanakoChan or Crimes Against Nature, install the Race Skeleton Fixes.")
+                    output.write("Skeleton Fixes Link (READ THE DESCRIPTION): https://www.nexusmods.com/fallout4/mods/56101")
                     no_repeat2 = Mod_Trap2 = 0
 
             if "FallSouls.dll" in logtext:
-                output.writelines(["[!] Found: FALLSOULS UNPAUSED GAME MENUS",
-                                   "Occasionally breaks the Quests menu, can cause crashes while changing MCM settings.",
-                                   "Advised Fix: Toggle PipboyMenu in FallSouls MCM settings or completely reinstall the mod.",
-                                   "-----"
-                                   ])
+                output.write("[!] Found: FALLSOULS UNPAUSED GAME MENUS")
+                output.write("Occasionally breaks the Quests menu, can cause crashes while changing MCM settings.")
+                output.write("Advised Fix: Toggle PipboyMenu in FallSouls MCM settings or completely reinstall the mod.")
+                output.write("-----")
                 Mod_Trap2 = 0
 
         # inherentlimitations= "[Due to inherent limitations, Auto-Scan will continue detecting certain mods\neven if fixes or patches for them are already installed. You can ignore these.]\n-----"
@@ -1200,21 +1136,18 @@ for file in logs:
             output.write("-----")
 
         elif "[00]" in logtext and Mod_Trap2 == 1:
-            output.writelines(["# AUTOSCAN FOUND NO PROBLEMATIC MODS WITH SOLUTIONS AND COMMUNITY PATCHES #",
-                               "-----"
-                               ])
+            output.write("# AUTOSCAN FOUND NO PROBLEMATIC MODS WITH SOLUTIONS AND COMMUNITY PATCHES #")
+            output.write("-----")
         elif logtext.count("[00]") == 0:
             output.write(nopluginlist)
 
-        output.writelines(["FOR FULL LIST OF IMPORTANT PATCHES AND FIXES FOR THE BASE GAME AND MODS,",
-                           "VISIT THIS ARTICLE: https://www.nexusmods.com/fallout4/articles/3769",
-                           "-----"
-                           ])
+        output.write("FOR FULL LIST OF IMPORTANT PATCHES AND FIXES FOR THE BASE GAME AND MODS,")
+        output.write("VISIT THIS ARTICLE: https://www.nexusmods.com/fallout4/articles/3769")
+        output.write("-----")
 
-        output.writelines(["====================================================",
-                           "CHECKING FOR MODS PATCHED THROUGH OPC INSTALLER...",
-                           "===================================================="
-                           ])
+        output.write("====================================================")
+        output.write("CHECKING FOR MODS PATCHED THROUGH OPC INSTALLER...")
+        output.write("====================================================")
         Mod_Trap3 = 1  # MOD TRAP 3 | NEED 8 SPACES FOR ESL [FE:XXX]
 
         # Needs 1 empty space as prefix to prevent duplicates.
@@ -1302,145 +1235,130 @@ for file in logs:
                         output.write(f"- Found:{line[0:9].strip()} {List_Warn3[order_elem]}")
                         Mod_Trap3 = 0
         if "[00]" in logtext and Mod_Trap3 == 0:
-            output.writelines(["-----",
-                               "FOR PATCH REPOSITORY THAT PREVENTS CRASHES AND FIXES PROBLEMS IN THESE AND OTHER MODS,",
-                               "VISIT OPTIMIZATION PATCHES COLLECTION: https://www.nexusmods.com/fallout4/mods/54872",
-                               "-----"
-                               ])
+            output.write("-----")
+            output.write("FOR PATCH REPOSITORY THAT PREVENTS CRASHES AND FIXES PROBLEMS IN THESE AND OTHER MODS,")
+            output.write("VISIT OPTIMIZATION PATCHES COLLECTION: https://www.nexusmods.com/fallout4/mods/54872")
+            output.write("-----")
         elif "[00]" in logtext and Mod_Trap3 == 1:
-            output.writelines(["# AUTOSCAN FOUND NO PROBLEMATIC MODS THAT ARE ALREADY PATCHED THROUGH OPC INSTALLER #",
-                               "-----"
-                               ])
+            output.write("# AUTOSCAN FOUND NO PROBLEMATIC MODS THAT ARE ALREADY PATCHED THROUGH OPC INSTALLER #")
+            output.write("-----")
         elif logtext.count("[00]") == 0:
-            output.writelines(nopluginlist)
+            output.write(nopluginlist)
 
         # ===========================================================
 
-        output.writelines(["====================================================",
-                           "CHECKING IF IMPORTANT PATCHES & FIXES ARE INSTALLED"
-                           "===================================================="
-                           ])
+        output.write("====================================================")
+        output.write("CHECKING IF IMPORTANT PATCHES & FIXES ARE INSTALLED")
+        output.write("====================================================")
 
         gpu_amd = False
         gpu_nvidia = False
         for line in loglines:
             if "GPU" in line and "Nvidia" in line:
                 gpu_nvidia = True
+                break
             if "GPU" in line and "AMD" in line:
                 gpu_amd = True
+                break
 
-        output.writelines(["IF YOU'RE USING DYNAMIC PERFORMANCE TUNER AND/OR LOAD ACCELERATOR,",
-                           "remove these mods completely and switch to High FPS Physics Fix!",
-                           "Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files",
-                           "-----"
-                           ])
+        output.write("IF YOU'RE USING DYNAMIC PERFORMANCE TUNER AND/OR LOAD ACCELERATOR,")
+        output.write("remove these mods completely and switch to High FPS Physics Fix!")
+        output.write("Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files")
+        output.write("-----")
 
         if CLAS_config.getboolean("MAIN", "FCX Mode") == True:
-            output.writelines(["* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *",
-                               "[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]",
-                               "-----"
-                               ])
+            output.write("* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *")
+            output.write("[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]")
+            output.write("-----")
 
             if info.VR_EXE.is_file() and info.VR_Buffout.is_file():
                 output.write("*Buffout 4 VR Version* is (manually) installed. \n-----")
             elif info.VR_EXE.is_file() and not info.VR_Buffout.is_file():
-                output.writelines(["# BUFFOUT 4 FOR VR VERSION ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
-                                   "# This is a mandatory Buffout 4 port for the VR Version of Fallout 4.",
-                                   "Link: https://www.nexusmods.com/fallout4/mods/64880?tab=files"
-                                   ])
+                output.write("# BUFFOUT 4 FOR VR VERSION ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
+                output.write("# This is a mandatory Buffout 4 port for the VR Version of Fallout 4.")
+                output.write("Link: https://www.nexusmods.com/fallout4/mods/64880?tab=files")
 
-            if info.F4CK_EXE.is_file() and os.path.exists(info.F4CK_Fixes):
+            if (info.F4CK_EXE.is_file() and os.path.exists(info.F4CK_Fixes)) or Path(info.Game_Path).joinpath("winhttp.dll").is_file():
                 output.write("*Creation Kit Fixes* is (manually) installed. \n-----")
             elif info.F4CK_EXE.is_file() and not os.path.exists(info.F4CK_Fixes):
-                output.writelines(["# CREATION KIT FIXES ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
-                                   "This is a highly recommended patch for the Fallout 4 Creation Kit.",
-                                   "Link: https://www.nexusmods.com/fallout4/mods/51165?tab=files",
-                                   "-----"
-                                   ])
+                output.write("# CREATION KIT FIXES ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
+                output.write("This is a highly recommended patch for the Fallout 4 Creation Kit.")
+                output.write("Link: https://www.nexusmods.com/fallout4/mods/51165?tab=files")
+                output.write("-----")
 
         if "[00]" in logtext:
             if any("CanarySaveFileMonitor" in elem for elem in plugin_list):
                 output.write("*Canary Save File Monitor* is installed. \n-----")
             else:
-                output.writelines(["# CANARY SAVE FILE MONITOR ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
-                                   "This is a highly recommended mod that can detect save file corrpution.",
-                                   "Link: https://www.nexusmods.com/fallout4/mods/44949?tab=files",
-                                   "-----"
-                                   ])
+                output.write("# CANARY SAVE FILE MONITOR ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
+                output.write("This is a highly recommended mod that can detect save file corrpution.")
+                output.write("Link: https://www.nexusmods.com/fallout4/mods/44949?tab=files")
+                output.write("-----")
 
             if "HighFPSPhysicsFix.dll" in logtext:
                 output.write("*High FPS Physics Fix* is installed. \n-----")
             else:
-                output.writelines(["# HIGH FPS PHYSICS FIX ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
-                                   "This is a mandatory patch / fix that prevents game engine problems.",
-                                   "Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files",
-                                   "-----"
-                                   ])
+                output.write("# HIGH FPS PHYSICS FIX ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
+                output.write("This is a mandatory patch / fix that prevents game engine problems.")
+                output.write("Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files")
+                output.write("-----")
 
             if any("PPF.esm" in elem for elem in plugin_list):
                 output.write("*Previs Repair Pack* is installed. \n-----")
             else:
-                output.writelines(["# PREVIS REPAIR PACK ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
-                                   "This is a highly recommended mod that can improve performance.",
-                                   "Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files",
-                                   "-----"
-                                   ])
+                output.write("# PREVIS REPAIR PACK ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
+                output.write("This is a highly recommended mod that can improve performance.")
+                output.write("Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files")
+                output.write("-----")
 
             if any("Unofficial Fallout 4 Patch.esp" in elem for elem in plugin_list):
                 output.write("*Unofficial Fallout 4 Patch* is installed. \n-----")
             else:
-                output.writelines(["# UNOFFICIAL FALLOUT 4 PATCH ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
-                                   "If you own all DLCs, make sure that the Unofficial Patch is installed.",
-                                   "Link: https://www.nexusmods.com/fallout4/mods/4598?tab=files",
-                                   "-----"
-                                   ])
+                output.write("# UNOFFICIAL FALLOUT 4 PATCH ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
+                output.write("If you own all DLCs, make sure that the Unofficial Patch is installed.")
+                output.write("Link: https://www.nexusmods.com/fallout4/mods/4598?tab=files")
+                output.write("-----")
 
             if "vulkan-1.dll" in logtext and gpu_amd:
                 output.write("Vulkan Renderer is installed. \n-----")
             elif logtext.count("vulkan-1.dll") == 0 and gpu_amd and not gpu_nvidia:
-                output.writelines(["# VULKAN RENDERER ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
-                                   "This is a highly recommended mod that can improve performance on AMD GPUs.",
-                                   "-----",
-                                   "Installation steps can be found in 'How To Read Crash Logs' PDF / Document.",
-                                   "Link: https://www.nexusmods.com/fallout4/mods/48053?tab=files",
-                                   "-----"
-                                   ])
+                output.write("# VULKAN RENDERER ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
+                output.write("This is a highly recommended mod that can improve performance on AMD GPUs.")
+                output.write("-----")
+                output.write("Installation steps can be found in 'How To Read Crash Logs' PDF / Document.")
+                output.write("Link: https://www.nexusmods.com/fallout4/mods/48053?tab=files")
+                output.write("-----")
 
             if "WeaponDebrisCrashFix.dll" in logtext and gpu_nvidia:
                 output.write("*Weapon Debris Crash Fix* is installed. \n-----")
             elif "WeaponDebrisCrashFix.dll" in logtext and not gpu_nvidia and gpu_amd:
-                output.writelines(["*Weapon Debris Crash Fix* is installed, but...",
-                                   "# YOU DON'T HAVE AN NVIDIA GPU OR BUFFOUT 4 CANNOT DETECT YOUR GPU MODEL #",
-                                   "Weapon Debris Crash Fix is only required for Nvidia GPUs (NOT AMD / OTHER)",
-                                   "-----"
-                                   ])
+                output.write("*Weapon Debris Crash Fix* is installed, but...")
+                output.write("# YOU DON'T HAVE AN NVIDIA GPU OR BUFFOUT 4 CANNOT DETECT YOUR GPU MODEL #")
+                output.write("Weapon Debris Crash Fix is only required for Nvidia GPUs (NOT AMD / OTHER)")
+                output.write("-----")
             if not "WeaponDebrisCrashFix.dll" in logtext and gpu_nvidia:
-                output.writelines(["# WEAPON DEBRIS CRASH FIX ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
-                                   "This is a mandatory patch / fix for players with Nvidia graphics cards.",
-                                   "Link: https://www.nexusmods.com/fallout4/mods/48078?tab=files",
-                                   "-----"
-                                   ])
+                output.write("# WEAPON DEBRIS CRASH FIX ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
+                output.write("This is a mandatory patch / fix for players with Nvidia graphics cards.")
+                output.write("Link: https://www.nexusmods.com/fallout4/mods/48078?tab=files")
+                output.write("-----")
 
             if "NVIDIA_Reflex.dll" in logtext and gpu_nvidia:
                 output.write("*Nvidia Reflex Support* is installed. \n-----")
             elif "NVIDIA_Reflex.dll" in logtext and not gpu_nvidia and gpu_amd:
-                output.writelines(["*Nvidia Reflex Support* is installed, but...",
-                                   "# YOU DON'T HAVE AN NVIDIA GPU OR BUFFOUT 4 CANNOT DETECT YOUR GPU MODEL #",
-                                   "Nvidia Reflex Support is only required for Nvidia GPUs (NOT AMD / OTHER)",
-                                   "-----"
-                                   ])
+                output.write("*Nvidia Reflex Support* is installed, but...")
+                output.write("# YOU DON'T HAVE AN NVIDIA GPU OR BUFFOUT 4 CANNOT DETECT YOUR GPU MODEL #")
+                output.write("Nvidia Reflex Support is only required for Nvidia GPUs (NOT AMD / OTHER)")
+                output.write("-----")
             if not "NVIDIA_Reflex.dll" in logtext and gpu_nvidia:
-                output.writelines(["# NVIDIA REFLEX SUPPORT ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
-                                   "This is a highly recommended mod that can reduce render latency.",
-                                   "Link: https://www.nexusmods.com/fallout4/mods/64459?tab=files",
-                                   "-----"
-                                   ])
+                output.write("# NVIDIA REFLEX SUPPORT ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
+                output.write("This is a highly recommended mod that can reduce render latency.")
+                output.write("Link: https://www.nexusmods.com/fallout4/mods/64459?tab=files")
+                output.write("-----")
         else:
-            output.writelines(nopluginlist)
-        output.writelines(["====================================================",
-                           "SCANNING THE LOG FOR SPECIFIC (POSSIBLE) CUPLRITS...",
-                           "===================================================="
-                           ])
+            output.write(nopluginlist)
+        output.write("====================================================")
+        output.write("SCANNING THE LOG FOR SPECIFIC (POSSIBLE) CUPLRITS...")
+        output.write("====================================================")
 
         list_DETPLUGINS = []
         list_DETFORMIDS = []
@@ -1448,11 +1366,10 @@ for file in logs:
         list_ALLPLUGINS = []
 
         if not "f4se_1_10_163.dll" in logtext and "steam_api64.dll" in logtext:
-            output.writelines(["AUTOSCAN CANNOT FIND FALLOUT 4 SCRIPT EXTENDER DLL!",
-                               "MAKE SURE THAT F4SE IS CORRECTLY INSTALLED!",
-                               "Link: https://f4se.silverlock.org",
-                               "-----"
-                               ])
+            output.write("AUTOSCAN CANNOT FIND FALLOUT 4 SCRIPT EXTENDER DLL!")
+            output.write("MAKE SURE THAT F4SE IS CORRECTLY INSTALLED!")
+            output.write("Link: https://f4se.silverlock.org")
+            output.write("-----")
 
         for line in loglines:
             if len(line) >= 6 and "]" in line[4]:
@@ -1488,18 +1405,16 @@ for file in logs:
                     PL_matches.append(string)
             if PL_matches:
                 PL_result.append(PL_matches)
-                output.write(f"- {' '.join(PL_matches)}")  # not 100% sure on this, will have to see how it works.
+                output.write(f"- {' '.join(PL_matches)}")
 
         if not PL_result:
-            output.writelines(["* AUTOSCAN COULDN'T FIND ANY PLUGIN CULRIPTS *",
-                               "-----"
-                               ])
+            output.write("* AUTOSCAN COULDN'T FIND ANY PLUGIN CULRIPTS *")
+            output.write("-----")
         else:
-            output.writelines(["-----",
-                               "These Plugins were caught by Buffout 4 and some of them might be responsible for this crash.",
-                               "You can try disabling these plugins and recheck your game, though this method can be unreliable.",
-                               "-----"
-                               ])
+            output.write("-----")
+            output.write("These Plugins were caught by Buffout 4 and some of them might be responsible for this crash.")
+            output.write("You can try disabling these plugins and recheck your game, though this method can be unreliable.")
+            output.write("-----")
 
         # ===========================================================
 
@@ -1529,15 +1444,13 @@ for file in logs:
                 output.write(elem)
 
             if not list_DETFORMIDS:
-                output.writelines(["* AUTOSCAN COULDN'T FIND ANY FORM ID CULRIPTS *",
-                                   "-----"
-                                   ])
+                output.write("* AUTOSCAN COULDN'T FIND ANY FORM ID CULRIPTS *")
+                output.write("-----")
         else:
-            output.writelines(["-----",
-                               "These Form IDs were caught by Buffout 4 and some of them might be related to this crash.",
-                               "You can try searching any listed Form IDs in FO4Edit and see if they lead to relevant records.",
-                               "-----"
-                               ])
+            output.write("-----")
+            output.write("These Form IDs were caught by Buffout 4 and some of them might be related to this crash.")
+            output.write("You can try searching any listed Form IDs in FO4Edit and see if they lead to relevant records.")
+            output.write("-----")
 
         # ===========================================================
 
@@ -1557,21 +1470,18 @@ for file in logs:
             output.write(elem)
 
         if not List_Records:
-            output.writelines(["* AUTOSCAN COULDN'T FIND ANY NAMED RECORDS *",
-                               "-----"
-                               ])
+            output.write("* AUTOSCAN COULDN'T FIND ANY NAMED RECORDS *")
+            output.write("-----")
         else:
-            output.writelines(["-----",
-                               "These records were caught by Buffout 4 and some of them might be related to this crash.",
-                               "Named records should give extra information on involved game objects and record types.",
-                               "-----"
-                               ])
+            output.write("-----")
+            output.write("These records were caught by Buffout 4 and some of them might be related to this crash.")
+            output.write("Named records should give extra information on involved game objects and record types.")
+            output.write("-----")
 
-        output.writelines(["FOR FULL LIST OF MODS THAT CAUSE PROBLEMS, THEIR ALTERNATIVES AND DETAILED SOLUTIONS,",
-                           "VISIT THE BUFFOUT 4 CRASH ARTICLE: https://www.nexusmods.com/fallout4/articles/3115",
-                           "===============================================================================",
-                           f"END OF AUTOSCAN | Author/Made By: Poet#9800 (DISCORD) | {CLAS_Date}"
-                           ])
+        output.write("FOR FULL LIST OF MODS THAT CAUSE PROBLEMS, THEIR ALTERNATIVES AND DETAILED SOLUTIONS,")
+        output.write("VISIT THE BUFFOUT 4 CRASH ARTICLE: https://www.nexusmods.com/fallout4/articles/3115")
+        output.write("===============================================================================")
+        output.write(f"END OF AUTOSCAN | Author/Made By: Poet#9800 (DISCORD) | {CLAS_Date}")
 
     # MOVE UNSOLVED LOGS TO SPECIAL FOLDER
     if CLAS_config.getboolean("MAIN", "Move Unsolved") == True:

--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -265,7 +265,7 @@ logs = glob("crash-*.log")  # + glob("crash-*.txt") # For people who just HAVE t
 
 for file in logs:
     logpath = Path(file).resolve()
-    scanpath = Path(str(logpath).replace(".log", "-AUTOSCAN.md"))
+    scanpath = Path(str(logpath.name).replace(".log", "-AUTOSCAN.md")).resolve()
     logname = logpath.name
     logtext = logpath.read_text()
     loglines: list | None = None
@@ -279,7 +279,7 @@ for file in logs:
             output.write("# NOTICE: YOU NEED TO UPDATE THE AUTO-SCANNER! #")
         output.write("====================================================")
 
-    # DEFINE LINE INDEXES FOR EVERYTHING REQUIRED HERE
+        # DEFINE LINE INDEXES FOR EVERYTHING REQUIRED HERE
         buff_ver = loglines[1].strip()
         buff_error = loglines[3].strip()
         plugin_idx = 1
@@ -317,26 +317,26 @@ for file in logs:
         output.write("CHECKING IF BUFFOUT 4 FILES/SETTINGS ARE CORRECT...")
         output.write("====================================================")
 
-        ALIB_Load= BUFF_Load = False
+        ALIB_Load = BUFF_Load = False
 
         # CHECK IF F4SE.LOG EXISTS AND REPORTS ANY ERRORS
         if CLAS_config.getboolean("MAIN", "FCX Mode") == True:
             output.writelines(["* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *",
-                           "[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]",
-                           "-----"
-                           ])
-            Error_List= []
-            F4SE_Error= F4SE_Version = F4SE_Buffout = 0
+                               "[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]",
+                               "-----"
+                               ])
+            Error_List = []
+            F4SE_Error = F4SE_Version = F4SE_Buffout = 0
             with open(info.FO4_F4SE_Path, "r") as LOG_Check:
-                Error_Check= LOG_Check.readlines()
+                Error_Check = LOG_Check.readlines()
                 for line in Error_Check:
                     if "0.6.23" in line:
-                        F4SE_Version= 1
+                        F4SE_Version = 1
                     if "Error" in line:
-                        F4SE_Error= 1
+                        F4SE_Error = 1
                         Error_List.append(line)
                     if "Buffout4.dll" in line and "loaded correctly" in line:
-                        F4SE_Buffout= 1
+                        F4SE_Buffout = 1
 
             if F4SE_Version == 1:
                 output.write("You have the latest version of Fallout 4 Script Extender (F4SE). \n-----")
@@ -354,28 +354,26 @@ for file in logs:
 
             if F4SE_Buffout == 1:
                 output.write("Script Extender reports that Buffout 4.dll was found and loaded correctly. \n-----")
-                ALIB_Load= BUFF_Load = True
+                ALIB_Load = BUFF_Load = True
             else:
-                output.writelines(["# SCRIPT EXTENDER REPORTS THAT BUFFOUT 4.DLL FAILED TO LOAD OR IS MISSING! #",
-                               "Follow Buffout 4 installation steps here: https://www.nexusmods.com/fallout4/articles/3115",
-                               "Buffout 4: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47359",
-                               "-----"
-                               ])
+                output.write("# SCRIPT EXTENDER REPORTS THAT BUFFOUT 4.DLL FAILED TO LOAD OR IS MISSING! #")
+                output.write("Follow Buffout 4 installation steps here: https://www.nexusmods.com/fallout4/articles/3115")
+                output.write("Buffout 4: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47359")
+                output.write("-----")
 
-            list_ERRORLOG= []
+            list_ERRORLOG = []
             for file in info.FO4_F4SE_Logs:
                 if fnmatch.fnmatch(file, ".log"):
                     with open(file, "r+") as LOG_Check:
-                        Log_Errors= LOG_Check.read()
+                        Log_Errors = LOG_Check.read()
                         if "error" in Log_Errors.lower():
-                            logname= str(file)
+                            logname = str(file)
                             if not logname == "f4se.log":
                                 list_ERRORLOG.append(logname)
 
             if len(list_ERRORLOG) >= 1:
-                output.writelines(["# CAUTION: THE FOLLOWING DLL LOGS ALSO REPORT ONE OR MORE ERRORS : #",
-                               "[These are located in your Documents/My Games/Fallout4/F4SE folder.]"
-                               ])
+                output.write("# CAUTION: THE FOLLOWING DLL LOGS ALSO REPORT ONE OR MORE ERRORS : #")
+                output.write("[These are located in your Documents/My Games/Fallout4/F4SE folder.]")
                 for elem in list_ERRORLOG:
                     output.write(f"{elem}\n-----")
             else:
@@ -383,1208 +381,1197 @@ for file in logs:
 
         # CHECK BUFFOUT 4 REQUIREMENTS AND TOML SETTINGS
             if info.Preloader_XML.is_file() and info.Preloader_DLL.is_file():
-                output.writelines(['OPTIONAL: Plugin Preloader is (manually) installed.\n',
-                               'NOTICE: If the game fails to start after installing this mod, open xSE PluginPreloader.xml with a text editor and CHANGE',
-                               '<LoadMethod Name="ImportAddressHook"> TO <LoadMethod Name="OnThreadAttach"> OR <LoadMethod Name="OnProcessAttach">',
-                               'IF THE GAME STILL REFUSES TO START, COMPLETELY REMOVE xSE PluginPreloader.xml AND IpHlpAPI.dll FROM YOUR FO4 GAME FOLDER',
-                               "-----"
-                               ])
+                output.write('OPTIONAL: Plugin Preloader is (manually) installed.\n')
+                output.write('NOTICE: If the game fails to start after installing this mod, open xSE PluginPreloader.xml with a text editor and CHANGE')
+                output.write('<LoadMethod Name="ImportAddressHook"> TO <LoadMethod Name="OnThreadAttach"> OR <LoadMethod Name="OnProcessAttach">')
+                output.write('IF THE GAME STILL REFUSES TO START, COMPLETELY REMOVE xSE PluginPreloader.xml AND IpHlpAPI.dll FROM YOUR FO4 GAME FOLDER')
+                output.write("-----")
             else:
                 output.write('OPTIONAL: Plugin Preloader is not (manually) installed.\n-----')
 
             if info.F4SE_Loader.is_file() and info.F4SE_DLL.is_file() and info.F4SE_SDLL.is_file():
                 output.write("REQUIRED: Fallout 4 Script Extender is (manually) installed. \n-----")
             else:
-                output.writelines(["# CAUTION: Auto-Scanner cannot find Script Extender files or they aren't (manually) installed! #",
-                               "FIX: Extract all files inside *f4se_0_06_21* folder into your Fallout 4 game folder.",
-                               "FALLOUT 4 SCRIPT EXTENDER: (Download Build 0.6.23) https://f4se.silverlock.org",
-                               "-----"
-                               ])
+                output.write("# CAUTION: Auto-Scanner cannot find Script Extender files or they aren't (manually) installed! #")
+                output.write("FIX: Extract all files inside *f4se_0_06_21* folder into your Fallout 4 game folder.")
+                output.write("FALLOUT 4 SCRIPT EXTENDER: (Download Build 0.6.23) https://f4se.silverlock.org")
+                output.write("-----")
 
             if info.Address_Library.is_file() or ALIB_Load == True:
                 output.write("REQUIRED: Address Library is (manually) installed. \n-----")
             else:
-                output.writelines(["# CAUTION: Auto-Scanner cannot find the Adress Library file or it isn't (manually) installed! #",
-                               "FIX: Place the *version-1-10-163-0.bin* file manually into Fallout 4/Data/F4SE/Plugins folder.",
-                               "ADDRESS LIBRARY: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47327?tab=files",
-                               "-----"
-                               ])
+                output.write("# CAUTION: Auto-Scanner cannot find the Adress Library file or it isn't (manually) installed! #")
+                output.write("FIX: Place the *version-1-10-163-0.bin* file manually into Fallout 4/Data/F4SE/Plugins folder.")
+                output.write("ADDRESS LIBRARY: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47327?tab=files")
+                output.write("-----")
 
             if info.Buffout_INI.is_file() and info.Buffout_DLL.is_file() or BUFF_Load == True:
                 with open(info.Buffout_INI, "r+") as BUFF_Custom:
-                    BUFF_config= BUFF_Custom.read()
+                    BUFF_config = BUFF_Custom.read()
                     output.write("REQUIRED: Buffout 4 is (manually) installed. Checking configuration...\n-----")
                     if ("achievements.dll" or "UnlimitedSurvivalMode.dll") in logtext and "Achievements = true" in BUFF_config:
-                        output.writelines(["# CAUTION: Achievements Mod and/or Unlimited Survival Mode is installed, but Achievements parameter is set to TRUE #",
-                                       "Auto-Scanner will change this parameter to FALSE to prevent conflicts with Buffout 4.",
-                                       "-----"
-                                       ])
-                        BUFF_config= BUFF_config.replace("Achievements = true", "Achievements = false")
+                        output.write("# CAUTION: Achievements Mod and/or Unlimited Survival Mode is installed, but Achievements parameter is set to TRUE #")
+                        output.write("Auto-Scanner will change this parameter to FALSE to prevent conflicts with Buffout 4.")
+                        output.write("-----")
+
+                        BUFF_config = BUFF_config.replace("Achievements = true", "Achievements = false")
                     else:
                         output.write("Achievements parameter in *Buffout4.toml* is correctly configured. \n-----")
 
                     if "BakaScrapHeap.dll" in logtext and "MemoryManager = true" in BUFF_config:
-                        output.writelines(["# CAUTION: Baka ScrapHeap is installed, but MemoryManager parameter is set to TRUE #",
-                                       "Auto-Scanner will change this parameter to FALSE to prevent conflicts with Buffout 4.",
-                                       "-----"])
-                        BUFF_config= BUFF_config.replace("MemoryManager = true", "MemoryManager = false")
+                        output.write("# CAUTION: Baka ScrapHeap is installed, but MemoryManager parameter is set to TRUE #")
+                        output.write("Auto-Scanner will change this parameter to FALSE to prevent conflicts with Buffout 4.")
+                        output.write("-----")
+                        BUFF_config = BUFF_config.replace("MemoryManager = true", "MemoryManager = false")
                     else:
                         output.write("Memory Manager parameter in *Buffout4.toml* is correctly configured. \n-----")
 
                     if "f4ee.dll" in logtext and "F4EE = false" in BUFF_config:
-                        output.writelines(["# CAUTION: Looks Menu is installed, but F4EE parameter under [Compatibility] is set to FALSE #",
-                                       "Auto-Scanner will change this parameter to TRUE to prevent bugs and crashes from Looks Menu.",
-                                       "-----"
-                                       ])
-                        BUFF_config= BUFF_config.replace("F4EE = false", "F4EE = true")
+                        output.write("# CAUTION: Looks Menu is installed, but F4EE parameter under [Compatibility] is set to FALSE #")
+                        output.write("Auto-Scanner will change this parameter to TRUE to prevent bugs and crashes from Looks Menu.")
+                        output.write("-----")
+                        BUFF_config = BUFF_config.replace("F4EE = false", "F4EE = true")
                     else:
                         output.write("Looks Menu (F4EE) parameter in *Buffout4.toml* is correctly configured. \n-----")
                 with open(info.Buffout_INI, "w+") as BUFF_Custom:
                     BUFF_Custom.write(BUFF_config)
             else:
-                output.writelines(["# CAUTION: Auto-Scanner cannot find Buffout 4 files or they aren't (manually) installed! #",
-                               "FIX: Follow Buffout 4 installation steps here: https://www.nexusmods.com/fallout4/articles/3115",
-                               "BUFFOUT 4: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47359?tab=files",
-                               "-----"
-                               ])
+                output.write("# CAUTION: Auto-Scanner cannot find Buffout 4 files or they aren't (manually) installed! #")
+                output.write("FIX: Follow Buffout 4 installation steps here: https://www.nexusmods.com/fallout4/articles/3115")
+                output.write("BUFFOUT 4: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47359?tab=files")
+                output.write("-----")
 
         else:  # INSTRUCTIONS FOR MANUAL FIXING WHEN FCX MODE IS FALSE
             if ("Achievements: true" in logtext and "achievements.dll" in logtext) or ("Achievements: true" in logtext and "UnlimitedSurvivalMode.dll" in logtext):
-                output.writelines(["# CAUTION: Achievements Mod and/or Unlimited Survival Mode is installed, but Achievements parameter is set to TRUE #",
-                               "FIX: Open *Buffout4.toml* and change Achievements parameter to FALSE, this prevents conflicts with Buffout 4.",
-                               "-----"
-                               ])
+                output.write("# CAUTION: Achievements Mod and/or Unlimited Survival Mode is installed, but Achievements parameter is set to TRUE #")
+                output.write("FIX: Open *Buffout4.toml* and change Achievements parameter to FALSE, this prevents conflicts with Buffout 4.")
+                output.write("-----")
             else:
                 output.write("Achievements parameter in *Buffout4.toml* is correctly configured. \n-----")
 
             if "MemoryManager: true" in logtext and "BakaScrapHeap.dll" in logtext:
-                output.writelines(["# CAUTION: Baka ScrapHeap is installed, but MemoryManager parameter is set to TRUE #",
-                               "FIX: Open *Buffout4.toml* and change MemoryManager parameter to FALSE, this prevents conflicts with Buffout 4.",
-                               "-----"])
+                output.write("# CAUTION: Baka ScrapHeap is installed, but MemoryManager parameter is set to TRUE #")
+                output.write("FIX: Open *Buffout4.toml* and change MemoryManager parameter to FALSE, this prevents conflicts with Buffout 4.")
+                output.write("-----")
             else:
                 output.write("Memory Manager parameter in *Buffout4.toml* is correctly configured. \n-----")
 
         if "F4EE: false" in logtext and "f4ee.dll" in logtext:
-            output.writelines(["# CAUTION: Looks Menu is installed, but F4EE parameter under [Compatibility] is set to FALSE #",
-                               "FIX: Open *Buffout4.toml* and change F4EE parameter to TRUE, this prevents bugs and crashes from Looks Menu.",
-                               "-----"
-                               ])
+            output.write("# CAUTION: Looks Menu is installed, but F4EE parameter under [Compatibility] is set to FALSE #")
+            output.write("FIX: Open *Buffout4.toml* and change F4EE parameter to TRUE, this prevents bugs and crashes from Looks Menu.")
+            output.write("-----")
         else:
             output.write("Looks Menu (F4EE) parameter in *Buffout4.toml* is correctly configured. \n-----")
 
-        output.writelines(["====================================================",
-                       "CHECKING IF LOG MATCHES ANY KNOWN CRASH MESSAGES...",
-                       "===================================================="
-                       ])
-        Buffout_Trap= False  # RETURN TRUE IF KNOWN CRASH MESSAGE WAS FOUND
+        output.write("====================================================")
+        output.write("CHECKING IF LOG MATCHES ANY KNOWN CRASH MESSAGES...")
+        output.write("====================================================")
+        Buffout_Trap = False  # RETURN TRUE IF KNOWN CRASH MESSAGE WAS FOUND
 
-    # ====================== HEADER ERRORS ======================
+        # ====================== HEADER ERRORS ======================
 
         if ".dll" in buff_error and "tbbmalloc" not in buff_error:
             output.write("# MAIN ERROR REPORTS A DLL WAS INVLOVED IN THIS CRASH! # \n-----")
 
         if "EXCEPTION_STACK_OVERFLOW" in buff_error:
             output.writelines(["# Checking for Stack Overflow Crash.........CULPRIT FOUND! #",
-                           "> Priority : [5]"
-                           ])
-            Buffout_Trap= True
+                               "> Priority : [5]"
+                               ])
+            Buffout_Trap = True
             statC_Overflow += 1
 
         if "0x000100000000" in buff_error:
             output.writelines(["# Checking for Active Effects Crash.........CULPRIT FOUND! #",
-                           "> Priority : [5]"
-                           ])
-        Buffout_Trap= True
+                               "> Priority : [5]"
+                               ])
+        Buffout_Trap = True
         statC_ActiveEffect += 1
 
-    if "EXCEPTION_INT_DIVIDE_BY_ZERO" in buff_error:
-        output.writelines(["# Checking for Bad Math Crash...............CULPRIT FOUND! #",
-                           "> Priority : [5]"
-                           ])
-        Buffout_Trap= True
-        statC_BadMath += 1
+        if "EXCEPTION_INT_DIVIDE_BY_ZERO" in buff_error:
+            output.writelines(["# Checking for Bad Math Crash...............CULPRIT FOUND! #",
+                               "> Priority : [5]"
+                               ])
+            Buffout_Trap = True
+            statC_BadMath += 1
 
-    if "0x000000000000" in buff_error:
-        output.writelines(["# Checking for Null Crash...................CULPRIT FOUND! #",
-                           "> Priority : [5]"
-                           ])
-        Buffout_Trap= True
-        statC_Null += 1
+        if "0x000000000000" in buff_error:
+            output.writelines(["# Checking for Null Crash...................CULPRIT FOUND! #",
+                               "> Priority : [5]"
+                               ])
+            Buffout_Trap = True
+            statC_Null += 1
 
-    # ======================= MAIN ERRORS =======================
+        # ======================= MAIN ERRORS =======================
 
-    # OTHER | RESERVED
-    # *[Creation Club Crash] | +01B59A4
-    # Uneducated Shooter (56789) | logtext.count("std::invalid_argument")
-    # logtext.count("BSResourceNiBinaryStream")
-    # logtext.count("ObjectBindPolicy")
+        # OTHER | RESERVED
+        # *[Creation Club Crash] | +01B59A4
+        # Uneducated Shooter (56789) | logtext.count("std::invalid_argument")
+        # logtext.count("BSResourceNiBinaryStream")
+        # logtext.count("ObjectBindPolicy")
 
-    # ===========================================================
-    if "DLCBannerDLC01.dds" in logtext:
-        output.writelines(["# Checking for DLL Crash....................CULPRIT FOUND! #",
-                           f'> Priority : [5] | DLCBannerDLC01.dds : {logtext.count("DLCBannerDLC01.dds")}'
-                           ])
-        Buffout_Trap= True
-        statC_DLL += 1
-    # ===========================================================
-    if "BGSLocation" in logtext and "BGSQueuedTerrainInitialLoad" in logtext:
-        output.writelines(['# Checking for LOD Crash....................CULPRIT FOUND! #',
-                           f'> Priority : [5] | BGSLocation : {logtext.count("BGSLocation")} | BGSQueuedTerrainInitialLoad : {logtext.count("BGSQueuedTerrainInitialLoad")}'
-                           ])
-        Buffout_Trap= True
-        statC_LOD += 1
-    # ===========================================================
-    if ("FaderData" or "FaderMenu" or "UIMessage") in logtext:
-        output.writelines(["# Checking for MCM Crash....................CULPRIT FOUND! #",
-                           f'> Priority : [3] | FaderData : {logtext.count("FaderData")} | FaderMenu : {logtext.count("FaderMenu")} | UIMessage : {logtext.count("UIMessage")}'
-                           ])
-        Buffout_Trap= True
-        statC_MCM += 1
-    # ===========================================================
-    if ("BGSDecalManager" or "BSTempEffectGeometryDecal") in logtext:
-        output.writelines(["# Checking for Decal Crash..................CULPRIT FOUND! #",
-                           f'> Priority : [5] | BGSDecalManager : {logtext.count("BGSDecalManager")} | BSTempEffectGeometryDecal : {logtext.count("BSTempEffectGeometryDecal")}'
-                           ])
-        Buffout_Trap= True
-        statC_Decal += 1
-    # ===========================================================
-    if logtext.count("PipboyMapData") >= 2:
-        output.writelines(["# Checking for Equip Crash..................CULPRIT FOUND! #",
-                           f'> Priority : [2] | PipboyMapData : {logtext.count("PipboyMapData")}'
-                           ])
-        Buffout_Trap= True
-        statC_Equip += 1
-    # ===========================================================
-    if (logtext.count("Papyrus") or logtext.count("VirtualMachine")) >= 2:
-        output.writelines(["# Checking for Script Crash.................CULPRIT FOUND! #",
-                           f'> Priority : [3] | Papyrus : {logtext.count("Papyrus")} | VirtualMachine : {logtext.count("VirtualMachine")}'
-                           ])
-        Buffout_Trap= True
-        statC_Papyrus += 1
-    # ===========================================================
-    if logtext.count("tbbmalloc.dll") >= 3 or "tbbmalloc" in buff_error:
-        output.writelines(["# Checking for Generic Crash................CULPRIT FOUND! #",
-                           f'> Priority : [2] | tbbmalloc.dll : {logtext.count("tbbmalloc.dll")}'
-                           ])
-        Buffout_Trap= True
-        statC_Generic += 1
-    # ===========================================================
-    if "LooseFileAsyncStream" in logtext:
-        output.writelines(["# Checking for BA2 Limit Crash..............CULPRIT FOUND! #",
-                           f'> Priority : [5] | LooseFileAsyncStream : {logtext.count("LooseFileAsyncStream")}'
-                           ])
-        Buffout_Trap= True
-        statC_BA2Limit += 1
-    # ===========================================================
-    if logtext.count("d3d11.dll") >= 3 or "d3d11" in buff_error:
-        output.writelines(["# Checking for Rendering Crash..............CULPRIT FOUND! #",
-                           f'> Priority : [4] | d3d11.dll : {logtext.count("d3d11.dll")}'
-                           ])
-        Buffout_Trap= True
-        statC_Rendering += 1
-    # ===========================================================
-    if ("GridAdjacencyMapNode" or "PowerUtils") in logtext:
-        output.writelines(["# Checking for Grid Scrap Crash.............CULPRIT FOUND! #",
-                           f'> Priority : [5] | GridAdjacencyMapNode : {logtext.count("GridAdjacencyMapNode")} | PowerUtils : {logtext.count("PowerUtils")}'
-                           ])
-        Buffout_Trap= True
-        statC_GridScrap += 1
-    # ===========================================================
-    if ("LooseFileStream" or "BSFadeNode" or "BSMultiBoundNode") in logtext and logtext.count("LooseFileAsyncStream") == 0:
-        output.writelines(["# Checking for Mesh (NIF) Crash.............CULPRIT FOUND! #",
-                           f'> Priority : [4] | LooseFileStream : {logtext.count("LooseFileStream")} | BSFadeNode : {logtext.count("BSFadeNode")}',
-                           f'                   BSMultiBoundNode : {logtext.count("BSMultiBoundNode")}'
-                           ])
-        Buffout_Trap= True
-        statC_NIF += 1
-    # ===========================================================
-    if ("Create2DTexture" or "DefaultTexture") in logtext:
-        output.writelines(["# Checking for Texture (DDS) Crash..........CULPRIT FOUND! #",
-                           f'> Priority : [3] | Create2DTexture : {logtext.count("Create2DTexture")} | DefaultTexture : {logtext.count("DefaultTexture")}'
-                           ])
-        Buffout_Trap= True
-        statlogtexture += 1
-    # ===========================================================
-    if ("DefaultTexture_Black" or "NiAlphaProperty") in logtext:
-        output.writelines(["# Checking for Material (BGSM) Crash........CULPRIT FOUND! #",
-                           f'> Priority : [3] | DefaultTexture_Black : {logtext.count("DefaultTexture_Black")} | NiAlphaProperty : {logtext.count("NiAlphaProperty")}'
-                           ])
-        Buffout_Trap= True
-        statC_BGSM += 1
-    # ===========================================================
-    if (logtext.count("bdhkm64.dll") or logtext.count("usvfs::hook_DeleteFileW")) >= 2:
-        output.writelines(["# Checking for BitDefender Crash............CULPRIT FOUND! #",
-                           f'> Priority : [5] | bdhkm64.dll : {logtext.count("bdhkm64.dll")} | usvfs::hook_DeleteFileW : {logtext.count("usvfs::hook_DeleteFileW")}'
-                           ])
-        Buffout_Trap= True
-        statC_BitDefender += 1
-    # ===========================================================
-    if ("PathingCell" or "BSPathBuilder" or "PathManagerServer") in logtext:
-        output.writelines(["# Checking for NPC Pathing Crash............CULPRIT FOUND! #",
-                           f'> Priority : [3] | PathingCell : {logtext.count("PathingCell")} | BSPathBuilder : {logtext.count("BSPathBuilder")}',
-                           f'                   PathManagerServer : {logtext.count("PathManagerServer")}'
-                           ])
-        Buffout_Trap= True
-        statC_NPCPathing += 1
-    elif ("NavMesh" or "BSNavmeshObstacleData" or "DynamicNavmesh") in logtext:
-        output.writelines(["# Checking for NPC Pathing Crash............CULPRIT FOUND! #",
-                           f'> Priority : [3] | NavMesh : {logtext.count("NavMesh")} | BSNavmeshObstacleData : {logtext.count("BSNavmeshObstacleData")}',
-                           f'                   DynamicNavmesh : {logtext.count("DynamicNavmesh")}'
-                           ])
-        Buffout_Trap= True
-        statC_NPCPathing += 1
-    # ===========================================================
-    if logtext.count("X3DAudio1_7.dll") >= 3 or logtext.count("XAudio2_7.dll") >= 3 or ("X3DAudio1_7" or "XAudio2_7") in buff_error:
-        output.writelines(["# Checking for Audio Driver Crash...........CULPRIT FOUND! #",
-                           f'> Priority : [5] | X3DAudio1_7.dll : {logtext.count("X3DAudio1_7.dll")} | XAudio2_7.dll : {logtext.count("XAudio2_7.dll")}'
-                           ])
-        Buffout_Trap= True
-        statC_Audio += 1
-    # ===========================================================
-    if logtext.count("cbp.dll") >= 3 or "skeleton.nif" in logtext or "cbp.dll" in buff_error:
-        output.writelines(["# Checking for Body Physics Crash...........CULPRIT FOUND! #",
-                           f'> Priority : [4] | cbp.dll : {logtext.count("cbp.dll")} | skeleton.nif : {logtext.count("skeleton.nif")}'
-                           ])
-        Buffout_Trap= True
-        statC_BodyPhysics += 1
-    # ===========================================================
-    if ("BSMemStorage" or "DataFileHandleReaderWriter") in logtext:
-        output.writelines(["# Checking for Plugin Limit Crash...........CULPRIT FOUND! #",
-                           f'> Priority : [5] | BSMemStorage : {logtext.count("BSMemStorage")} | DataFileHandleReaderWriter : {logtext.count("DataFileHandleReaderWriter")}'])
-        Buffout_Trap= True
-        statC_PluginLimit += 1
-    # ===========================================================
-    if "GamebryoSequenceGenerator" in logtext or "+0DB9300" in buff_error:
-        output.writelines(["# Checking for Plugin Order Crash...........CULPRIT FOUND! #",
-                           f'> Priority : [5] | GamebryoSequenceGenerator : {logtext.count("GamebryoSequenceGenerator")}'
-                           ])
-        Buffout_Trap= True
-        statC_LoadOrder += 1
-    # ===========================================================
-    if logtext.count("BSD3DResourceCreator") == 3 or logtext.count("BSD3DResourceCreator") == 6:
-        output.writelines(["# Checking for MO2 Extractor Crash..........CULPRIT FOUND! #",
-                           f'> Priority : [5] | BSD3DResourceCreator : {logtext.count("BSD3DResourceCreator")}'
-                           ])
-        Buffout_Trap= True
-        statC_MO2Unp += 1
-    # ===========================================================
-    if logtext.count("flexRelease_x64.dll") >= 2 or "flexRelease_x64" in buff_error:
-        output.writelines(["# Checking for Nvidia Debris Crash..........CULPRIT FOUND! #",
-                           f'> Priority : [5] | flexRelease_x64.dll : {logtext.count("flexRelease_x64.dll")}'
-                           ])
-        Buffout_Trap= True
-        statC_NVDebris += 1
-    # ===========================================================
-    if logtext.count("nvwgf2umx.dll") >= 10 or ("nvwgf2umx" or "USER32.dll") in buff_error:
-        output.writelines(["# Checking for Nvidia Driver Crash..........CULPRIT FOUND! #",
-                           f'> Priority : [5] | nvwgf2umx.dll : {logtext.count("nvwgf2umx.dll")} | USER32.dll : {logtext.count("USER32.dll")}'
-                           ])
-        Buffout_Trap= True
-        statC_NVDriver += 1
-    # ===========================================================
-    if (logtext.count("KERNELBASE.dll") or logtext.count("MSVCP140.dll")) >= 3 and "DxvkSubmissionQueue" in logtext:
-        output.writelines(["# Checking for Vulkan Memory Crash..........CULPRIT FOUND! #",
-                           f'> Priority : [5] | KERNELBASE.dll : {logtext.count("KERNELBASE.dll")} | MSVCP140.dll : {logtext.count("MSVCP140.dll")}',
-                           f'                   DxvkSubmissionQueue : {logtext.count("DxvkSubmissionQueue")}'
-                           ])
-        Buffout_Trap= True
-        statC_VulkanMem += 1
-    # ===========================================================
-    if ("dxvk::DXGIAdapter" or "dxvk::DXGIFactory") in logtext:
-        output.writelines(["# Checking for Vulkan Settings Crash........CULPRIT FOUND! #",
-                           f'> Priority : [5] | dxvk::DXGIAdapter : {logtext.count("dxvk::DXGIAdapter")} | dxvk::DXGIFactory : {logtext.count("dxvk::DXGIFactory")}'
-                           ])
-        Buffout_Trap= True
-        statC_VulkanSet += 1
-    # ===========================================================
-    if ("BSXAudio2DataSrc" or "BSXAudio2GameSound") in logtext:
-        output.writelines(["# Checking for Corrupted Audio Crash........CULPRIT FOUND! #",
-                           f'> Priority : [4] | BSXAudio2DataSrc : {logtext.count("BSXAudio2DataSrc")} | BSXAudio2GameSound : {logtext.count("BSXAudio2GameSound")}'
-                           ])
-        Buffout_Trap= True
-        statC_CorruptedAudio += 1
-    # ===========================================================
-    if ("SysWindowCompileAndRun" or "ConsoleLogPrinter") in logtext:
-        output.writelines(["# Checking for Console Command Crash........CULPRIT FOUND! #",
-                           f'> Priority : [1] | SysWindowCompileAndRun : {logtext.count("SysWindowCompileAndRun")} | ConsoleLogPrinter : {logtext.count("ConsoleLogPrinter")}'
-                           ])
-        Buffout_Trap= True
-        statC_ConsoleCommands += 1
-    # ===========================================================
-    if "BGSWaterCollisionManager" in logtext:
-        output.writelines(["# Checking for Water Collision Crash........CULPRIT FOUND! #",
-                           "PLEASE CONTACT ME AS SOON AS POSSIBLE! (CONTACT INFO BELOW)",
-                           f'> Priority : [6] | BGSWaterCollisionManager : {logtext.count("BGSWaterCollisionManager")}'
-                           ])
-        Buffout_Trap= True
-        statC_Water += 1
-    # ===========================================================
-    if "ParticleSystem" in logtext:
-        output.writelines(["# Checking for Particle Effects Crash.......CULPRIT FOUND! #",
-                           f'> Priority : [4] | ParticleSystem : {logtext.count("ParticleSystem")}'
-                           ])
-        Buffout_Trap= True
-        statC_Particles += 1
-    # ===========================================================
-    if ("hkbVariableBindingSet" or "hkbHandIkControlsModifier" or "hkbBehaviorGraph" or "hkbModifierList") in logtext:
-        output.writelines(["# Checking for Animation / Physics Crash....CULPRIT FOUND! #",
-                           f'> Priority : [5] | hkbVariableBindingSet : {logtext.count("hkbVariableBindingSet")} | hkbHandIkControlsModifier : {logtext.count("hkbHandIkControlsModifier")}',
-                           f'                   hkbBehaviorGraph : {logtext.count("hkbBehaviorGraph")} | hkbModifierList : {logtext.count("hkbModifierList")}'
-                           ])
-        Buffout_Trap= True
-        statC_AnimationPhysics += 1
-    # ===========================================================
-    if "DLCBanner05.dds" in logtext:
-        output.writelines(["# Checking for Archive Invalidation Crash...CULPRIT FOUND! #",
-                           f'> Priority : [5] | DLCBanner05.dds : {logtext.count("DLCBanner05.dds")}'
-                           ])
-        Buffout_Trap= True
-        statC_Invalidation += 1
+        # ===========================================================
+        if "DLCBannerDLC01.dds" in logtext:
+            output.writelines(["# Checking for DLL Crash....................CULPRIT FOUND! #",
+                               f'> Priority : [5] | DLCBannerDLC01.dds : {logtext.count("DLCBannerDLC01.dds")}'
+                               ])
+            Buffout_Trap = True
+            statC_DLL += 1
+        # ===========================================================
+        if "BGSLocation" in logtext and "BGSQueuedTerrainInitialLoad" in logtext:
+            output.writelines(['# Checking for LOD Crash....................CULPRIT FOUND! #',
+                               f'> Priority : [5] | BGSLocation : {logtext.count("BGSLocation")} | BGSQueuedTerrainInitialLoad : {logtext.count("BGSQueuedTerrainInitialLoad")}'
+                               ])
+            Buffout_Trap = True
+            statC_LOD += 1
+        # ===========================================================
+        if ("FaderData" or "FaderMenu" or "UIMessage") in logtext:
+            output.writelines(["# Checking for MCM Crash....................CULPRIT FOUND! #",
+                               f'> Priority : [3] | FaderData : {logtext.count("FaderData")} | FaderMenu : {logtext.count("FaderMenu")} | UIMessage : {logtext.count("UIMessage")}'
+                               ])
+            Buffout_Trap = True
+            statC_MCM += 1
+        # ===========================================================
+        if ("BGSDecalManager" or "BSTempEffectGeometryDecal") in logtext:
+            output.writelines(["# Checking for Decal Crash..................CULPRIT FOUND! #",
+                               f'> Priority : [5] | BGSDecalManager : {logtext.count("BGSDecalManager")} | BSTempEffectGeometryDecal : {logtext.count("BSTempEffectGeometryDecal")}'
+                               ])
+            Buffout_Trap = True
+            statC_Decal += 1
+        # ===========================================================
+        if logtext.count("PipboyMapData") >= 2:
+            output.writelines(["# Checking for Equip Crash..................CULPRIT FOUND! #",
+                               f'> Priority : [2] | PipboyMapData : {logtext.count("PipboyMapData")}'
+                               ])
+            Buffout_Trap = True
+            statC_Equip += 1
+        # ===========================================================
+        if (logtext.count("Papyrus") or logtext.count("VirtualMachine")) >= 2:
+            output.writelines(["# Checking for Script Crash.................CULPRIT FOUND! #",
+                               f'> Priority : [3] | Papyrus : {logtext.count("Papyrus")} | VirtualMachine : {logtext.count("VirtualMachine")}'
+                               ])
+            Buffout_Trap = True
+            statC_Papyrus += 1
+        # ===========================================================
+        if logtext.count("tbbmalloc.dll") >= 3 or "tbbmalloc" in buff_error:
+            output.writelines(["# Checking for Generic Crash................CULPRIT FOUND! #",
+                               f'> Priority : [2] | tbbmalloc.dll : {logtext.count("tbbmalloc.dll")}'
+                               ])
+            Buffout_Trap = True
+            statC_Generic += 1
+        # ===========================================================
+        if "LooseFileAsyncStream" in logtext:
+            output.writelines(["# Checking for BA2 Limit Crash..............CULPRIT FOUND! #",
+                               f'> Priority : [5] | LooseFileAsyncStream : {logtext.count("LooseFileAsyncStream")}'
+                               ])
+            Buffout_Trap = True
+            statC_BA2Limit += 1
+        # ===========================================================
+        if logtext.count("d3d11.dll") >= 3 or "d3d11" in buff_error:
+            output.writelines(["# Checking for Rendering Crash..............CULPRIT FOUND! #",
+                               f'> Priority : [4] | d3d11.dll : {logtext.count("d3d11.dll")}'
+                               ])
+            Buffout_Trap = True
+            statC_Rendering += 1
+        # ===========================================================
+        if ("GridAdjacencyMapNode" or "PowerUtils") in logtext:
+            output.writelines(["# Checking for Grid Scrap Crash.............CULPRIT FOUND! #",
+                               f'> Priority : [5] | GridAdjacencyMapNode : {logtext.count("GridAdjacencyMapNode")} | PowerUtils : {logtext.count("PowerUtils")}'
+                               ])
+            Buffout_Trap = True
+            statC_GridScrap += 1
+        # ===========================================================
+        if ("LooseFileStream" or "BSFadeNode" or "BSMultiBoundNode") in logtext and logtext.count("LooseFileAsyncStream") == 0:
+            output.writelines(["# Checking for Mesh (NIF) Crash.............CULPRIT FOUND! #",
+                               f'> Priority : [4] | LooseFileStream : {logtext.count("LooseFileStream")} | BSFadeNode : {logtext.count("BSFadeNode")}',
+                               f'                   BSMultiBoundNode : {logtext.count("BSMultiBoundNode")}'
+                               ])
+            Buffout_Trap = True
+            statC_NIF += 1
+        # ===========================================================
+        if ("Create2DTexture" or "DefaultTexture") in logtext:
+            output.writelines(["# Checking for Texture (DDS) Crash..........CULPRIT FOUND! #",
+                               f'> Priority : [3] | Create2DTexture : {logtext.count("Create2DTexture")} | DefaultTexture : {logtext.count("DefaultTexture")}'
+                               ])
+            Buffout_Trap = True
+            statlogtexture += 1
+        # ===========================================================
+        if ("DefaultTexture_Black" or "NiAlphaProperty") in logtext:
+            output.writelines(["# Checking for Material (BGSM) Crash........CULPRIT FOUND! #",
+                               f'> Priority : [3] | DefaultTexture_Black : {logtext.count("DefaultTexture_Black")} | NiAlphaProperty : {logtext.count("NiAlphaProperty")}'
+                               ])
+            Buffout_Trap = True
+            statC_BGSM += 1
+        # ===========================================================
+        if (logtext.count("bdhkm64.dll") or logtext.count("usvfs::hook_DeleteFileW")) >= 2:
+            output.writelines(["# Checking for BitDefender Crash............CULPRIT FOUND! #",
+                               f'> Priority : [5] | bdhkm64.dll : {logtext.count("bdhkm64.dll")} | usvfs::hook_DeleteFileW : {logtext.count("usvfs::hook_DeleteFileW")}'
+                               ])
+            Buffout_Trap = True
+            statC_BitDefender += 1
+        # ===========================================================
+        if ("PathingCell" or "BSPathBuilder" or "PathManagerServer") in logtext:
+            output.writelines(["# Checking for NPC Pathing Crash............CULPRIT FOUND! #",
+                               f'> Priority : [3] | PathingCell : {logtext.count("PathingCell")} | BSPathBuilder : {logtext.count("BSPathBuilder")}',
+                               f'                   PathManagerServer : {logtext.count("PathManagerServer")}'
+                               ])
+            Buffout_Trap = True
+            statC_NPCPathing += 1
+        elif ("NavMesh" or "BSNavmeshObstacleData" or "DynamicNavmesh") in logtext:
+            output.writelines(["# Checking for NPC Pathing Crash............CULPRIT FOUND! #",
+                               f'> Priority : [3] | NavMesh : {logtext.count("NavMesh")} | BSNavmeshObstacleData : {logtext.count("BSNavmeshObstacleData")}',
+                               f'                   DynamicNavmesh : {logtext.count("DynamicNavmesh")}'
+                               ])
+            Buffout_Trap = True
+            statC_NPCPathing += 1
+        # ===========================================================
+        if logtext.count("X3DAudio1_7.dll") >= 3 or logtext.count("XAudio2_7.dll") >= 3 or ("X3DAudio1_7" or "XAudio2_7") in buff_error:
+            output.writelines(["# Checking for Audio Driver Crash...........CULPRIT FOUND! #",
+                               f'> Priority : [5] | X3DAudio1_7.dll : {logtext.count("X3DAudio1_7.dll")} | XAudio2_7.dll : {logtext.count("XAudio2_7.dll")}'
+                               ])
+            Buffout_Trap = True
+            statC_Audio += 1
+        # ===========================================================
+        if logtext.count("cbp.dll") >= 3 or "skeleton.nif" in logtext or "cbp.dll" in buff_error:
+            output.writelines(["# Checking for Body Physics Crash...........CULPRIT FOUND! #",
+                               f'> Priority : [4] | cbp.dll : {logtext.count("cbp.dll")} | skeleton.nif : {logtext.count("skeleton.nif")}'
+                               ])
+            Buffout_Trap = True
+            statC_BodyPhysics += 1
+        # ===========================================================
+        if ("BSMemStorage" or "DataFileHandleReaderWriter") in logtext:
+            output.writelines(["# Checking for Plugin Limit Crash...........CULPRIT FOUND! #",
+                               f'> Priority : [5] | BSMemStorage : {logtext.count("BSMemStorage")} | DataFileHandleReaderWriter : {logtext.count("DataFileHandleReaderWriter")}'])
+            Buffout_Trap = True
+            statC_PluginLimit += 1
+        # ===========================================================
+        if "GamebryoSequenceGenerator" in logtext or "+0DB9300" in buff_error:
+            output.writelines(["# Checking for Plugin Order Crash...........CULPRIT FOUND! #",
+                               f'> Priority : [5] | GamebryoSequenceGenerator : {logtext.count("GamebryoSequenceGenerator")}'
+                               ])
+            Buffout_Trap = True
+            statC_LoadOrder += 1
+        # ===========================================================
+        if logtext.count("BSD3DResourceCreator") == 3 or logtext.count("BSD3DResourceCreator") == 6:
+            output.writelines(["# Checking for MO2 Extractor Crash..........CULPRIT FOUND! #",
+                               f'> Priority : [5] | BSD3DResourceCreator : {logtext.count("BSD3DResourceCreator")}'
+                               ])
+            Buffout_Trap = True
+            statC_MO2Unp += 1
+        # ===========================================================
+        if logtext.count("flexRelease_x64.dll") >= 2 or "flexRelease_x64" in buff_error:
+            output.writelines(["# Checking for Nvidia Debris Crash..........CULPRIT FOUND! #",
+                               f'> Priority : [5] | flexRelease_x64.dll : {logtext.count("flexRelease_x64.dll")}'
+                               ])
+            Buffout_Trap = True
+            statC_NVDebris += 1
+        # ===========================================================
+        if logtext.count("nvwgf2umx.dll") >= 10 or ("nvwgf2umx" or "USER32.dll") in buff_error:
+            output.writelines(["# Checking for Nvidia Driver Crash..........CULPRIT FOUND! #",
+                               f'> Priority : [5] | nvwgf2umx.dll : {logtext.count("nvwgf2umx.dll")} | USER32.dll : {logtext.count("USER32.dll")}'
+                               ])
+            Buffout_Trap = True
+            statC_NVDriver += 1
+        # ===========================================================
+        if (logtext.count("KERNELBASE.dll") or logtext.count("MSVCP140.dll")) >= 3 and "DxvkSubmissionQueue" in logtext:
+            output.writelines(["# Checking for Vulkan Memory Crash..........CULPRIT FOUND! #",
+                               f'> Priority : [5] | KERNELBASE.dll : {logtext.count("KERNELBASE.dll")} | MSVCP140.dll : {logtext.count("MSVCP140.dll")}',
+                               f'                   DxvkSubmissionQueue : {logtext.count("DxvkSubmissionQueue")}'
+                               ])
+            Buffout_Trap = True
+            statC_VulkanMem += 1
+        # ===========================================================
+        if ("dxvk::DXGIAdapter" or "dxvk::DXGIFactory") in logtext:
+            output.writelines(["# Checking for Vulkan Settings Crash........CULPRIT FOUND! #",
+                               f'> Priority : [5] | dxvk::DXGIAdapter : {logtext.count("dxvk::DXGIAdapter")} | dxvk::DXGIFactory : {logtext.count("dxvk::DXGIFactory")}'
+                               ])
+            Buffout_Trap = True
+            statC_VulkanSet += 1
+        # ===========================================================
+        if ("BSXAudio2DataSrc" or "BSXAudio2GameSound") in logtext:
+            output.writelines(["# Checking for Corrupted Audio Crash........CULPRIT FOUND! #",
+                               f'> Priority : [4] | BSXAudio2DataSrc : {logtext.count("BSXAudio2DataSrc")} | BSXAudio2GameSound : {logtext.count("BSXAudio2GameSound")}'
+                               ])
+            Buffout_Trap = True
+            statC_CorruptedAudio += 1
+        # ===========================================================
+        if ("SysWindowCompileAndRun" or "ConsoleLogPrinter") in logtext:
+            output.writelines(["# Checking for Console Command Crash........CULPRIT FOUND! #",
+                               f'> Priority : [1] | SysWindowCompileAndRun : {logtext.count("SysWindowCompileAndRun")} | ConsoleLogPrinter : {logtext.count("ConsoleLogPrinter")}'
+                               ])
+            Buffout_Trap = True
+            statC_ConsoleCommands += 1
+        # ===========================================================
+        if "BGSWaterCollisionManager" in logtext:
+            output.writelines(["# Checking for Water Collision Crash........CULPRIT FOUND! #",
+                               "PLEASE CONTACT ME AS SOON AS POSSIBLE! (CONTACT INFO BELOW)",
+                               f'> Priority : [6] | BGSWaterCollisionManager : {logtext.count("BGSWaterCollisionManager")}'
+                               ])
+            Buffout_Trap = True
+            statC_Water += 1
+        # ===========================================================
+        if "ParticleSystem" in logtext:
+            output.writelines(["# Checking for Particle Effects Crash.......CULPRIT FOUND! #",
+                               f'> Priority : [4] | ParticleSystem : {logtext.count("ParticleSystem")}'
+                               ])
+            Buffout_Trap = True
+            statC_Particles += 1
+        # ===========================================================
+        if ("hkbVariableBindingSet" or "hkbHandIkControlsModifier" or "hkbBehaviorGraph" or "hkbModifierList") in logtext:
+            output.writelines(["# Checking for Animation / Physics Crash....CULPRIT FOUND! #",
+                               f'> Priority : [5] | hkbVariableBindingSet : {logtext.count("hkbVariableBindingSet")} | hkbHandIkControlsModifier : {logtext.count("hkbHandIkControlsModifier")}',
+                               f'                   hkbBehaviorGraph : {logtext.count("hkbBehaviorGraph")} | hkbModifierList : {logtext.count("hkbModifierList")}'
+                               ])
+            Buffout_Trap = True
+            statC_AnimationPhysics += 1
+        # ===========================================================
+        if "DLCBanner05.dds" in logtext:
+            output.writelines(["# Checking for Archive Invalidation Crash...CULPRIT FOUND! #",
+                               f'> Priority : [5] | DLCBanner05.dds : {logtext.count("DLCBanner05.dds")}'
+                               ])
+            Buffout_Trap = True
+            statC_Invalidation += 1
 
-    # ===========================================================
-    output.write("---------- Unsolved Crash Messages Below ----------")
+        # ===========================================================
+        output.write("---------- Unsolved Crash Messages Below ----------")
 
-    if "+01B59A4" in buff_error:
-        output.writelines(["Checking for *[Creation Club Crash].......DETECTED!",
-                           "> Priority : [5]"
-                           ])
-        Buffout_Trap= True
-        statU_CClub += 1
+        if "+01B59A4" in buff_error:
+            output.writelines(["Checking for *[Creation Club Crash].......DETECTED!",
+                               "> Priority : [5]"
+                               ])
+            Buffout_Trap = True
+            statU_CClub += 1
 
-    if ("BGSMod::Attachment" or "BGSMod::Template" or "BGSMod::Template::Item") in logtext:
-        output.writelines(["Checking for *[Item Crash]................DETECTED!",
-                           f'> Priority : [5] | BGSMod::Attachment : {logtext.count("BGSMod::Attachment")} | BGSMod::Template : {logtext.count("BGSMod::Template")}',
-                           f'                        BGSMod::Template::Item : {logtext.count("BGSMod::Template::Item")}'
-                           ])
-        Buffout_Trap= True
-        statU_Item += 1
-    # ===========================================================
-    if logtext.count("BGSSaveFormBuffer") >= 2:
-        output.writelines(["Checking for *[Save Crash]................DETECTED!",
-                           f'> Priority : [5] | BGSSaveFormBuffer : {logtext.count("BGSSaveFormBuffer")}'
-                           ])
-        Buffout_Trap= True
-        statU_Save += 1
-    # ===========================================================
-    if ("ButtonEvent" or "MenuControls" or "MenuOpenCloseHandler" or "PlayerControls" or "DXGISwapChain") in logtext:
-        output.writelines(["Checking for *[Input Crash]...............DETECTED!",
-                           f'> Priority : [5] | ButtonEvent : {logtext.count("ButtonEvent")} | MenuControls : {logtext.count("MenuControls")}',
-                           f'                        MenuOpenCloseHandler : {logtext.count("MenuOpenCloseHandler")} | PlayerControls : {logtext.count("PlayerControls")}',
-                           f'                        DXGISwapChain : {logtext.count("DXGISwapChain")}'
-                           ])
-        Buffout_Trap= True
-        statU_Input += 1
-    # ===========================================================
-    if ("BGSSaveLoadManager" or "BGSSaveLoadThread" or "BGSSaveFormBuffer") in logtext or ("+0CDAD30" or "+0D09AB7") in buff_error:
-        output.writelines(["Checking for *[Bad INI Crash].............DETECTED!",
-                           f'> Priority : [5] | BGSSaveLoadManager : {logtext.count("BGSSaveLoadManager")} | BGSSaveLoadThread : {logtext.count("BGSSaveLoadThread")}',
-                           f'                        BGSSaveFormBuffer : {logtext.count("BGSSaveFormBuffer")}'
-                           ])
-        Buffout_Trap= True
-        statU_INI += 1
-    # ===========================================================
-    if ("BGSProcedurePatrol" or "BGSProcedurePatrolExecState" or "PatrolActorPackageData") in logtext:
-        output.writelines(["Checking for *[NPC Patrol Crash]..........DETECTED!",
-                           f'> Priority : [5] | BGSProcedurePatrol : {logtext.count("BGSProcedurePatrol")} | BGSProcedurePatrolExecStatel : {logtext.count("BGSProcedurePatrolExecState")}',
-                           f'                        PatrolActorPackageData : {logtext.count("PatrolActorPackageData")}'
-                           ])
-        Buffout_Trap= True
-        statU_Patrol += 1
-    # ===========================================================
-    if ("BSPackedCombinedGeomDataExtra" or "BGSCombinedCellGeometryDB" or "BGSStaticCollection" or "TESObjectCELL") in logtext:
-        output.writelines(["Checking for *[Precombines Crash].........DETECTED!",
-                           f'> Priority : [5] | BGSStaticCollection : {logtext.count("BGSStaticCollection")} | BGSCombinedCellGeometryDB : {logtext.count("BGSCombinedCellGeometryDB")}',
-                           f'                        BSPackedCombinedGeomDataExtra : {logtext.count("BSPackedCombinedGeomDataExtra")} | TESObjectCELL : {logtext.count("TESObjectCELL")}'
-                           ])
-        Buffout_Trap= True
-        statU_Precomb += 1
-    # ===========================================================
-    if "HUDAmmoCounter" in logtext:
-        output.writelines(["Checking for *[Ammo Counter Crash]........DETECTED!",
-                           f'> Priority : [5] | HUDAmmoCounter : {logtext.count("HUDAmmoCounter")}'
-                           ])
-        Buffout_Trap= True
-        statU_HUDAmmo += 1
-    # ===========================================================
-    if ("BGSProjectile" or "CombatProjectileAimController") in logtext:
-        output.writelines(["Checking for *[NPC Projectile Crash].....DETECTED!",
-                           f'> Priority : [5] | BGSProjectile : {logtext.count("BGSProjectile")} | CombatProjectileAimController : {logtext.count("CombatProjectileAimController")}'
-                           ])
-        Buffout_Trap= True
-    # ===========================================================
-    if logtext.count("PlayerCharacter") >= 1 and (logtext.count("0x00000007") or logtext.count("0x00000014") or logtext.count("0x00000008")) >= 3:
-        output.write("Checking for *[Player Character Crash]....DETECTED!")
-        output.write(f'> Priority : [5] | PlayerCharacter : {logtext.count("PlayerCharacter")} | 0x00000007 : {logtext.count("0x00000007")}')
-        output.write(f'                        0x00000008 : {logtext.count("0x00000008")} | 0x000000014 : {logtext.count("0x00000014")}')
-        output.writelines(["Checking for *[Player Character Crash]....DETECTED!",
-                           f'> Priority : [5] | PlayerCharacter : {logtext.count("PlayerCharacter")} | 0x00000007 : {logtext.count("0x00000007")}',
-                           f'                        0x00000008 : {logtext.count("0x00000008")} | 0x000000014 : {logtext.count("0x00000014")}'
-                           ])
-        Buffout_Trap= True
-        statU_Player += 1
+        if ("BGSMod::Attachment" or "BGSMod::Template" or "BGSMod::Template::Item") in logtext:
+            output.writelines(["Checking for *[Item Crash]................DETECTED!",
+                               f'> Priority : [5] | BGSMod::Attachment : {logtext.count("BGSMod::Attachment")} | BGSMod::Template : {logtext.count("BGSMod::Template")}',
+                               f'                        BGSMod::Template::Item : {logtext.count("BGSMod::Template::Item")}'
+                               ])
+            Buffout_Trap = True
+            statU_Item += 1
+        # ===========================================================
+        if logtext.count("BGSSaveFormBuffer") >= 2:
+            output.writelines(["Checking for *[Save Crash]................DETECTED!",
+                               f'> Priority : [5] | BGSSaveFormBuffer : {logtext.count("BGSSaveFormBuffer")}'
+                               ])
+            Buffout_Trap = True
+            statU_Save += 1
+        # ===========================================================
+        if ("ButtonEvent" or "MenuControls" or "MenuOpenCloseHandler" or "PlayerControls" or "DXGISwapChain") in logtext:
+            output.writelines(["Checking for *[Input Crash]...............DETECTED!",
+                               f'> Priority : [5] | ButtonEvent : {logtext.count("ButtonEvent")} | MenuControls : {logtext.count("MenuControls")}',
+                               f'                        MenuOpenCloseHandler : {logtext.count("MenuOpenCloseHandler")} | PlayerControls : {logtext.count("PlayerControls")}',
+                               f'                        DXGISwapChain : {logtext.count("DXGISwapChain")}'
+                               ])
+            Buffout_Trap = True
+            statU_Input += 1
+        # ===========================================================
+        if ("BGSSaveLoadManager" or "BGSSaveLoadThread" or "BGSSaveFormBuffer") in logtext or ("+0CDAD30" or "+0D09AB7") in buff_error:
+            output.writelines(["Checking for *[Bad INI Crash].............DETECTED!",
+                               f'> Priority : [5] | BGSSaveLoadManager : {logtext.count("BGSSaveLoadManager")} | BGSSaveLoadThread : {logtext.count("BGSSaveLoadThread")}',
+                               f'                        BGSSaveFormBuffer : {logtext.count("BGSSaveFormBuffer")}'
+                               ])
+            Buffout_Trap = True
+            statU_INI += 1
+        # ===========================================================
+        if ("BGSProcedurePatrol" or "BGSProcedurePatrolExecState" or "PatrolActorPackageData") in logtext:
+            output.writelines(["Checking for *[NPC Patrol Crash]..........DETECTED!",
+                               f'> Priority : [5] | BGSProcedurePatrol : {logtext.count("BGSProcedurePatrol")} | BGSProcedurePatrolExecStatel : {logtext.count("BGSProcedurePatrolExecState")}',
+                               f'                        PatrolActorPackageData : {logtext.count("PatrolActorPackageData")}'
+                               ])
+            Buffout_Trap = True
+            statU_Patrol += 1
+        # ===========================================================
+        if ("BSPackedCombinedGeomDataExtra" or "BGSCombinedCellGeometryDB" or "BGSStaticCollection" or "TESObjectCELL") in logtext:
+            output.writelines(["Checking for *[Precombines Crash].........DETECTED!",
+                               f'> Priority : [5] | BGSStaticCollection : {logtext.count("BGSStaticCollection")} | BGSCombinedCellGeometryDB : {logtext.count("BGSCombinedCellGeometryDB")}',
+                               f'                        BSPackedCombinedGeomDataExtra : {logtext.count("BSPackedCombinedGeomDataExtra")} | TESObjectCELL : {logtext.count("TESObjectCELL")}'
+                               ])
+            Buffout_Trap = True
+            statU_Precomb += 1
+        # ===========================================================
+        if "HUDAmmoCounter" in logtext:
+            output.writelines(["Checking for *[Ammo Counter Crash]........DETECTED!",
+                               f'> Priority : [5] | HUDAmmoCounter : {logtext.count("HUDAmmoCounter")}'
+                               ])
+            Buffout_Trap = True
+            statU_HUDAmmo += 1
+        # ===========================================================
+        if ("BGSProjectile" or "CombatProjectileAimController") in logtext:
+            output.writelines(["Checking for *[NPC Projectile Crash].....DETECTED!",
+                               f'> Priority : [5] | BGSProjectile : {logtext.count("BGSProjectile")} | CombatProjectileAimController : {logtext.count("CombatProjectileAimController")}'
+                               ])
+            Buffout_Trap = True
+        # ===========================================================
+        if logtext.count("PlayerCharacter") >= 1 and (logtext.count("0x00000007") or logtext.count("0x00000014") or logtext.count("0x00000008")) >= 3:
+            output.write("Checking for *[Player Character Crash]....DETECTED!")
+            output.write(f'> Priority : [5] | PlayerCharacter : {logtext.count("PlayerCharacter")} | 0x00000007 : {logtext.count("0x00000007")}')
+            output.write(f'                        0x00000008 : {logtext.count("0x00000008")} | 0x000000014 : {logtext.count("0x00000014")}')
+            output.writelines(["Checking for *[Player Character Crash]....DETECTED!",
+                               f'> Priority : [5] | PlayerCharacter : {logtext.count("PlayerCharacter")} | 0x00000007 : {logtext.count("0x00000007")}',
+                               f'                        0x00000008 : {logtext.count("0x00000008")} | 0x000000014 : {logtext.count("0x00000014")}'
+                               ])
+            Buffout_Trap = True
+            statU_Player += 1
 
-    # ===========================================================
+        # ===========================================================
 
-    if Buffout_Trap == False:  # DEFINE CHECK IF NOTHING TRIGGERED BUFFOUT TRAP
+        if Buffout_Trap == False:  # DEFINE CHECK IF NOTHING TRIGGERED BUFFOUT TRAP
+            output.writelines([
+                "-----",
+                "# AUTOSCAN FOUND NO CRASH ERRORS / CULPRITS THAT MATCH THE CURRENT DATABASE #",
+                "Check below for mods that can cause frequent crashes and other problems.",
+                "-----"
+            ])
+        else:
+            output.writelines([
+                "-----",
+                "FOR DETAILED DESCRIPTIONS AND POSSIBLE SOLUTIONS TO ANY ABOVE DETECTED CRASH CULPRITS,",
+                "SEE: https://docs.google.com/document/d/17FzeIMJ256xE85XdjoPvv_Zi3C5uHeSTQh6wOZugs4c",
+                "-----"
+            ])
+
         output.writelines([
-            "-----",
-            "# AUTOSCAN FOUND NO CRASH ERRORS / CULPRITS THAT MATCH THE CURRENT DATABASE #",
-            "Check below for mods that can cause frequent crashes and other problems.",
-            "-----"
+            "====================================================",
+            "CHECKING FOR MODS THAT CAN CAUSE FREQUENT CRASHES...",
+            "===================================================="
         ])
-    else:
-        output.writelines([
-            "-----",
-            "FOR DETAILED DESCRIPTIONS AND POSSIBLE SOLUTIONS TO ANY ABOVE DETECTED CRASH CULPRITS,",
-            "SEE: https://docs.google.com/document/d/17FzeIMJ256xE85XdjoPvv_Zi3C5uHeSTQh6wOZugs4c",
-            "-----"
-        ])
+        Mod_Trap1 = 1
 
-    output.writelines([
-        "====================================================",
-        "CHECKING FOR MODS THAT CAN CAUSE FREQUENT CRASHES...",
-        "===================================================="
-    ])
-    Mod_Trap1= 1
+        # Why lists and not dictionaries? So I can preserve alphabetical order in code and
+        # numerical order in output without having to rename a bunch of variables.
+        # Needs 1 empty space as prefix to prevent duplicates.
+        List_Mods1 = [" DamageThresholdFramework.esm",
+                      " Endless Warfare.esm",
+                      " ExtendedWeaponSystem.esm",
+                      " EPO",
+                      " SakhalinWasteland",
+                      " 76HUD",
+                      " NCRenegade",
+                      " Respawnable Legendary Bosses",
+                      " Scrap Everything - Core",
+                      " Scrap Everything - Ultimate",
+                      " Shade Girl Leather Outfits",
+                      " SpringCleaning.esm",
+                      " (STO) NO",
+                      " TacticalTablet.esp",
+                      " True Nights v03.esp",
+                      " WeaponsFramework",
+                      " WOTC.esp"]
 
-    # Why lists and not dictionaries? So I can preserve alphabetical order in code and
-    # numerical order in output without having to rename a bunch of variables.
-    # Needs 1 empty space as prefix to prevent duplicates.
-    List_Mods1= [" DamageThresholdFramework.esm",
-                  " Endless Warfare.esm",
-                  " ExtendedWeaponSystem.esm",
-                  " EPO",
-                  " SakhalinWasteland",
-                  " 76HUD",
-                  " NCRenegade",
-                  " Respawnable Legendary Bosses",
-                  " Scrap Everything - Core",
-                  " Scrap Everything - Ultimate",
-                  " Shade Girl Leather Outfits",
-                  " SpringCleaning.esm",
-                  " (STO) NO",
-                  " TacticalTablet.esp",
-                  " True Nights v03.esp",
-                  " WeaponsFramework",
-                  " WOTC.esp"]
+        List_Warn1 = ["DAMAGE THRESHOLD FRAMEWORK \n"
+                      "- Can cause crashes in combat on some occasions due to how damage calculations are done.",
 
-    List_Warn1= ["DAMAGE THRESHOLD FRAMEWORK \n"
-                  "- Can cause crashes in combat on some occasions due to how damage calculations are done.",
+                      "ENDLESS WARFARE \n"
+                      "- Some enemy spawn points could be bugged or crash the game due to scripts or pathfinding.",
 
-                  "ENDLESS WARFARE \n"
-                  "- Some enemy spawn points could be bugged or crash the game due to scripts or pathfinding.",
+                      "EXTENDED WEAPON SYSTEMS \n"
+                      "- Alternative to Tactical Reload that suffers from similar weapon related problems and crashes.",
 
-                  "EXTENDED WEAPON SYSTEMS \n"
-                  "- Alternative to Tactical Reload that suffers from similar weapon related problems and crashes.",
+                      "EXTREME PARTICLES OVERHAUL \n"
+                      "- Can cause particle effects related crashes, its INI file raises particle count to 500000. \n"
+                      "  Consider switching to Burst Impact Blast FX: https://www.nexusmods.com/fallout4/mods/57789",
 
-                  "EXTREME PARTICLES OVERHAUL \n"
-                  "- Can cause particle effects related crashes, its INI file raises particle count to 500000. \n"
-                  "  Consider switching to Burst Impact Blast FX: https://www.nexusmods.com/fallout4/mods/57789",
+                      "FALLOUT SAKHALIN \n"
+                      "- Breaks the precombine system all across Far Harbor which will randomly crash your game.",
 
-                  "FALLOUT SAKHALIN \n"
-                  "- Breaks the precombine system all across Far Harbor which will randomly crash your game.",
+                      "HUD76 HUD REPLACER \n"
+                      "- Can sometimes cause interface and pip-boy related bugs, glitches and crashes.",
 
-                  "HUD76 HUD REPLACER \n"
-                  "- Can sometimes cause interface and pip-boy related bugs, glitches and crashes.",
+                      "NCR RENEGADE ARMOR \n"
+                      "- Broken outfit mesh that crashes the game in 3rd person or when NPCs wearing it are hit.",
 
-                  "NCR RENEGADE ARMOR \n"
-                  "- Broken outfit mesh that crashes the game in 3rd person or when NPCs wearing it are hit.",
+                      "RESPAWNABLE LEGENDARY BOSSES \n"
+                      "- Can sometimes cause Deathclaw / Behmoth boulder projectile crashes for unknown reasons.",
 
-                  "RESPAWNABLE LEGENDARY BOSSES \n"
-                  "- Can sometimes cause Deathclaw / Behmoth boulder projectile crashes for unknown reasons.",
+                      "SCRAP EVERYTHING (CORE) \n"
+                      "- Weird crashes and issues due to multiple unknown problems. This mod must be always last in your load order.",
 
-                  "SCRAP EVERYTHING (CORE) \n"
-                  "- Weird crashes and issues due to multiple unknown problems. This mod must be always last in your load order.",
+                      "SCRAP EVERYTHING (ULTIMATE) \n"
+                      "- Weird crashes and issues due to multiple unknown problems. This mod must be always last in your load order.",
 
-                  "SCRAP EVERYTHING (ULTIMATE) \n"
-                  "- Weird crashes and issues due to multiple unknown problems. This mod must be always last in your load order.",
+                      "SHADE GIRL LEATHER OUTFITS \n"
+                      "- Outfits can crash the game while browsing the armor workbench or upon starting a new game due to bad meshes.",
 
-                  "SHADE GIRL LEATHER OUTFITS \n"
-                  "- Outfits can crash the game while browsing the armor workbench or upon starting a new game due to bad meshes.",
+                      "SPRING CLEANING \n"
+                      "- Abandoned and severely outdated mod that breaks precombines and could potentially even break your save file.",
 
-                  "SPRING CLEANING \n"
-                  "- Abandoned and severely outdated mod that breaks precombines and could potentially even break your save file.",
+                      "STALKER TEXTURE OVERHAUL \n"
+                      "- Doesn't work due to incorrect folder structure and has a corrupted dds file that causes Create2DTexture crashes.",
 
-                  "STALKER TEXTURE OVERHAUL \n"
-                  "- Doesn't work due to incorrect folder structure and has a corrupted dds file that causes Create2DTexture crashes.",
+                      "TACTICAL TABLET \n"
+                      "- Can cause flickering with certain scopes or crashes while browsing workbenches, most commonly with ECO.",
 
-                  "TACTICAL TABLET \n"
-                  "- Can cause flickering with certain scopes or crashes while browsing workbenches, most commonly with ECO.",
+                      "TRUE NIGHTS \n"
+                      "- Has an invalid Image Space Adapter (IMAD) Record that will corrupt your save memory and has to be manually fixed.",
 
-                  "TRUE NIGHTS \n"
-                  "- Has an invalid Image Space Adapter (IMAD) Record that will corrupt your save memory and has to be manually fixed.",
+                      "WEAPONS FRAMEWORK BETA \n"
+                      "- Will randomly cause crashes when used with Tactical Reload and possibly other weapon or combat related mods. \n"
+                      "  Visit Important Patches List article for possible solutions: https://www.nexusmods.com/fallout4/articles/3769",
 
-                  "WEAPONS FRAMEWORK BETA \n"
-                  "- Will randomly cause crashes when used with Tactical Reload and possibly other weapon or combat related mods. \n"
-                  "  Visit Important Patches List article for possible solutions: https://www.nexusmods.com/fallout4/articles/3769",
+                      "WAR OF THE COMMONWEALTH \n"
+                      "- Seems responsible for consistent crashes with specific spawn points or randomly during settlement attacks."]
 
-                  "WAR OF THE COMMONWEALTH \n"
-                  "- Seems responsible for consistent crashes with specific spawn points or randomly during settlement attacks."]
+        if "[00]" in logtext:
+            for line in plugin_list:
+                for elem in List_Mods1:
+                    if "File:" not in line and "[FE" not in line and elem in line:
+                        order_elem = List_Mods1.index(elem)
+                        output.writelines([f"[!] Found:{line[0:5].strip()} {List_Warn1[order_elem]}",
+                                           "-----"])
+                        Mod_Trap1 = 0
+                    elif "File:" not in line and "[FE" in line and elem in line:
+                        order_elem = List_Mods1.index(elem)
+                        output.writelines([f"[!] Found:{line[0:9].strip()} {List_Warn1[order_elem]}",
+                                           "-----"])
+                        Mod_Trap1 = 0
 
-    if "[00]" in logtext:
-        for line in plugin_list:
-            for elem in List_Mods1:
-                if "File:" not in line and "[FE" not in line and elem in line:
-                    order_elem= List_Mods1.index(elem)
-                    output.writelines([f"[!] Found:{line[0:5].strip()} {List_Warn1[order_elem]}",
-                                       "-----"])
-                    Mod_Trap1= 0
-                elif "File:" not in line and "[FE" in line and elem in line:
-                    order_elem= List_Mods1.index(elem)
-                    output.writelines([f"[!] Found:{line[0:9].strip()} {List_Warn1[order_elem]}",
-                    "-----"])
-                    Mod_Trap1= 0
-
-        if logtext.count("ClassicHolsteredWeapons") >= 3 or "ClassicHolsteredWeapons" in buff_error:
-            output.writelines(["[!] Found: CLASSIC HOLSTERED WEAPONS",
-                               "AUTOSCAN IS PRETTY CERTAIN THAT CHW CAUSED THIS CRASH!",
-                               "You should disable CHW to further confirm this.",
-                               "Visit the main crash logs article for additional solutions.",
-                               "-----"
-                               ])
-            statM_CHW += 1
-            Mod_Trap1= 0
-            Buffout_Trap= True
-        elif logtext.count("ClassicHolsteredWeapons") >= 2 and ("UniquePlayer.esp" or "HHS.dll" or "cbp.dll" or "Body.nif") in logtext:
-            output.writelines(["[!] Found: CLASSIC HOLSTERED WEAPONS",
-                               "AUTOSCAN ALSO DETECTED ONE OR SEVERAL MODS THAT WILL CRASH WITH CHW.",
-                               "You should disable CHW to further confirm it caused this crash.",
-                               "Visit the main crash logs article for additional solutions.",
-                               "-----"
-                               ])
-            statM_CHW += 1
-            Mod_Trap1= 0
-            Buffout_Trap= True
-        elif "ClassicHolsteredWeapons" in logtext and "d3d11" in buff_error:
-            output.writelines(["[!] Found: CLASSIC HOLSTERED WEAPONS, BUT...",
-                               "AUTOSCAN CANNOT ACCURATELY DETERMINE IF CHW CAUSED THIS CRASH OR NOT.",
-                               "You should open CHW's ini file and change IsHolsterVisibleOnNPCs to 0.",
-                               "This usually prevents most common crashes with Classic Holstered Weapons.",
-                               "-----"
-                               ])
-            Mod_Trap1= 0
-    if "[00]" in logtext and Mod_Trap1 == 0:
-        output.writelines(["# CAUTION: ANY ABOVE DETECTED MODS HAVE A MUCH HIGHER CHANCE TO CRASH YOUR GAME! #",
-                           "You can disable any/all of them temporarily to confirm they caused this crash.",
-                           "-----"
-                           ])
-        statL_scanned += 1
-    elif "[00]" in logtext and Mod_Trap1 == 1:
-        output.writelines(["# AUTOSCAN FOUND NO PROBLEMATIC MODS THAT MATCH THE CURRENT DATABASE FOR THIS LOG #",
-                           "THAT DOESN'T MEAN THERE AREN'T ANY! YOU SHOULD RUN PLUGIN CHECKER IN WRYE BASH.",
-                           "Wrye Bash Link: https://www.nexusmods.com/fallout4/mods/20032?tab=files",
-                           "-----"
-                           ])
-        statL_scanned += 1
-    elif not "[00]" in logtext:
-        output.writelines(["# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #\n",
-                           "Autoscan cannot continue. Try scanning a different crash log.\n",
-                           "-----"
-                           ])
-        statL_incomplete += 1
-
-    output.writelines(["====================================================",
-                       "CHECKING FOR MODS WITH SOLUTIONS & COMMUNITY PATCHES",
-                       "===================================================="
-                       ])
-    Mod_Trap2= no_repeat1 = no_repeat2 = 1  # MOD TRAP 2 | NEED 8 SPACES FOR ESL [FE:XXX]
-
-    # Needs 1 empty space as prefix to prevent duplicates.
-    List_Mods2= [" DLCUltraHighResolution.esm",
-                  " AAF.esm",
-                  " ArmorKeywords.esm",
-                  " BTInteriors_Project.esp",
-                  " CombatZoneRestored.esp",
-                  " D.E.C.A.Y.esp",
-                  " EveryonesBestFriend",
-                  " M8r_Item_Tags",
-                  " Fo4FI_FPS_fix",
-                  " BostonFPSFixAIO.esp",
-                  " FunctionalDisplays.esp",
-                  " skeletonmaleplayer",
-                  " skeletonfemaleplayer",
-                  " CapsWidget",
-                  " Homemaker.esm",
-                  " Horizon.esm",
-                  " ESPExplorerFO4.esp",
-                  " LegendaryModification.esp",
-                  " LooksMenu Customization Compendium.esp",
-                  " MilitarizedMinutemen.esp",
-                  " MoreUniques",
-                  " NAC.es",
-                  " Northland Diggers New.esp",
-                  " ProjectZeta.esm",
-                  " RaiderOverhaul.esp",
-                  " Rusty Face Fix",
-                  " SKKCraftableWeaponsAmmo",
-                  " SOTS.esp",
-                  " StartMeUp.esp",
-                  " SuperMutantRedux.esp",
-                  " TacticalReload.esm",
-                  " Creatures and Monsters.esp",
-                  " ZombieWalkers"]
-
-    List_Warn2= ["HIGH RESOLUTION DLC. I STRONGLY ADVISE NOT USING IT! \n"
-                  "Right click on Fallout 4 in your Steam Library folder, then select Properties \n"
-                  "Switch to the DLC tab and uncheck / disable the High Resolution Texture Pack",
-                  #
-                  "ADVANCED ANIMATION FRAMEWORK \n"
-                  "Newest AAF version only available on Moddingham | AAF Tech Support: https://discord.gg/gWZuhMC \n"
-                  "Newest AAF Link (register / login to download): https://www.moddingham.com/viewtopic.php?t=2 \n"
-                  "-----\n"
-                  "Looks Menu versions 1.6.20 & 1.6.19 can frequently break adult mod related (erection) morphs \n"
-                  "If you notice AAF realted problems, remove latest version of Looks Menu and switch to 1.6.18",
-                  #
-                  "ARMOR AND WEAPON KEYWORDS \n"
-                  "If you don't rely on AWKCR, consider switching to Equipment and Crafting Overhaul \n"
-                  "Better Alternative: https://www.nexusmods.com/fallout4/mods/55503?tab=files",
-                  #
-                  "BEANTOWN INTERIORS PROJECT \n"
-                  "Usually causes fps drops, stuttering, crashing and culling issues in multiple locations. \n"
-                  "Patch Link: https://www.nexusmods.com/fallout4/mods/53894?tab=files",
-                  #
-                  "COMBAT ZONE RESTORED \n"
-                  "Contains few small issues and NPCs usually have trouble navigating the interior space. \n"
-                  "Patch Link: https://www.nexusmods.com/fallout4/mods/59329?tab=files",
-                  #
-                  "DECAY BETTER GHOULS \n"
-                  "You have to install DECAY Redux patch to prevent its audio files from crashing the game. \n"
-                  "Patch Link: https://www.nexusmods.com/fallout4/mods/59025?tab=files",
-                  #
-                  "EVERYONE'S BEST FRIEND \n"
-                  "This mod needs a compatibility patch to properly work with the Unofficial Patch (UFO4P). \n"
-                  "Patch Link: https://www.nexusmods.com/fallout4/mods/43409?tab=files",
-                  #
-                  "FALLUI ITEM SORTER (OLD) \n"
-                  "This is an outdated item tagging / sorting patch that can cause crashes or conflicts in all kinds of situations. \n"
-                  "I strongly recommend to instead generate your own sorting patch and place it last in your load order. \n"
-                  "That way, you won't experience any conflicts / crashes and even modded items will be sorted. \n"
-                  "Generate Sorting Patch With This: https://www.nexusmods.com/fallout4/mods/48826?tab=files",
-                  #
-                  "FO4FI FPS FIX \n"
-                  "This mod is severely outdated and will cause crashes even with compatibility patches. \n"
-                  "Better Alternative: https://www.nexusmods.com/fallout4/mods/46403?tab=files",
-                  #
-                  "BOSTON FPS FIX \n"
-                  "This mod is severely outdated and will cause crashes even with compatibility patches. \n"
-                  "Better Alternative: https://www.nexusmods.com/fallout4/mods/46403?tab=files",
-                  #
-                  "FUNCTIONAL DISPLAYS \n"
-                  "Frequently causes object model (nif) related crashes and this needs to be manually corrected. \n"
-                  "Advised Fix: Open its Meshes folder and delete everything inside EXCEPT for the Functional Displays folder.",
-                  #
-                  "GENDER SPECIFIC SKELETONS (MALE) \n"
-                  "High chance to cause a crash when starting a new game or during the game intro sequence. \n"
-                  "Advised Fix: Enable the mod only after leaving Vault 111. Existing saves shouldn't be affected.",
-                  #
-                  "GENDER SPECIFIC SKELETONS (FEMALE) \n"
-                  "High chance to cause a crash when starting a new game or during the game intro sequence. \n"
-                  "Advised Fix: Enable the mod only after leaving Vault 111. Existing saves shouldn't be affected.",
-                  #
-                  "HUD CAPS \n"
-                  "Often breaks the Save / Quicksave function due to poor script implementation. \n"
-                  "Advised Fix: Download fixed pex file and place it into HUDCaps/Scripts folder. \n"
-                  "Fix Link: https://drive.google.com/file/d/1egmtKVR7mSbjRgo106UbXv_ySKBg5az2",
-                  #
-                  "HOMEMAKER \n"
-                  "Causes a crash while scrolling over Military / BoS fences in the Settlement Menu. \n"
-                  "Patch Link: https://www.nexusmods.com/fallout4/mods/41434?tab=files",
-                  #
-                  "HORIZON \n"
-                  "Use the mod specific unofficial patch for 1.8.7 until a newer version gets released. \n"
-                  "Patch Link: https://www.nexusmods.com/fallout4/mods/61998?tab=files",
-                  #
-                  "IN GAME ESP EXPLORER \n"
-                  "Can cause a crash when pressing F10 due to a typo in the INI settings. \n"
-                  "Fix Link: https://www.nexusmods.com/fallout4/mods/64752?tab=files \n"
-                  "OR Switch To: https://www.nexusmods.com/fallout4/mods/56922?tab=files",
-                  #
-                  "LEGENDARY MODIFICATION \n"
-                  "Old mod plagued with all kinds of bugs and crashes, can conflict with some modded weapons. \n"
-                  "Better Alternative: https://www.nexusmods.com/fallout4/mods/55503?tab=files",
-                  #
-                  "LOOKS MENU CUSTOMIZATION COMPENDIUM \n"
-                  "Apparently breaks the original Looks Menu mod by turning off some important values. \n"
-                  "Fix Link: https://www.nexusmods.com/fallout4/mods/56465?tab=files",
-                  #
-                  "MILITARIZED MINUTEMEN \n"
-                  "Can occasionally crash the game due to a broken mesh on some minutemen outfits. \n"
-                  "Patch Link: https://www.nexusmods.com/fallout4/mods/55301?tab=files",
-                  #
-                  "MORE UNIQUE WEAPONS EXPANSION \n"
-                  "Causes crashes due to broken precombines and compatibility issues with other weapon mods. \n"
-                  "Patch Link: https://www.nexusmods.com/fallout4/mods/54848?tab=files",
-                  #
-                  "NATURAL AND ATMOSPHERIC COMMONWEALTH \n"
-                  "If you notice weird looking skin tones with either NAC or NACX, install this patch. \n"
-                  "Patch Link: https://www.nexusmods.com/fallout4/mods/57052?tab=files",
-                  #
-                  "NORTHLAND DIGGERS RESOURCES \n"
-                  "Contains various bugs and issues that can cause crashes or negatively affect other mods. \n"
-                  "Fix Link: https://www.nexusmods.com/fallout4/mods/53395?tab=files",
-                  #
-                  "PROJECT ZETA \n"
-                  "Invasion quests seem overly buggy or trigger too frequently, minor sound issues. \n"
-                  "Fix Link: https://www.nexusmods.com/fallout4/mods/65166?tab=files",
-                  #
-                  "RAIDER OVERHAUL \n"
-                  "Old mod that requires several patches to function as intended. Use ONE Version instead. \n"
-                  "Upated ONE Version: https://www.nexusmods.com/fallout4/mods/51658?tab=files",
-                  #
-                  "RUSTY FACE FIX \n"
-                  "Can cause script lag or even crash the game in very rare cases. Switch to REDUX Version instead. \n"
-                  "Updated REDUX Version: https://www.nexusmods.com/fallout4/mods/64270?tab=files",
-                  #
-                  "SKK CRAFT WEAPONS AND SCRAP AMMO \n"
-                  "Version 008 is incompatible with AWKCR and will cause crashes while saving the game. \n"
-                  "Advised Fix: Use Version 007 or remove AWKCR and switch to Equipment and Crafting Overhaul.",
-                  #
-                  "SOUTH OF THE SEA \n"
-                  "Very unstable mod that consistently and frequently causes strange problems and crashes. \n"
-                  "Patch Link: https://www.nexusmods.com/fallout4/mods/59792?tab=files",
-                  #
-                  "START ME UP \n"
-                  "Abandoned mod that can cause infinite loading and other problems. Switch to REDUX Version instead. \n"
-                  "Updated REDUX Version: https://www.nexusmods.com/fallout4/mods/56984?tab=files",
-                  #
-                  "SUPER MUTANT REDUX \n"
-                  "Causes crashes at specific locations or with certain Super Muntant enemies and items. \n"
-                  "Patch Link: https://www.nexusmods.com/fallout4/mods/51353?tab=files",
-                  #
-                  "TACTICAL RELOAD \n"
-                  "Can cause weapon and combat related crashes. TR Expansion For ECO is highly recommended. \n"
-                  "TR Expansion For ECO Link: https://www.nexusmods.com/fallout4/mods/62737",
-                  #
-                  "UNIQUE NPCs CREATURES AND MONSTERS \n"
-                  "Causes crashes and breaks precombines at specific locations, some creature spawns are too frequent. \n"
-                  "Patch Link: https://www.nexusmods.com/fallout4/mods/48637?tab=files",
-                  #
-                  "ZOMBIE WALKERS \n"
-                  "Version 2.6.3 contains a resurrection script that will regularly crash the game. \n"
-                  "Advised Fix: Make sure you're using the 3.0 Beta version of this mod or newer."]
-
-    if "[00]" in logtext:
-        for line in plugin_list:
-            for elem in List_Mods2:
-                if "File:" not in line and "[FE" not in line and elem in line:
-                    order_elem= List_Mods2.index(elem)
-                    output.writelines([f"[!] Found:{line[0:5].strip()} {List_Warn2[order_elem]}",
-                                       "-----"
-                                       ])
-                    Mod_Trap2= 0
-                elif "File:" not in line and "[FE" in line and elem in line:
-                    order_elem= List_Mods2.index(elem)
-                    output.writelines([f"[!] Found:{line[0:9].strip()} {List_Warn2[order_elem]}",
-                                      "-----"
-                                      ])
-                    Mod_Trap2= 0
-            if no_repeat1 == 1 and "File:" not in line and ("Depravity" or "FusionCityRising" or "HotC" or "OutcastsAndRemnants" or "ProjectValkyrie") in line:
-                output.writelines([f"[!] Found:{line[0:9].strip()} THUGGYSMURF QUEST MOD",
-                                   "If you have Depravity, Fusion City Rising, HOTC, Outcasts and Remnants and/or Project Valkyrie",
-                                   "install this patch with facegen data, fully generated precomb/previs data and several tweaks.",
-                                   "Patch Link: https://www.nexusmods.com/fallout4/mods/56876?tab=files",
+            if logtext.count("ClassicHolsteredWeapons") >= 3 or "ClassicHolsteredWeapons" in buff_error:
+                output.writelines(["[!] Found: CLASSIC HOLSTERED WEAPONS",
+                                   "AUTOSCAN IS PRETTY CERTAIN THAT CHW CAUSED THIS CRASH!",
+                                   "You should disable CHW to further confirm this.",
+                                   "Visit the main crash logs article for additional solutions.",
                                    "-----"
                                    ])
-                no_repeat1= Mod_Trap2 = 0
-            if no_repeat1 == 1 and "File:" not in line and ("CaN.esm" or "AnimeRace_Nanako.esp") in line:
-                output.writelines([f"[!] Found:{line[0:9].strip()} CUSTOM RACE SKELETON MOD",
-                                   "If you have AnimeRace NanakoChan or Crimes Against Nature, install the Race Skeleton Fixes.",
-                                   "Skeleton Fixes Link (READ THE DESCRIPTION): https://www.nexusmods.com/fallout4/mods/56101"
+                statM_CHW += 1
+                Mod_Trap1 = 0
+                Buffout_Trap = True
+            elif logtext.count("ClassicHolsteredWeapons") >= 2 and ("UniquePlayer.esp" or "HHS.dll" or "cbp.dll" or "Body.nif") in logtext:
+                output.writelines(["[!] Found: CLASSIC HOLSTERED WEAPONS",
+                                   "AUTOSCAN ALSO DETECTED ONE OR SEVERAL MODS THAT WILL CRASH WITH CHW.",
+                                   "You should disable CHW to further confirm it caused this crash.",
+                                   "Visit the main crash logs article for additional solutions.",
+                                   "-----"
                                    ])
-                no_repeat2= Mod_Trap2 = 0
-
-        if "FallSouls.dll" in logtext:
-            output.writelines(["[!] Found: FALLSOULS UNPAUSED GAME MENUS",
-                               "Occasionally breaks the Quests menu, can cause crashes while changing MCM settings.",
-                               "Advised Fix: Toggle PipboyMenu in FallSouls MCM settings or completely reinstall the mod.",
+                statM_CHW += 1
+                Mod_Trap1 = 0
+                Buffout_Trap = True
+            elif "ClassicHolsteredWeapons" in logtext and "d3d11" in buff_error:
+                output.writelines(["[!] Found: CLASSIC HOLSTERED WEAPONS, BUT...",
+                                   "AUTOSCAN CANNOT ACCURATELY DETERMINE IF CHW CAUSED THIS CRASH OR NOT.",
+                                   "You should open CHW's ini file and change IsHolsterVisibleOnNPCs to 0.",
+                                   "This usually prevents most common crashes with Classic Holstered Weapons.",
+                                   "-----"
+                                   ])
+                Mod_Trap1 = 0
+        if "[00]" in logtext and Mod_Trap1 == 0:
+            output.writelines(["# CAUTION: ANY ABOVE DETECTED MODS HAVE A MUCH HIGHER CHANCE TO CRASH YOUR GAME! #",
+                               "You can disable any/all of them temporarily to confirm they caused this crash.",
                                "-----"
                                ])
-            Mod_Trap2= 0
+            statL_scanned += 1
+        elif "[00]" in logtext and Mod_Trap1 == 1:
+            output.writelines(["# AUTOSCAN FOUND NO PROBLEMATIC MODS THAT MATCH THE CURRENT DATABASE FOR THIS LOG #",
+                               "THAT DOESN'T MEAN THERE AREN'T ANY! YOU SHOULD RUN PLUGIN CHECKER IN WRYE BASH.",
+                               "Wrye Bash Link: https://www.nexusmods.com/fallout4/mods/20032?tab=files",
+                               "-----"
+                               ])
+            statL_scanned += 1
+        elif not "[00]" in logtext:
+            output.writelines(["# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #\n",
+                               "Autoscan cannot continue. Try scanning a different crash log.\n",
+                               "-----"
+                               ])
+            statL_incomplete += 1
 
-    inherentlimitations= ["[Due to inherent limitations, Auto-Scan will continue detecting certain mods,",
-                           " even if fixes or patches for them are already installed. You can ignore these.]",
-                           "-----"
-                           ]
-    nopluginlist= ["# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #",
-                    "Autoscan cannot continue. Try scanning a different crash log.",
-                    "-----"
-                    ]
-    if "[00]" in logtext and Mod_Trap2 == 0:
-        output.writelines(inherentlimitations)
-    elif "[00]" in logtext and Mod_Trap2 == 1:
-        output.writelines(["# AUTOSCAN FOUND NO PROBLEMATIC MODS WITH SOLUTIONS AND COMMUNITY PATCHES #",
-                           "-----"
+        output.writelines(["====================================================",
+                           "CHECKING FOR MODS WITH SOLUTIONS & COMMUNITY PATCHES",
+                           "===================================================="
                            ])
-    elif logtext.count("[00]") == 0:
-        output.writelines(nopluginlist)
+        Mod_Trap2 = no_repeat1 = no_repeat2 = 1  # MOD TRAP 2 | NEED 8 SPACES FOR ESL [FE:XXX]
 
-    output.writelines(["FOR FULL LIST OF IMPORTANT PATCHES AND FIXES FOR THE BASE GAME AND MODS,",
-                       "VISIT THIS ARTICLE: https://www.nexusmods.com/fallout4/articles/3769",
-                       "-----"
-                       ])
+        # Needs 1 empty space as prefix to prevent duplicates.
+        List_Mods2 = [" DLCUltraHighResolution.esm",
+                      " AAF.esm",
+                      " ArmorKeywords.esm",
+                      " BTInteriors_Project.esp",
+                      " CombatZoneRestored.esp",
+                      " D.E.C.A.Y.esp",
+                      " EveryonesBestFriend",
+                      " M8r_Item_Tags",
+                      " Fo4FI_FPS_fix",
+                      " BostonFPSFixAIO.esp",
+                      " FunctionalDisplays.esp",
+                      " skeletonmaleplayer",
+                      " skeletonfemaleplayer",
+                      " CapsWidget",
+                      " Homemaker.esm",
+                      " Horizon.esm",
+                      " ESPExplorerFO4.esp",
+                      " LegendaryModification.esp",
+                      " LooksMenu Customization Compendium.esp",
+                      " MilitarizedMinutemen.esp",
+                      " MoreUniques",
+                      " NAC.es",
+                      " Northland Diggers New.esp",
+                      " ProjectZeta.esm",
+                      " RaiderOverhaul.esp",
+                      " Rusty Face Fix",
+                      " SKKCraftableWeaponsAmmo",
+                      " SOTS.esp",
+                      " StartMeUp.esp",
+                      " SuperMutantRedux.esp",
+                      " TacticalReload.esm",
+                      " Creatures and Monsters.esp",
+                      " ZombieWalkers"]
 
-    output.writelines(["====================================================",
-                       "CHECKING FOR MODS PATCHED THROUGH OPC INSTALLER...",
-                       "===================================================="
-                       ])
-    Mod_Trap3 = 1  # MOD TRAP 3 | NEED 8 SPACES FOR ESL [FE:XXX]
+        List_Warn2 = ["HIGH RESOLUTION DLC. I STRONGLY ADVISE NOT USING IT! \n"
+                      "Right click on Fallout 4 in your Steam Library folder, then select Properties \n"
+                      "Switch to the DLC tab and uncheck / disable the High Resolution Texture Pack",
+                      #
+                      "ADVANCED ANIMATION FRAMEWORK \n"
+                      "Newest AAF version only available on Moddingham | AAF Tech Support: https://discord.gg/gWZuhMC \n"
+                      "Newest AAF Link (register / login to download): https://www.moddingham.com/viewtopic.php?t=2 \n"
+                      "-----\n"
+                      "Looks Menu versions 1.6.20 & 1.6.19 can frequently break adult mod related (erection) morphs \n"
+                      "If you notice AAF realted problems, remove latest version of Looks Menu and switch to 1.6.18",
+                      #
+                      "ARMOR AND WEAPON KEYWORDS \n"
+                      "If you don't rely on AWKCR, consider switching to Equipment and Crafting Overhaul \n"
+                      "Better Alternative: https://www.nexusmods.com/fallout4/mods/55503?tab=files",
+                      #
+                      "BEANTOWN INTERIORS PROJECT \n"
+                      "Usually causes fps drops, stuttering, crashing and culling issues in multiple locations. \n"
+                      "Patch Link: https://www.nexusmods.com/fallout4/mods/53894?tab=files",
+                      #
+                      "COMBAT ZONE RESTORED \n"
+                      "Contains few small issues and NPCs usually have trouble navigating the interior space. \n"
+                      "Patch Link: https://www.nexusmods.com/fallout4/mods/59329?tab=files",
+                      #
+                      "DECAY BETTER GHOULS \n"
+                      "You have to install DECAY Redux patch to prevent its audio files from crashing the game. \n"
+                      "Patch Link: https://www.nexusmods.com/fallout4/mods/59025?tab=files",
+                      #
+                      "EVERYONE'S BEST FRIEND \n"
+                      "This mod needs a compatibility patch to properly work with the Unofficial Patch (UFO4P). \n"
+                      "Patch Link: https://www.nexusmods.com/fallout4/mods/43409?tab=files",
+                      #
+                      "FALLUI ITEM SORTER (OLD) \n"
+                      "This is an outdated item tagging / sorting patch that can cause crashes or conflicts in all kinds of situations. \n"
+                      "I strongly recommend to instead generate your own sorting patch and place it last in your load order. \n"
+                      "That way, you won't experience any conflicts / crashes and even modded items will be sorted. \n"
+                      "Generate Sorting Patch With This: https://www.nexusmods.com/fallout4/mods/48826?tab=files",
+                      #
+                      "FO4FI FPS FIX \n"
+                      "This mod is severely outdated and will cause crashes even with compatibility patches. \n"
+                      "Better Alternative: https://www.nexusmods.com/fallout4/mods/46403?tab=files",
+                      #
+                      "BOSTON FPS FIX \n"
+                      "This mod is severely outdated and will cause crashes even with compatibility patches. \n"
+                      "Better Alternative: https://www.nexusmods.com/fallout4/mods/46403?tab=files",
+                      #
+                      "FUNCTIONAL DISPLAYS \n"
+                      "Frequently causes object model (nif) related crashes and this needs to be manually corrected. \n"
+                      "Advised Fix: Open its Meshes folder and delete everything inside EXCEPT for the Functional Displays folder.",
+                      #
+                      "GENDER SPECIFIC SKELETONS (MALE) \n"
+                      "High chance to cause a crash when starting a new game or during the game intro sequence. \n"
+                      "Advised Fix: Enable the mod only after leaving Vault 111. Existing saves shouldn't be affected.",
+                      #
+                      "GENDER SPECIFIC SKELETONS (FEMALE) \n"
+                      "High chance to cause a crash when starting a new game or during the game intro sequence. \n"
+                      "Advised Fix: Enable the mod only after leaving Vault 111. Existing saves shouldn't be affected.",
+                      #
+                      "HUD CAPS \n"
+                      "Often breaks the Save / Quicksave function due to poor script implementation. \n"
+                      "Advised Fix: Download fixed pex file and place it into HUDCaps/Scripts folder. \n"
+                      "Fix Link: https://drive.google.com/file/d/1egmtKVR7mSbjRgo106UbXv_ySKBg5az2",
+                      #
+                      "HOMEMAKER \n"
+                      "Causes a crash while scrolling over Military / BoS fences in the Settlement Menu. \n"
+                      "Patch Link: https://www.nexusmods.com/fallout4/mods/41434?tab=files",
+                      #
+                      "HORIZON \n"
+                      "Use the mod specific unofficial patch for 1.8.7 until a newer version gets released. \n"
+                      "Patch Link: https://www.nexusmods.com/fallout4/mods/61998?tab=files",
+                      #
+                      "IN GAME ESP EXPLORER \n"
+                      "Can cause a crash when pressing F10 due to a typo in the INI settings. \n"
+                      "Fix Link: https://www.nexusmods.com/fallout4/mods/64752?tab=files \n"
+                      "OR Switch To: https://www.nexusmods.com/fallout4/mods/56922?tab=files",
+                      #
+                      "LEGENDARY MODIFICATION \n"
+                      "Old mod plagued with all kinds of bugs and crashes, can conflict with some modded weapons. \n"
+                      "Better Alternative: https://www.nexusmods.com/fallout4/mods/55503?tab=files",
+                      #
+                      "LOOKS MENU CUSTOMIZATION COMPENDIUM \n"
+                      "Apparently breaks the original Looks Menu mod by turning off some important values. \n"
+                      "Fix Link: https://www.nexusmods.com/fallout4/mods/56465?tab=files",
+                      #
+                      "MILITARIZED MINUTEMEN \n"
+                      "Can occasionally crash the game due to a broken mesh on some minutemen outfits. \n"
+                      "Patch Link: https://www.nexusmods.com/fallout4/mods/55301?tab=files",
+                      #
+                      "MORE UNIQUE WEAPONS EXPANSION \n"
+                      "Causes crashes due to broken precombines and compatibility issues with other weapon mods. \n"
+                      "Patch Link: https://www.nexusmods.com/fallout4/mods/54848?tab=files",
+                      #
+                      "NATURAL AND ATMOSPHERIC COMMONWEALTH \n"
+                      "If you notice weird looking skin tones with either NAC or NACX, install this patch. \n"
+                      "Patch Link: https://www.nexusmods.com/fallout4/mods/57052?tab=files",
+                      #
+                      "NORTHLAND DIGGERS RESOURCES \n"
+                      "Contains various bugs and issues that can cause crashes or negatively affect other mods. \n"
+                      "Fix Link: https://www.nexusmods.com/fallout4/mods/53395?tab=files",
+                      #
+                      "PROJECT ZETA \n"
+                      "Invasion quests seem overly buggy or trigger too frequently, minor sound issues. \n"
+                      "Fix Link: https://www.nexusmods.com/fallout4/mods/65166?tab=files",
+                      #
+                      "RAIDER OVERHAUL \n"
+                      "Old mod that requires several patches to function as intended. Use ONE Version instead. \n"
+                      "Upated ONE Version: https://www.nexusmods.com/fallout4/mods/51658?tab=files",
+                      #
+                      "RUSTY FACE FIX \n"
+                      "Can cause script lag or even crash the game in very rare cases. Switch to REDUX Version instead. \n"
+                      "Updated REDUX Version: https://www.nexusmods.com/fallout4/mods/64270?tab=files",
+                      #
+                      "SKK CRAFT WEAPONS AND SCRAP AMMO \n"
+                      "Version 008 is incompatible with AWKCR and will cause crashes while saving the game. \n"
+                      "Advised Fix: Use Version 007 or remove AWKCR and switch to Equipment and Crafting Overhaul.",
+                      #
+                      "SOUTH OF THE SEA \n"
+                      "Very unstable mod that consistently and frequently causes strange problems and crashes. \n"
+                      "Patch Link: https://www.nexusmods.com/fallout4/mods/59792?tab=files",
+                      #
+                      "START ME UP \n"
+                      "Abandoned mod that can cause infinite loading and other problems. Switch to REDUX Version instead. \n"
+                      "Updated REDUX Version: https://www.nexusmods.com/fallout4/mods/56984?tab=files",
+                      #
+                      "SUPER MUTANT REDUX \n"
+                      "Causes crashes at specific locations or with certain Super Muntant enemies and items. \n"
+                      "Patch Link: https://www.nexusmods.com/fallout4/mods/51353?tab=files",
+                      #
+                      "TACTICAL RELOAD \n"
+                      "Can cause weapon and combat related crashes. TR Expansion For ECO is highly recommended. \n"
+                      "TR Expansion For ECO Link: https://www.nexusmods.com/fallout4/mods/62737",
+                      #
+                      "UNIQUE NPCs CREATURES AND MONSTERS \n"
+                      "Causes crashes and breaks precombines at specific locations, some creature spawns are too frequent. \n"
+                      "Patch Link: https://www.nexusmods.com/fallout4/mods/48637?tab=files",
+                      #
+                      "ZOMBIE WALKERS \n"
+                      "Version 2.6.3 contains a resurrection script that will regularly crash the game. \n"
+                      "Advised Fix: Make sure you're using the 3.0 Beta version of this mod or newer."]
 
-    # Needs 1 empty space as prefix to prevent duplicates.
-    List_Mods3 = [" Beyond the Borders",
-                  " Deadly Commonwealth Expansion",
-                  " Dogmeat and Strong Armor",
-                  " DoYourDamnJobCodsworth",
-                  " ConcordEXPANDED",
-                  " HagenEXPANDED",
-                  " GlowingSeaEXPANDED",
-                  " SalemEXPANDED",
-                  " SwampsEXPANDED",
-                  " _hod",
-                  " ImmersiveBeantown",
-                  " CovenantComplex",
-                  " GunnersPlazaInterior",
-                  " ImmersiveHubCity",
-                  " Immersive_Lexington",
-                  " Immersive Nahant",
-                  " Immersive S Boston",
-                  " MutilatedDeadBodies",
-                  " Vault4.esp",
-                  " atlanticofficesf23",
-                  " Minutemen Supply Caches",
-                  " moreXplore",
-                  " NEST_BUNKER_PROJECT",
-                  " Raider Children.esp",
-                  " sectorv",
-                  " SettlementShelters",
-                  " subwayrunnnerdynamiclighting",
-                  " 3DNPC_FO4Settler.esp",
-                  " 3DNPC_FO4.esp",
-                  " The Hollow",
-                  " nvvault1080",
-                  " Vertibird Faction Paint Schemes",
-                  " MojaveImports.esp",
-                  " Firelance2.5",
-                  " zxcMicroAdditions"]
+        if "[00]" in logtext:
+            for line in plugin_list:
+                for elem in List_Mods2:
+                    if "File:" not in line and "[FE" not in line and elem in line:
+                        order_elem = List_Mods2.index(elem)
+                        output.writelines([f"[!] Found:{line[0:5].strip()} {List_Warn2[order_elem]}",
+                                           "-----"
+                                           ])
+                        Mod_Trap2 = 0
+                    elif "File:" not in line and "[FE" in line and elem in line:
+                        order_elem = List_Mods2.index(elem)
+                        output.writelines([f"[!] Found:{line[0:9].strip()} {List_Warn2[order_elem]}",
+                                           "-----"
+                                           ])
+                        Mod_Trap2 = 0
+                if no_repeat1 == 1 and "File:" not in line and ("Depravity" or "FusionCityRising" or "HotC" or "OutcastsAndRemnants" or "ProjectValkyrie") in line:
+                    output.writelines([f"[!] Found:{line[0:9].strip()} THUGGYSMURF QUEST MOD",
+                                       "If you have Depravity, Fusion City Rising, HOTC, Outcasts and Remnants and/or Project Valkyrie",
+                                       "install this patch with facegen data, fully generated precomb/previs data and several tweaks.",
+                                       "Patch Link: https://www.nexusmods.com/fallout4/mods/56876?tab=files",
+                                       "-----"
+                                       ])
+                    no_repeat1 = Mod_Trap2 = 0
+                if no_repeat1 == 1 and "File:" not in line and ("CaN.esm" or "AnimeRace_Nanako.esp") in line:
+                    output.writelines([f"[!] Found:{line[0:9].strip()} CUSTOM RACE SKELETON MOD",
+                                       "If you have AnimeRace NanakoChan or Crimes Against Nature, install the Race Skeleton Fixes.",
+                                       "Skeleton Fixes Link (READ THE DESCRIPTION): https://www.nexusmods.com/fallout4/mods/56101"
+                                       ])
+                    no_repeat2 = Mod_Trap2 = 0
 
-    List_Warn3 = ["Beyond the Borders",
-                  "Deadly Commonwealth Expansion",
-                  "Dogmeat and Strong Armor",
-                  "Do Your Damn Job Codsworth",
-                  "Concord Expanded",
-                  "Fort Hagen Expanded",
-                  "Glowing Sea Expanded",
-                  "Salem Expanded",
-                  "Swamps Expanded",
-                  "Hearts Of Darkness",
-                  "Immersive Beantown Brewery",
-                  "Immersive Covenant Compound",
-                  "Immersive Gunners Plaza",
-                  "Immersive Hub City",
-                  "Immersive & Extended Lexington",
-                  "Immersive & Extended Nahant",
-                  "Immersive Military Checkpoint",
-                  "Mutilated Dead Bodies",
-                  "Fourville (Vault 4)",
-                  "Lost Building of Atlantic",
-                  "Minutemen Supply Caches",
-                  "MoreXplore",
-                  "NEST Survival Bunkers",
-                  "Raider Children & Other Horrors",
-                  "Sector Five - Rise and Fall",
-                  "Settlement Shelters",
-                  "Subway Runner (Dynamic Lights)",
-                  "Settlers of the Commonwealth",
-                  "Tales from the Commonwealth",
-                  "The Hollow",
-                  "Vault 1080 (Vault 80)",
-                  "Vertibird Faction Paint Schemes",
-                  "Wasteland Imports (Mojave Imports)",
-                  "Xander's Aid",
-                  "ZXC Micro Additions"]
+            if "FallSouls.dll" in logtext:
+                output.writelines(["[!] Found: FALLSOULS UNPAUSED GAME MENUS",
+                                   "Occasionally breaks the Quests menu, can cause crashes while changing MCM settings.",
+                                   "Advised Fix: Toggle PipboyMenu in FallSouls MCM settings or completely reinstall the mod.",
+                                   "-----"
+                                   ])
+                Mod_Trap2 = 0
 
-    if "[00]" in logtext:
-        for line in plugin_list:
-            for elem in List_Mods3:
-                if "File:" not in line and "[FE" not in line and elem in line:
-                    order_elem = List_Mods3.index(elem)
-                    output.write(f"- Found:{line[0:5].strip()} {List_Warn3[order_elem]}")
-                    Mod_Trap3 = 0
-                elif "File:" not in line and "[FE" in line and elem in line:
-                    order_elem = List_Mods3.index(elem)
-                    output.write(f"- Found:{line[0:9].strip()} {List_Warn3[order_elem]}")
-                    Mod_Trap3 = 0
-    if "[00]" in logtext and Mod_Trap3 == 0:
-        output.writelines(["-----",
-                           "FOR PATCH REPOSITORY THAT PREVENTS CRASHES AND FIXES PROBLEMS IN THESE AND OTHER MODS,",
-                           "VISIT OPTIMIZATION PATCHES COLLECTION: https://www.nexusmods.com/fallout4/mods/54872",
-                           "-----"
-                           ])
-    elif "[00]" in logtext and Mod_Trap3 == 1:
-        output.writelines(["# AUTOSCAN FOUND NO PROBLEMATIC MODS THAT ARE ALREADY PATCHED THROUGH OPC INSTALLER #",
-                           "-----"
-                           ])
-    elif logtext.count("[00]") == 0:
-        output.writelines(nopluginlist)
+        # inherentlimitations= "[Due to inherent limitations, Auto-Scan will continue detecting certain mods\neven if fixes or patches for them are already installed. You can ignore these.]\n-----"
 
-    # ===========================================================
-    
-    output.writelines(["====================================================",
-                       "CHECKING IF IMPORTANT PATCHES & FIXES ARE INSTALLED"
-                       "===================================================="
-                       ])
+        nopluginlist = "# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #\nAutoscan cannot continue. Try scanning a different crash log.\n-----"
+        if "[00]" in logtext and Mod_Trap2 == 0:
+            output.write("[Due to inherent limitations, Auto-Scan will continue detecting certain mods")
+            output.write("even if fixes or patches for them are already installed. You can ignore these.]")
+            output.write("-----")
 
-    gpu_amd = False
-    gpu_nvidia = False
-    for line in loglines:
-        if "GPU" in line and "Nvidia" in line:
-            gpu_nvidia = True
-        if "GPU" in line and "AMD" in line:
-            gpu_amd = True
-
-    output.writelines(["IF YOU'RE USING DYNAMIC PERFORMANCE TUNER AND/OR LOAD ACCELERATOR,",
-                       "remove these mods completely and switch to High FPS Physics Fix!",
-                       "Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files",
-                       "-----"
-                       ])
-
-    if CLAS_config.getboolean("MAIN", "FCX Mode") == True:
-        output.writelines(["* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *",
-                           "[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]",
-                           "-----"
-                           ])
-
-        if info.VR_EXE.is_file() and info.VR_Buffout.is_file():
-            output.write("*Buffout 4 VR Version* is (manually) installed. \n-----")
-        elif info.VR_EXE.is_file() and not info.VR_Buffout.is_file():
-            output.writelines(["# BUFFOUT 4 FOR VR VERSION ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
-                               "# This is a mandatory Buffout 4 port for the VR Version of Fallout 4.",
-                               "Link: https://www.nexusmods.com/fallout4/mods/64880?tab=files"
-                               ])
-
-        if info.F4CK_EXE.is_file() and os.path.exists(info.F4CK_Fixes):
-            output.write("*Creation Kit Fixes* is (manually) installed. \n-----")
-        elif info.F4CK_EXE.is_file() and not os.path.exists(info.F4CK_Fixes):
-            output.writelines(["# CREATION KIT FIXES ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
-                               "This is a highly recommended patch for the Fallout 4 Creation Kit.",
-                               "Link: https://www.nexusmods.com/fallout4/mods/51165?tab=files",
+        elif "[00]" in logtext and Mod_Trap2 == 1:
+            output.writelines(["# AUTOSCAN FOUND NO PROBLEMATIC MODS WITH SOLUTIONS AND COMMUNITY PATCHES #",
                                "-----"
                                ])
+        elif logtext.count("[00]") == 0:
+            output.write(nopluginlist)
 
-    if "[00]" in logtext:
-        if any("CanarySaveFileMonitor" in elem for elem in plugin_list):
-            output.write("*Canary Save File Monitor* is installed. \n-----")
-        else:
-            output.writelines(["# CANARY SAVE FILE MONITOR ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
-                               "This is a highly recommended mod that can detect save file corrpution.",
-                               "Link: https://www.nexusmods.com/fallout4/mods/44949?tab=files",
-                               "-----"
-                               ])
-
-        if "HighFPSPhysicsFix.dll" in logtext:
-            output.write("*High FPS Physics Fix* is installed. \n-----")
-        else:
-            output.writelines(["# HIGH FPS PHYSICS FIX ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
-                               "This is a mandatory patch / fix that prevents game engine problems.",
-                               "Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files",
-                               "-----"
-                               ])
-
-        if any("PPF.esm" in elem for elem in plugin_list):
-            output.write("*Previs Repair Pack* is installed. \n-----")
-        else:
-            output.writelines(["# PREVIS REPAIR PACK ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
-                               "This is a highly recommended mod that can improve performance.",
-                               "Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files",
-                               "-----"
-                               ])
-
-        if any("Unofficial Fallout 4 Patch.esp" in elem for elem in plugin_list):
-            output.write("*Unofficial Fallout 4 Patch* is installed. \n-----")
-        else:
-            output.writelines(["# UNOFFICIAL FALLOUT 4 PATCH ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
-                               "If you own all DLCs, make sure that the Unofficial Patch is installed.",
-                               "Link: https://www.nexusmods.com/fallout4/mods/4598?tab=files",
-                               "-----"
-                               ])
-
-        if "vulkan-1.dll" in logtext and gpu_amd:
-            output.write("Vulkan Renderer is installed. \n-----")
-        elif logtext.count("vulkan-1.dll") == 0 and gpu_amd and not gpu_nvidia:
-            output.writelines(["# VULKAN RENDERER ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
-                               "This is a highly recommended mod that can improve performance on AMD GPUs.",
-                               "-----",
-                               "Installation steps can be found in 'How To Read Crash Logs' PDF / Document.",
-                               "Link: https://www.nexusmods.com/fallout4/mods/48053?tab=files",
-                               "-----"
-                               ])
-
-        if "WeaponDebrisCrashFix.dll" in logtext and gpu_nvidia:
-            output.write("*Weapon Debris Crash Fix* is installed. \n-----")
-        elif "WeaponDebrisCrashFix.dll" in logtext and not gpu_nvidia and gpu_amd:
-            output.writelines(["*Weapon Debris Crash Fix* is installed, but...",
-                               "# YOU DON'T HAVE AN NVIDIA GPU OR BUFFOUT 4 CANNOT DETECT YOUR GPU MODEL #",
-                               "Weapon Debris Crash Fix is only required for Nvidia GPUs (NOT AMD / OTHER)",
-                               "-----"
-                               ])
-        if not "WeaponDebrisCrashFix.dll" in logtext and gpu_nvidia:
-            output.writelines(["# WEAPON DEBRIS CRASH FIX ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
-                               "This is a mandatory patch / fix for players with Nvidia graphics cards.",
-                               "Link: https://www.nexusmods.com/fallout4/mods/48078?tab=files",
-                               "-----"
-                               ])
-
-        if "NVIDIA_Reflex.dll" in logtext and gpu_nvidia:
-            output.write("*Nvidia Reflex Support* is installed. \n-----")
-        elif "NVIDIA_Reflex.dll" in logtext and not gpu_nvidia and gpu_amd:
-            output.writelines(["*Nvidia Reflex Support* is installed, but...",
-                               "# YOU DON'T HAVE AN NVIDIA GPU OR BUFFOUT 4 CANNOT DETECT YOUR GPU MODEL #",
-                               "Nvidia Reflex Support is only required for Nvidia GPUs (NOT AMD / OTHER)",
-                               "-----"
-                               ])
-        if not "NVIDIA_Reflex.dll" in logtext and gpu_nvidia:
-            output.writelines(["# NVIDIA REFLEX SUPPORT ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
-                               "This is a highly recommended mod that can reduce render latency.",
-                               "Link: https://www.nexusmods.com/fallout4/mods/64459?tab=files",
-                               "-----"
-                               ])
-    else:
-        output.writelines(nopluginlist)
-    output.writelines(["====================================================",
-                       "SCANNING THE LOG FOR SPECIFIC (POSSIBLE) CUPLRITS...",
-                       "===================================================="
-                       ])
-
-    list_DETPLUGINS = []
-    list_DETFORMIDS = []
-    list_DETFILES = []
-    list_ALLPLUGINS = []
-
-    if not "f4se_1_10_163.dll" in logtext and "steam_api64.dll" in logtext:
-        output.writelines(["AUTOSCAN CANNOT FIND FALLOUT 4 SCRIPT EXTENDER DLL!",
-                           "MAKE SURE THAT F4SE IS CORRECTLY INSTALLED!",
-                           "Link: https://f4se.silverlock.org",
+        output.writelines(["FOR FULL LIST OF IMPORTANT PATCHES AND FIXES FOR THE BASE GAME AND MODS,",
+                           "VISIT THIS ARTICLE: https://www.nexusmods.com/fallout4/articles/3769",
                            "-----"
                            ])
 
-    for line in loglines:
-        if len(line) >= 6 and "]" in line[4]:
-            list_ALLPLUGINS.append(line.strip())
-        if len(line) >= 7 and "]" in line[5]:
-            list_ALLPLUGINS.append(line.strip())
-        if len(line) >= 10 and "]" in line[8]:
-            list_ALLPLUGINS.append(line.strip())
-        if len(line) >= 11 and "]" in line[9]:
-            list_ALLPLUGINS.append(line.strip())
+        output.writelines(["====================================================",
+                           "CHECKING FOR MODS PATCHED THROUGH OPC INSTALLER...",
+                           "===================================================="
+                           ])
+        Mod_Trap3 = 1  # MOD TRAP 3 | NEED 8 SPACES FOR ESL [FE:XXX]
 
-    output.write("LIST OF (POSSIBLE) PLUGIN CULRIPTS:")
-    for line in loglines:
-        if "File:" in line:
-            line = line.replace("File: ", "")
-            line = line.replace('"', '')
-            list_DETPLUGINS.append(line.strip())
+        # Needs 1 empty space as prefix to prevent duplicates.
+        List_Mods3 = [" Beyond the Borders",
+                      " Deadly Commonwealth Expansion",
+                      " Dogmeat and Strong Armor",
+                      " DoYourDamnJobCodsworth",
+                      " ConcordEXPANDED",
+                      " HagenEXPANDED",
+                      " GlowingSeaEXPANDED",
+                      " SalemEXPANDED",
+                      " SwampsEXPANDED",
+                      " _hod",
+                      " ImmersiveBeantown",
+                      " CovenantComplex",
+                      " GunnersPlazaInterior",
+                      " ImmersiveHubCity",
+                      " Immersive_Lexington",
+                      " Immersive Nahant",
+                      " Immersive S Boston",
+                      " MutilatedDeadBodies",
+                      " Vault4.esp",
+                      " atlanticofficesf23",
+                      " Minutemen Supply Caches",
+                      " moreXplore",
+                      " NEST_BUNKER_PROJECT",
+                      " Raider Children.esp",
+                      " sectorv",
+                      " SettlementShelters",
+                      " subwayrunnnerdynamiclighting",
+                      " 3DNPC_FO4Settler.esp",
+                      " 3DNPC_FO4.esp",
+                      " The Hollow",
+                      " nvvault1080",
+                      " Vertibird Faction Paint Schemes",
+                      " MojaveImports.esp",
+                      " Firelance2.5",
+                      " zxcMicroAdditions"]
 
-    list_DETPLUGINS = list(dict.fromkeys(list_DETPLUGINS))
-    list_remove = ["Fallout4.esm", "DLCCoast.esm", "DLCNukaWorld.esm", "DLCRobot.esm", "DLCworkshop01.esm", "DLCworkshop02.esm", "DLCworkshop03.esm", ""]
-    for elem in list_remove:
-        if elem in list_DETPLUGINS:
-            list_DETPLUGINS.remove(elem)
+        List_Warn3 = ["Beyond the Borders",
+                      "Deadly Commonwealth Expansion",
+                      "Dogmeat and Strong Armor",
+                      "Do Your Damn Job Codsworth",
+                      "Concord Expanded",
+                      "Fort Hagen Expanded",
+                      "Glowing Sea Expanded",
+                      "Salem Expanded",
+                      "Swamps Expanded",
+                      "Hearts Of Darkness",
+                      "Immersive Beantown Brewery",
+                      "Immersive Covenant Compound",
+                      "Immersive Gunners Plaza",
+                      "Immersive Hub City",
+                      "Immersive & Extended Lexington",
+                      "Immersive & Extended Nahant",
+                      "Immersive Military Checkpoint",
+                      "Mutilated Dead Bodies",
+                      "Fourville (Vault 4)",
+                      "Lost Building of Atlantic",
+                      "Minutemen Supply Caches",
+                      "MoreXplore",
+                      "NEST Survival Bunkers",
+                      "Raider Children & Other Horrors",
+                      "Sector Five - Rise and Fall",
+                      "Settlement Shelters",
+                      "Subway Runner (Dynamic Lights)",
+                      "Settlers of the Commonwealth",
+                      "Tales from the Commonwealth",
+                      "The Hollow",
+                      "Vault 1080 (Vault 80)",
+                      "Vertibird Faction Paint Schemes",
+                      "Wasteland Imports (Mojave Imports)",
+                      "Xander's Aid",
+                      "ZXC Micro Additions"]
 
-    PL_strings = list_ALLPLUGINS
-    PL_substrings = list_DETPLUGINS
-    PL_result = []
+        if "[00]" in logtext:
+            for line in plugin_list:
+                for elem in List_Mods3:
+                    if "File:" not in line and "[FE" not in line and elem in line:
+                        order_elem = List_Mods3.index(elem)
+                        output.write(f"- Found:{line[0:5].strip()} {List_Warn3[order_elem]}")
+                        Mod_Trap3 = 0
+                    elif "File:" not in line and "[FE" in line and elem in line:
+                        order_elem = List_Mods3.index(elem)
+                        output.write(f"- Found:{line[0:9].strip()} {List_Warn3[order_elem]}")
+                        Mod_Trap3 = 0
+        if "[00]" in logtext and Mod_Trap3 == 0:
+            output.writelines(["-----",
+                               "FOR PATCH REPOSITORY THAT PREVENTS CRASHES AND FIXES PROBLEMS IN THESE AND OTHER MODS,",
+                               "VISIT OPTIMIZATION PATCHES COLLECTION: https://www.nexusmods.com/fallout4/mods/54872",
+                               "-----"
+                               ])
+        elif "[00]" in logtext and Mod_Trap3 == 1:
+            output.writelines(["# AUTOSCAN FOUND NO PROBLEMATIC MODS THAT ARE ALREADY PATCHED THROUGH OPC INSTALLER #",
+                               "-----"
+                               ])
+        elif logtext.count("[00]") == 0:
+            output.writelines(nopluginlist)
 
-    for string in PL_strings:
-        PL_matches = []
-        for substring in PL_substrings:
-            if substring in string:
-                PL_matches.append(string)
-        if PL_matches:
-            PL_result.append(PL_matches)
-            output.write(f"- {' '.join(PL_matches)}") # not 100% sure on this, will have to see how it works.
+        # ===========================================================
 
-    if not PL_result:
-        output.writelines(["* AUTOSCAN COULDN'T FIND ANY PLUGIN CULRIPTS *",
+        output.writelines(["====================================================",
+                           "CHECKING IF IMPORTANT PATCHES & FIXES ARE INSTALLED"
+                           "===================================================="
+                           ])
+
+        gpu_amd = False
+        gpu_nvidia = False
+        for line in loglines:
+            if "GPU" in line and "Nvidia" in line:
+                gpu_nvidia = True
+            if "GPU" in line and "AMD" in line:
+                gpu_amd = True
+
+        output.writelines(["IF YOU'RE USING DYNAMIC PERFORMANCE TUNER AND/OR LOAD ACCELERATOR,",
+                           "remove these mods completely and switch to High FPS Physics Fix!",
+                           "Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files",
                            "-----"
                            ])
-    else:
-        output.writelines(["-----",
-                           "These Plugins were caught by Buffout 4 and some of them might be responsible for this crash.",
-                           "You can try disabling these plugins and recheck your game, though this method can be unreliable.",
-                           "-----"
-                           ])
 
-    # ===========================================================
+        if CLAS_config.getboolean("MAIN", "FCX Mode") == True:
+            output.writelines(["* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *",
+                               "[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]",
+                               "-----"
+                               ])
 
-    output.write("LIST OF (POSSIBLE) FORM ID CULRIPTS:")
-    for line in loglines:
-        if "Form ID:" in line and not "0xFF" in line:
-            line = line.replace("0x", "")
-            if "[00]" in logtext:
-                line = line.replace("Form ID: ", "")
-                line = line.strip()
-                ID_Only = line
-                for elem in plugin_list:
-                    if "]" in elem and "[FE" not in elem:
-                        if elem[2:4].strip() == ID_Only[:2]:
-                            Full_Line = "Form ID: " + ID_Only + " | " + elem.strip()
-                            list_DETFORMIDS.append(Full_Line.replace("    ", ""))
-                    if "[FE" in elem:
-                        elem = elem.replace(":", "")
-                        if elem[2:7] == ID_Only[:5]:
-                            Full_Line = "Form ID: " + ID_Only + " | " + elem.strip()
-                            list_DETFORMIDS.append(Full_Line.replace("    ", ""))
+            if info.VR_EXE.is_file() and info.VR_Buffout.is_file():
+                output.write("*Buffout 4 VR Version* is (manually) installed. \n-----")
+            elif info.VR_EXE.is_file() and not info.VR_Buffout.is_file():
+                output.writelines(["# BUFFOUT 4 FOR VR VERSION ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
+                                   "# This is a mandatory Buffout 4 port for the VR Version of Fallout 4.",
+                                   "Link: https://www.nexusmods.com/fallout4/mods/64880?tab=files"
+                                   ])
+
+            if info.F4CK_EXE.is_file() and os.path.exists(info.F4CK_Fixes):
+                output.write("*Creation Kit Fixes* is (manually) installed. \n-----")
+            elif info.F4CK_EXE.is_file() and not os.path.exists(info.F4CK_Fixes):
+                output.writelines(["# CREATION KIT FIXES ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
+                                   "This is a highly recommended patch for the Fallout 4 Creation Kit.",
+                                   "Link: https://www.nexusmods.com/fallout4/mods/51165?tab=files",
+                                   "-----"
+                                   ])
+
+        if "[00]" in logtext:
+            if any("CanarySaveFileMonitor" in elem for elem in plugin_list):
+                output.write("*Canary Save File Monitor* is installed. \n-----")
             else:
-                list_DETFORMIDS.append(line.strip())
+                output.writelines(["# CANARY SAVE FILE MONITOR ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
+                                   "This is a highly recommended mod that can detect save file corrpution.",
+                                   "Link: https://www.nexusmods.com/fallout4/mods/44949?tab=files",
+                                   "-----"
+                                   ])
 
-    list_DETFORMIDS = list(dict.fromkeys(list_DETFORMIDS))
-    for elem in list_DETFORMIDS:
-        output.write(elem)
+            if "HighFPSPhysicsFix.dll" in logtext:
+                output.write("*High FPS Physics Fix* is installed. \n-----")
+            else:
+                output.writelines(["# HIGH FPS PHYSICS FIX ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
+                                   "This is a mandatory patch / fix that prevents game engine problems.",
+                                   "Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files",
+                                   "-----"
+                                   ])
 
-    if not list_DETFORMIDS:
-        output.writelines(["* AUTOSCAN COULDN'T FIND ANY FORM ID CULRIPTS *",
-                           "-----"
+            if any("PPF.esm" in elem for elem in plugin_list):
+                output.write("*Previs Repair Pack* is installed. \n-----")
+            else:
+                output.writelines(["# PREVIS REPAIR PACK ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
+                                   "This is a highly recommended mod that can improve performance.",
+                                   "Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files",
+                                   "-----"
+                                   ])
+
+            if any("Unofficial Fallout 4 Patch.esp" in elem for elem in plugin_list):
+                output.write("*Unofficial Fallout 4 Patch* is installed. \n-----")
+            else:
+                output.writelines(["# UNOFFICIAL FALLOUT 4 PATCH ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
+                                   "If you own all DLCs, make sure that the Unofficial Patch is installed.",
+                                   "Link: https://www.nexusmods.com/fallout4/mods/4598?tab=files",
+                                   "-----"
+                                   ])
+
+            if "vulkan-1.dll" in logtext and gpu_amd:
+                output.write("Vulkan Renderer is installed. \n-----")
+            elif logtext.count("vulkan-1.dll") == 0 and gpu_amd and not gpu_nvidia:
+                output.writelines(["# VULKAN RENDERER ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
+                                   "This is a highly recommended mod that can improve performance on AMD GPUs.",
+                                   "-----",
+                                   "Installation steps can be found in 'How To Read Crash Logs' PDF / Document.",
+                                   "Link: https://www.nexusmods.com/fallout4/mods/48053?tab=files",
+                                   "-----"
+                                   ])
+
+            if "WeaponDebrisCrashFix.dll" in logtext and gpu_nvidia:
+                output.write("*Weapon Debris Crash Fix* is installed. \n-----")
+            elif "WeaponDebrisCrashFix.dll" in logtext and not gpu_nvidia and gpu_amd:
+                output.writelines(["*Weapon Debris Crash Fix* is installed, but...",
+                                   "# YOU DON'T HAVE AN NVIDIA GPU OR BUFFOUT 4 CANNOT DETECT YOUR GPU MODEL #",
+                                   "Weapon Debris Crash Fix is only required for Nvidia GPUs (NOT AMD / OTHER)",
+                                   "-----"
+                                   ])
+            if not "WeaponDebrisCrashFix.dll" in logtext and gpu_nvidia:
+                output.writelines(["# WEAPON DEBRIS CRASH FIX ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
+                                   "This is a mandatory patch / fix for players with Nvidia graphics cards.",
+                                   "Link: https://www.nexusmods.com/fallout4/mods/48078?tab=files",
+                                   "-----"
+                                   ])
+
+            if "NVIDIA_Reflex.dll" in logtext and gpu_nvidia:
+                output.write("*Nvidia Reflex Support* is installed. \n-----")
+            elif "NVIDIA_Reflex.dll" in logtext and not gpu_nvidia and gpu_amd:
+                output.writelines(["*Nvidia Reflex Support* is installed, but...",
+                                   "# YOU DON'T HAVE AN NVIDIA GPU OR BUFFOUT 4 CANNOT DETECT YOUR GPU MODEL #",
+                                   "Nvidia Reflex Support is only required for Nvidia GPUs (NOT AMD / OTHER)",
+                                   "-----"
+                                   ])
+            if not "NVIDIA_Reflex.dll" in logtext and gpu_nvidia:
+                output.writelines(["# NVIDIA REFLEX SUPPORT ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
+                                   "This is a highly recommended mod that can reduce render latency.",
+                                   "Link: https://www.nexusmods.com/fallout4/mods/64459?tab=files",
+                                   "-----"
+                                   ])
+        else:
+            output.writelines(nopluginlist)
+        output.writelines(["====================================================",
+                           "SCANNING THE LOG FOR SPECIFIC (POSSIBLE) CUPLRITS...",
+                           "===================================================="
                            ])
-    else:
-        output.writelines(["-----",
-                           "These Form IDs were caught by Buffout 4 and some of them might be related to this crash.",
-                           "You can try searching any listed Form IDs in FO4Edit and see if they lead to relevant records.",
-                           "-----"
-                           ])
 
-    # ===========================================================
+        list_DETPLUGINS = []
+        list_DETFORMIDS = []
+        list_DETFILES = []
+        list_ALLPLUGINS = []
 
-    List_Files = [".bgsm", ".bto", ".btr", ".dds", ".fuz", ".hkb", ".hkx", ".ini", ".nif", ".pex", ".swf", ".txt", ".uvd", ".wav", ".xwm", "data\\*"]
-    List_Exclude = ['""', "...", ".esp"]
+        if not "f4se_1_10_163.dll" in logtext and "steam_api64.dll" in logtext:
+            output.writelines(["AUTOSCAN CANNOT FIND FALLOUT 4 SCRIPT EXTENDER DLL!",
+                               "MAKE SURE THAT F4SE IS CORRECTLY INSTALLED!",
+                               "Link: https://f4se.silverlock.org",
+                               "-----"
+                               ])
 
-    output.write("LIST OF DETECTED (NAMED) RECORDS:")
-    List_Records = []
-    for line in loglines:
-        if "Name" in line or any(elem in line for elem in List_Files):
-            if not any(elem in line for elem in List_Exclude):
+        for line in loglines:
+            if len(line) >= 6 and "]" in line[4]:
+                list_ALLPLUGINS.append(line.strip())
+            if len(line) >= 7 and "]" in line[5]:
+                list_ALLPLUGINS.append(line.strip())
+            if len(line) >= 10 and "]" in line[8]:
+                list_ALLPLUGINS.append(line.strip())
+            if len(line) >= 11 and "]" in line[9]:
+                list_ALLPLUGINS.append(line.strip())
+
+        output.write("LIST OF (POSSIBLE) PLUGIN CULRIPTS:")
+        for line in loglines:
+            if "File:" in line:
+                line = line.replace("File: ", "")
                 line = line.replace('"', '')
-                List_Records.append(line.strip())
+                list_DETPLUGINS.append(line.strip())
 
-    List_Records = list(dict.fromkeys(List_Records))
-    for elem in List_Records:
-        output.write(elem)
+        list_DETPLUGINS = list(dict.fromkeys(list_DETPLUGINS))
+        list_remove = ["Fallout4.esm", "DLCCoast.esm", "DLCNukaWorld.esm", "DLCRobot.esm", "DLCworkshop01.esm", "DLCworkshop02.esm", "DLCworkshop03.esm", ""]
+        for elem in list_remove:
+            if elem in list_DETPLUGINS:
+                list_DETPLUGINS.remove(elem)
 
-    if not List_Records:
-        output.writelines(["* AUTOSCAN COULDN'T FIND ANY NAMED RECORDS *",
-                           "-----"
+        PL_strings = list_ALLPLUGINS
+        PL_substrings = list_DETPLUGINS
+        PL_result = []
+
+        for string in PL_strings:
+            PL_matches = []
+            for substring in PL_substrings:
+                if substring in string:
+                    PL_matches.append(string)
+            if PL_matches:
+                PL_result.append(PL_matches)
+                output.write(f"- {' '.join(PL_matches)}")  # not 100% sure on this, will have to see how it works.
+
+        if not PL_result:
+            output.writelines(["* AUTOSCAN COULDN'T FIND ANY PLUGIN CULRIPTS *",
+                               "-----"
+                               ])
+        else:
+            output.writelines(["-----",
+                               "These Plugins were caught by Buffout 4 and some of them might be responsible for this crash.",
+                               "You can try disabling these plugins and recheck your game, though this method can be unreliable.",
+                               "-----"
+                               ])
+
+        # ===========================================================
+
+        output.write("LIST OF (POSSIBLE) FORM ID CULRIPTS:")
+        for line in loglines:
+            if "Form ID:" in line and not "0xFF" in line:
+                line = line.replace("0x", "")
+                if "[00]" in logtext:
+                    line = line.replace("Form ID: ", "")
+                    line = line.strip()
+                    ID_Only = line
+                    for elem in plugin_list:
+                        if "]" in elem and "[FE" not in elem:
+                            if elem[2:4].strip() == ID_Only[:2]:
+                                Full_Line = "Form ID: " + ID_Only + " | " + elem.strip()
+                                list_DETFORMIDS.append(Full_Line.replace("    ", ""))
+                        if "[FE" in elem:
+                            elem = elem.replace(":", "")
+                            if elem[2:7] == ID_Only[:5]:
+                                Full_Line = "Form ID: " + ID_Only + " | " + elem.strip()
+                                list_DETFORMIDS.append(Full_Line.replace("    ", ""))
+                else:
+                    list_DETFORMIDS.append(line.strip())
+
+            list_DETFORMIDS = list(dict.fromkeys(list_DETFORMIDS))
+            for elem in list_DETFORMIDS:
+                output.write(elem)
+
+            if not list_DETFORMIDS:
+                output.writelines(["* AUTOSCAN COULDN'T FIND ANY FORM ID CULRIPTS *",
+                                   "-----"
+                                   ])
+        else:
+            output.writelines(["-----",
+                               "These Form IDs were caught by Buffout 4 and some of them might be related to this crash.",
+                               "You can try searching any listed Form IDs in FO4Edit and see if they lead to relevant records.",
+                               "-----"
+                               ])
+
+        # ===========================================================
+
+        List_Files = [".bgsm", ".bto", ".btr", ".dds", ".fuz", ".hkb", ".hkx", ".ini", ".nif", ".pex", ".swf", ".txt", ".uvd", ".wav", ".xwm", "data\\*"]
+        List_Exclude = ['""', "...", ".esp"]
+
+        output.write("LIST OF DETECTED (NAMED) RECORDS:")
+        List_Records = []
+        for line in loglines:
+            if "Name" in line or any(elem in line for elem in List_Files):
+                if not any(elem in line for elem in List_Exclude):
+                    line = line.replace('"', '')
+                    List_Records.append(line.strip())
+
+        List_Records = list(dict.fromkeys(List_Records))
+        for elem in List_Records:
+            output.write(elem)
+
+        if not List_Records:
+            output.writelines(["* AUTOSCAN COULDN'T FIND ANY NAMED RECORDS *",
+                               "-----"
+                               ])
+        else:
+            output.writelines(["-----",
+                               "These records were caught by Buffout 4 and some of them might be related to this crash.",
+                               "Named records should give extra information on involved game objects and record types.",
+                               "-----"
+                               ])
+
+        output.writelines(["FOR FULL LIST OF MODS THAT CAUSE PROBLEMS, THEIR ALTERNATIVES AND DETAILED SOLUTIONS,",
+                           "VISIT THE BUFFOUT 4 CRASH ARTICLE: https://www.nexusmods.com/fallout4/articles/3115",
+                           "===============================================================================",
+                           f"END OF AUTOSCAN | Author/Made By: Poet#9800 (DISCORD) | {CLAS_Date}"
                            ])
-    else:
-        output.writelines(["-----",
-                           "These records were caught by Buffout 4 and some of them might be related to this crash.",
-                           "Named records should give extra information on involved game objects and record types.",
-                           "-----"
-                           ])
-
-    output.writelines(["FOR FULL LIST OF MODS THAT CAUSE PROBLEMS, THEIR ALTERNATIVES AND DETAILED SOLUTIONS,",
-                       "VISIT THE BUFFOUT 4 CRASH ARTICLE: https://www.nexusmods.com/fallout4/articles/3115",
-                       "===============================================================================",
-                       f"END OF AUTOSCAN | Author/Made By: Poet#9800 (DISCORD) | {CLAS_Date}"
-                       ])
-    output.close()
 
     # MOVE UNSOLVED LOGS TO SPECIAL FOLDER
     if CLAS_config.getboolean("MAIN", "Move Unsolved") == True:
@@ -1619,17 +1606,16 @@ print(random.choice(Sneaky_Tips))
 
 # ============ CHECK FOR EMPTY (FAUTLY) AUTO-SCANS ============
 list_SCANFAIL = []
-for file in os.listdir("."):
-    if fnmatch.fnmatch(file, "*-AUTOSCAN.md"):
-        line_count = 0
-        scanname = str(file)
-        autoscan_log = open(file, errors="ignore")
+for file in glob("*-AUTOSCAN.md"):
+    line_count = 0
+    scanname = str(file)
+    with open(file, errors="ignore") as autoscan_log:
         for line in autoscan_log:
             if line != "\n":
                 line_count += 1
-        if int(line_count) <= 10:
-            list_SCANFAIL.append(scanname.removesuffix("-AUTOSCAN.md") + ".log")
-            statL_failed += 1
+    if int(line_count) <= 10:
+        list_SCANFAIL.append(scanname.replace("-AUTOSCAN.md", ".log"))
+        statL_failed += 1
 
 if len(list_SCANFAIL) >= 1:
     print("NOTICE: AUTOSCANNER WAS UNABLE TO PROPERLY SCAN THE FOLLOWING LOG(S): ")

--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -1368,7 +1368,7 @@ for file in logs:
             output.write("AUTOSCAN CANNOT FIND FALLOUT 4 SCRIPT EXTENDER DLL!\n")
             output.write("MAKE SURE THAT F4SE IS CORRECTLY INSTALLED!\n")
             output.write("Link: https://f4se.silverlock.org\n")
-            output.write("-----")
+            output.write("-----\n")
 
         for line in loglines:
             if len(line) >= 6 and "]" in line[4]:
@@ -1404,7 +1404,7 @@ for file in logs:
                     PL_matches.append(string)
             if PL_matches:
                 PL_result.append(PL_matches)
-                output.write(f"- {' '.join(PL_matches)}")
+                output.write(f"- {' '.join(PL_matches)}\n")
 
         if not PL_result:
             output.write("* AUTOSCAN COULDN'T FIND ANY PLUGIN CULRIPTS *\n")

--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -273,11 +273,11 @@ for file in logs:
         loglines = lines.readlines()
     with scanpath.open("w", encoding='utf-8-sig', errors="ignore") as output:
         output.write(logname)
-        output.write("This crash log was automatically scanned.")
-        output.write(f"VER {CLAS_Current[-4:]} | MIGHT CONTAIN FALSE POSITIVES.")
+        output.write("This crash log was automatically scanned.\n")
+        output.write(f"VER {CLAS_Current[-4:]} | MIGHT CONTAIN FALSE POSITIVES.\n")
         if CLAS_Update == True:
-            output.write("# NOTICE: YOU NEED TO UPDATE THE AUTO-SCANNER! #")
-        output.write("====================================================")
+            output.write("# NOTICE: YOU NEED TO UPDATE THE AUTO-SCANNER! #\n")
+        output.write("====================================================\n")
 
         # DEFINE LINE INDEXES FOR EVERYTHING REQUIRED HERE
         buff_ver = loglines[1].strip()
@@ -297,33 +297,33 @@ for file in logs:
                     plugin_list.append(line)
 
         # BUFFOUT VERSION CHECK
-        buff_latest = "Buffout 4 v1.26.2"
-        output.write(f"Main Error: {buff_error}")
+        buff_latest = "Buffout 4 v1.26.2\n"
+        output.write(f"Main Error: {buff_error}\n")
         output.write("====================================================")
-        output.write(f"Detected Buffout Version: {buff_ver.strip()}")
-        output.write(f"Latest Buffout Version: {buff_latest.strip()}")
+        output.write(f"Detected Buffout Version: {buff_ver.strip()}\n")
+        output.write(f"Latest Buffout Version: {buff_latest.strip()}\n")
 
         if buff_ver.casefold() == buff_latest.casefold():
-            output.write("You have the lastest version of Buffout 4!")
+            output.write("You have the lastest version of Buffout 4!\n")
         else:
-            output.write("REPORTED BUFFOUT VERSION DOES NOT MATCH THE BUFFOUT VERSION USED BY AUTOSCAN")
-            output.write("UPDATE BUFFOUT 4 IF NECESSARY: https://www.nexusmods.com/fallout4/mods/47359")
+            output.write("REPORTED BUFFOUT VERSION DOES NOT MATCH THE BUFFOUT VERSION USED BY AUTOSCAN\n")
+            output.write("UPDATE BUFFOUT 4 IF NECESSARY: https://www.nexusmods.com/fallout4/mods/47359\n")
 
         if "v1." not in buff_ver:
             statL_veryold += 1
             statL_scanned -= 1
 
-        output.write("====================================================")
-        output.write("CHECKING IF BUFFOUT 4 FILES/SETTINGS ARE CORRECT...")
-        output.write("====================================================")
+        output.write("====================================================\n")
+        output.write("CHECKING IF BUFFOUT 4 FILES/SETTINGS ARE CORRECT...\n")
+        output.write("====================================================\n")
 
         ALIB_Load = BUFF_Load = False
 
         # CHECK IF F4SE.LOG EXISTS AND REPORTS ANY ERRORS
         if CLAS_config.getboolean("MAIN", "FCX Mode") == True:
-            output.writelines(["* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *",
-                               "[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]",
-                               "-----"
+            output.writelines(["* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *\n",
+                               "[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]\n",
+                               "-----\n"
                                ])
             Error_List = []
             F4SE_Error = F4SE_Version = F4SE_Buffout = 0
@@ -339,27 +339,27 @@ for file in logs:
                         F4SE_Buffout = 1
 
             if F4SE_Version == 1:
-                output.write("You have the latest version of Fallout 4 Script Extender (F4SE). \n-----")
+                output.write("You have the latest version of Fallout 4 Script Extender (F4SE). \n-----\n")
             else:
-                output.write("# REPORTED F4SE VERSION DOES NOT MATCH THE F4SE VERSION USED BY AUTOSCAN #")
-                output.write("UPDATE FALLOUT 4 SCRIPT EXTENDER IF NECESSARY: https://f4se.silverlock.org")
-                output.write("-----")
+                output.write("# REPORTED F4SE VERSION DOES NOT MATCH THE F4SE VERSION USED BY AUTOSCAN #\n")
+                output.write("UPDATE FALLOUT 4 SCRIPT EXTENDER IF NECESSARY: https://f4se.silverlock.org\n")
+                output.write("-----\n")
 
             if F4SE_Error == 1:
-                output.write("# SCRIPT EXTENDER REPORTS THAT THE FOLLOWING PLUGINS FAILED TO LOAD! #")
+                output.write("# SCRIPT EXTENDER REPORTS THAT THE FOLLOWING PLUGINS FAILED TO LOAD! #\n")
                 for elem in Error_List:
-                    output.write(f"{elem}\n-----")
+                    output.write(f"{elem}\n-----\n")
             else:
-                output.write("Script Extender reports that all DLL mod plugins have loaded correctly. \n-----")
+                output.write("Script Extender reports that all DLL mod plugins have loaded correctly. \n-----\n")
 
             if F4SE_Buffout == 1:
-                output.write("Script Extender reports that Buffout 4.dll was found and loaded correctly. \n-----")
+                output.write("Script Extender reports that Buffout 4.dll was found and loaded correctly. \n-----\n")
                 ALIB_Load = BUFF_Load = True
             else:
-                output.write("# SCRIPT EXTENDER REPORTS THAT BUFFOUT 4.DLL FAILED TO LOAD OR IS MISSING! #")
-                output.write("Follow Buffout 4 installation steps here: https://www.nexusmods.com/fallout4/articles/3115")
-                output.write("Buffout 4: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47359")
-                output.write("-----")
+                output.write("# SCRIPT EXTENDER REPORTS THAT BUFFOUT 4.DLL FAILED TO LOAD OR IS MISSING! #\n")
+                output.write("Follow Buffout 4 installation steps here: https://www.nexusmods.com/fallout4/articles/3115\n")
+                output.write("Buffout 4: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47359\n")
+                output.write("-----\n")
 
             list_ERRORLOG = []
             for file in info.FO4_F4SE_Logs:
@@ -372,128 +372,128 @@ for file in logs:
                                 list_ERRORLOG.append(logname)
 
             if len(list_ERRORLOG) >= 1:
-                output.write("# CAUTION: THE FOLLOWING DLL LOGS ALSO REPORT ONE OR MORE ERRORS : #")
-                output.write("[These are located in your Documents/My Games/Fallout4/F4SE folder.]")
+                output.write("# CAUTION: THE FOLLOWING DLL LOGS ALSO REPORT ONE OR MORE ERRORS : #\n")
+                output.write("[These are located in your Documents/My Games/Fallout4/F4SE folder.]\n")
                 for elem in list_ERRORLOG:
-                    output.write(f"{elem}\n-----")
+                    output.write(f"{elem}\n-----\n")
             else:
-                output.write("Available DLL logs do not report any additional errors, all is well. \n-----")
+                output.write("Available DLL logs do not report any additional errors, all is well. \n-----\n")
 
         # CHECK BUFFOUT 4 REQUIREMENTS AND TOML SETTINGS
             if info.Preloader_XML.is_file() and info.Preloader_DLL.is_file():
-                output.write('OPTIONAL: Plugin Preloader is (manually) installed.\n')
-                output.write('NOTICE: If the game fails to start after installing this mod, open xSE PluginPreloader.xml with a text editor and CHANGE')
-                output.write('<LoadMethod Name="ImportAddressHook"> TO <LoadMethod Name="OnThreadAttach"> OR <LoadMethod Name="OnProcessAttach">')
-                output.write('IF THE GAME STILL REFUSES TO START, COMPLETELY REMOVE xSE PluginPreloader.xml AND IpHlpAPI.dll FROM YOUR FO4 GAME FOLDER')
-                output.write("-----")
+                output.write('OPTIONAL: Plugin Preloader is (manually) installed.\n\n')
+                output.write('NOTICE: If the game fails to start after installing this mod, open xSE PluginPreloader.xml with a text editor and CHANGE\n')
+                output.write('<LoadMethod Name="ImportAddressHook"> TO <LoadMethod Name="OnThreadAttach"> OR <LoadMethod Name="OnProcessAttach">\n')
+                output.write('IF THE GAME STILL REFUSES TO START, COMPLETELY REMOVE xSE PluginPreloader.xml AND IpHlpAPI.dll FROM YOUR FO4 GAME FOLDER\n')
+                output.write("-----\n")
             else:
-                output.write('OPTIONAL: Plugin Preloader is not (manually) installed.\n-----')
+                output.write('OPTIONAL: Plugin Preloader is not (manually) installed.\n-----\n')
 
             if info.F4SE_Loader.is_file() and info.F4SE_DLL.is_file() and info.F4SE_SDLL.is_file():
-                output.write("REQUIRED: Fallout 4 Script Extender is (manually) installed. \n-----")
+                output.write("REQUIRED: Fallout 4 Script Extender is (manually) installed. \n-----\n")
             else:
-                output.write("# CAUTION: Auto-Scanner cannot find Script Extender files or they aren't (manually) installed! #")
-                output.write("FIX: Extract all files inside *f4se_0_06_21* folder into your Fallout 4 game folder.")
-                output.write("FALLOUT 4 SCRIPT EXTENDER: (Download Build 0.6.23) https://f4se.silverlock.org")
-                output.write("-----")
+                output.write("# CAUTION: Auto-Scanner cannot find Script Extender files or they aren't (manually) installed! #\n")
+                output.write("FIX: Extract all files inside *f4se_0_06_21* folder into your Fallout 4 game folder.\n")
+                output.write("FALLOUT 4 SCRIPT EXTENDER: (Download Build 0.6.23) https://f4se.silverlock.org\n")
+                output.write("-----\n")
 
             if info.Address_Library.is_file() or ALIB_Load == True:
-                output.write("REQUIRED: Address Library is (manually) installed. \n-----")
+                output.write("REQUIRED: Address Library is (manually) installed. \n-----\n")
             else:
-                output.write("# CAUTION: Auto-Scanner cannot find the Adress Library file or it isn't (manually) installed! #")
-                output.write("FIX: Place the *version-1-10-163-0.bin* file manually into Fallout 4/Data/F4SE/Plugins folder.")
-                output.write("ADDRESS LIBRARY: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47327?tab=files")
-                output.write("-----")
+                output.write("# CAUTION: Auto-Scanner cannot find the Adress Library file or it isn't (manually) installed! #\n")
+                output.write("FIX: Place the *version-1-10-163-0.bin* file manually into Fallout 4/Data/F4SE/Plugins folder.\n")
+                output.write("ADDRESS LIBRARY: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47327?tab=files\n")
+                output.write("-----\n")
 
             if info.Buffout_INI.is_file() and info.Buffout_DLL.is_file() or BUFF_Load == True:
                 with open(info.Buffout_INI, "r+") as BUFF_Custom:
                     BUFF_config = BUFF_Custom.read()
-                    output.write("REQUIRED: Buffout 4 is (manually) installed. Checking configuration...\n-----")
+                    output.write("REQUIRED: Buffout 4 is (manually) installed. Checking configuration...\n-----\n")
                     if ("achievements.dll" or "UnlimitedSurvivalMode.dll") in logtext and "Achievements = true" in BUFF_config:
-                        output.write("# CAUTION: Achievements Mod and/or Unlimited Survival Mode is installed, but Achievements parameter is set to TRUE #")
-                        output.write("Auto-Scanner will change this parameter to FALSE to prevent conflicts with Buffout 4.")
-                        output.write("-----")
+                        output.write("# CAUTION: Achievements Mod and/or Unlimited Survival Mode is installed, but Achievements parameter is set to TRUE #\n")
+                        output.write("Auto-Scanner will change this parameter to FALSE to prevent conflicts with Buffout 4.\n")
+                        output.write("-----\n")
 
                         BUFF_config = BUFF_config.replace("Achievements = true", "Achievements = false")
                     else:
-                        output.write("Achievements parameter in *Buffout4.toml* is correctly configured. \n-----")
+                        output.write("Achievements parameter in *Buffout4.toml* is correctly configured. \n-----\n")
 
                     if "BakaScrapHeap.dll" in logtext and "MemoryManager = true" in BUFF_config:
-                        output.write("# CAUTION: Baka ScrapHeap is installed, but MemoryManager parameter is set to TRUE #")
-                        output.write("Auto-Scanner will change this parameter to FALSE to prevent conflicts with Buffout 4.")
-                        output.write("-----")
+                        output.write("# CAUTION: Baka ScrapHeap is installed, but MemoryManager parameter is set to TRUE #\n")
+                        output.write("Auto-Scanner will change this parameter to FALSE to prevent conflicts with Buffout 4.\n")
+                        output.write("-----\n")
                         BUFF_config = BUFF_config.replace("MemoryManager = true", "MemoryManager = false")
                     else:
-                        output.write("Memory Manager parameter in *Buffout4.toml* is correctly configured. \n-----")
+                        output.write("Memory Manager parameter in *Buffout4.toml* is correctly configured. \n-----\n")
 
                     if "f4ee.dll" in logtext and "F4EE = false" in BUFF_config:
-                        output.write("# CAUTION: Looks Menu is installed, but F4EE parameter under [Compatibility] is set to FALSE #")
-                        output.write("Auto-Scanner will change this parameter to TRUE to prevent bugs and crashes from Looks Menu.")
-                        output.write("-----")
+                        output.write("# CAUTION: Looks Menu is installed, but F4EE parameter under [Compatibility] is set to FALSE #\n")
+                        output.write("Auto-Scanner will change this parameter to TRUE to prevent bugs and crashes from Looks Menu.\n")
+                        output.write("-----\n")
                         BUFF_config = BUFF_config.replace("F4EE = false", "F4EE = true")
                     else:
-                        output.write("Looks Menu (F4EE) parameter in *Buffout4.toml* is correctly configured. \n-----")
+                        output.write("Looks Menu (F4EE) parameter in *Buffout4.toml* is correctly configured. \n-----\n")
                 with open(info.Buffout_INI, "w+") as BUFF_Custom:
                     BUFF_Custom.write(BUFF_config)
             else:
-                output.write("# CAUTION: Auto-Scanner cannot find Buffout 4 files or they aren't (manually) installed! #")
-                output.write("FIX: Follow Buffout 4 installation steps here: https://www.nexusmods.com/fallout4/articles/3115")
-                output.write("BUFFOUT 4: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47359?tab=files")
-                output.write("-----")
+                output.write("# CAUTION: Auto-Scanner cannot find Buffout 4 files or they aren't (manually) installed! #\n")
+                output.write("FIX: Follow Buffout 4 installation steps here: https://www.nexusmods.com/fallout4/articles/3115\n")
+                output.write("BUFFOUT 4: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47359?tab=files\n")
+                output.write("-----\n")
 
         else:  # INSTRUCTIONS FOR MANUAL FIXING WHEN FCX MODE IS FALSE
             if ("Achievements: true" in logtext and "achievements.dll" in logtext) or ("Achievements: true" in logtext and "UnlimitedSurvivalMode.dll" in logtext):
-                output.write("# CAUTION: Achievements Mod and/or Unlimited Survival Mode is installed, but Achievements parameter is set to TRUE #")
-                output.write("FIX: Open *Buffout4.toml* and change Achievements parameter to FALSE, this prevents conflicts with Buffout 4.")
-                output.write("-----")
+                output.write("# CAUTION: Achievements Mod and/or Unlimited Survival Mode is installed, but Achievements parameter is set to TRUE #\n")
+                output.write("FIX: Open *Buffout4.toml* and change Achievements parameter to FALSE, this prevents conflicts with Buffout 4.\n")
+                output.write("-----\n")
             else:
-                output.write("Achievements parameter in *Buffout4.toml* is correctly configured. \n-----")
+                output.write("Achievements parameter in *Buffout4.toml* is correctly configured. \n-----\n")
 
             if "MemoryManager: true" in logtext and "BakaScrapHeap.dll" in logtext:
-                output.write("# CAUTION: Baka ScrapHeap is installed, but MemoryManager parameter is set to TRUE #")
-                output.write("FIX: Open *Buffout4.toml* and change MemoryManager parameter to FALSE, this prevents conflicts with Buffout 4.")
-                output.write("-----")
+                output.write("# CAUTION: Baka ScrapHeap is installed, but MemoryManager parameter is set to TRUE #\n")
+                output.write("FIX: Open *Buffout4.toml* and change MemoryManager parameter to FALSE, this prevents conflicts with Buffout 4.\n")
+                output.write("-----\n")
             else:
-                output.write("Memory Manager parameter in *Buffout4.toml* is correctly configured. \n-----")
+                output.write("Memory Manager parameter in *Buffout4.toml* is correctly configured. \n-----\n")
 
         if "F4EE: false" in logtext and "f4ee.dll" in logtext:
-            output.write("# CAUTION: Looks Menu is installed, but F4EE parameter under [Compatibility] is set to FALSE #")
-            output.write("FIX: Open *Buffout4.toml* and change F4EE parameter to TRUE, this prevents bugs and crashes from Looks Menu.")
-            output.write("-----")
+            output.write("# CAUTION: Looks Menu is installed, but F4EE parameter under [Compatibility] is set to FALSE #\n")
+            output.write("FIX: Open *Buffout4.toml* and change F4EE parameter to TRUE, this prevents bugs and crashes from Looks Menu.\n")
+            output.write("-----\n")
         else:
-            output.write("Looks Menu (F4EE) parameter in *Buffout4.toml* is correctly configured. \n-----")
+            output.write("Looks Menu (F4EE) parameter in *Buffout4.toml* is correctly configured. \n-----\n")
 
-        output.write("====================================================")
-        output.write("CHECKING IF LOG MATCHES ANY KNOWN CRASH MESSAGES...")
-        output.write("====================================================")
+        output.write("====================================================\n")
+        output.write("CHECKING IF LOG MATCHES ANY KNOWN CRASH MESSAGES...\n")
+        output.write("====================================================\n")
         Buffout_Trap = False  # RETURN TRUE IF KNOWN CRASH MESSAGE WAS FOUND
 
         # ====================== HEADER ERRORS ======================
 
         if ".dll" in buff_error and "tbbmalloc" not in buff_error:
-            output.write("# MAIN ERROR REPORTS A DLL WAS INVLOVED IN THIS CRASH! # \n-----")
+            output.write("# MAIN ERROR REPORTS A DLL WAS INVLOVED IN THIS CRASH! # \n-----\n")
 
         if "EXCEPTION_STACK_OVERFLOW" in buff_error:
-            output.write("# Checking for Stack Overflow Crash.........CULPRIT FOUND! #")
-            output.write("> Priority : [5]")
+            output.write("# Checking for Stack Overflow Crash.........CULPRIT FOUND! #\n")
+            output.write("> Priority : [5]\n")
             Buffout_Trap = True
             statC_Overflow += 1
 
         if "0x000100000000" in buff_error:
-            output.write("# Checking for Active Effects Crash.........CULPRIT FOUND! #")
-            output.write("> Priority : [5]")
+            output.write("# Checking for Active Effects Crash.........CULPRIT FOUND! #\n")
+            output.write("> Priority : [5]\n")
             Buffout_Trap = True
             statC_ActiveEffect += 1
 
         if "EXCEPTION_INT_DIVIDE_BY_ZERO" in buff_error:
-            output.write("# Checking for Bad Math Crash...............CULPRIT FOUND! #")
-            output.write("> Priority : [5]")
+            output.write("# Checking for Bad Math Crash...............CULPRIT FOUND! #\n")
+            output.write("> Priority : [5]\n")
             Buffout_Trap = True
             statC_BadMath += 1
 
         if "0x000000000000" in buff_error:
-            output.write("# Checking for Null Crash...................CULPRIT FOUND! #")
-            output.write("> Priority : [5]")
+            output.write("# Checking for Null Crash...................CULPRIT FOUND! #\n")
+            output.write("> Priority : [5]\n")
             Buffout_Trap = True
             statC_Null += 1
 
@@ -507,282 +507,281 @@ for file in logs:
 
         # ===========================================================
         if "DLCBannerDLC01.dds" in logtext:
-            output.write("# Checking for DLL Crash....................CULPRIT FOUND! #")
-            output.write(f'> Priority : [5] | DLCBannerDLC01.dds : {logtext.count("DLCBannerDLC01.dds")}')
+            output.write("# Checking for DLL Crash....................CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [5] | DLCBannerDLC01.dds : {logtext.count("DLCBannerDLC01.dds")}\n')
             Buffout_Trap = True
             statC_DLL += 1
         # ===========================================================
         if "BGSLocation" in logtext and "BGSQueuedTerrainInitialLoad" in logtext:
-            output.write('# Checking for LOD Crash....................CULPRIT FOUND! #')
-            output.write(f'> Priority : [5] | BGSLocation : {logtext.count("BGSLocation")} | BGSQueuedTerrainInitialLoad : {logtext.count("BGSQueuedTerrainInitialLoad")}')
+            output.write('# Checking for LOD Crash....................CULPRIT FOUND! #\n')
+            output.write(f'> Priority : [5] | BGSLocation : {logtext.count("BGSLocation")} | BGSQueuedTerrainInitialLoad : {logtext.count("BGSQueuedTerrainInitialLoad")}\n')
             Buffout_Trap = True
             statC_LOD += 1
         # ===========================================================
         if ("FaderData" or "FaderMenu" or "UIMessage") in logtext:
-            output.write("# Checking for MCM Crash....................CULPRIT FOUND! #")
-            output.write(f'> Priority : [3] | FaderData : {logtext.count("FaderData")} | FaderMenu : {logtext.count("FaderMenu")} | UIMessage : {logtext.count("UIMessage")}')
+            output.write("# Checking for MCM Crash....................CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [3] | FaderData : {logtext.count("FaderData")} | FaderMenu : {logtext.count("FaderMenu")} | UIMessage : {logtext.count("UIMessage")}\n')
             Buffout_Trap = True
             statC_MCM += 1
         # ===========================================================
         if ("BGSDecalManager" or "BSTempEffectGeometryDecal") in logtext:
-            output.write("# Checking for Decal Crash..................CULPRIT FOUND! #")
-            output.write(f'> Priority : [5] | BGSDecalManager : {logtext.count("BGSDecalManager")} | BSTempEffectGeometryDecal : {logtext.count("BSTempEffectGeometryDecal")}')
+            output.write("# Checking for Decal Crash..................CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [5] | BGSDecalManager : {logtext.count("BGSDecalManager")} | BSTempEffectGeometryDecal : {logtext.count("BSTempEffectGeometryDecal")}\n')
             Buffout_Trap = True
             statC_Decal += 1
         # ===========================================================
         if logtext.count("PipboyMapData") >= 2:
-            output.write("# Checking for Equip Crash..................CULPRIT FOUND! #")
-            output.write(f'> Priority : [2] | PipboyMapData : {logtext.count("PipboyMapData")}')
+            output.write("# Checking for Equip Crash..................CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [2] | PipboyMapData : {logtext.count("PipboyMapData")}\n')
             Buffout_Trap = True
             statC_Equip += 1
         # ===========================================================
         if (logtext.count("Papyrus") or logtext.count("VirtualMachine")) >= 2:
-            output.writelines("# Checking for Script Crash.................CULPRIT FOUND! #")
-            output.write(f'> Priority : [3] | Papyrus : {logtext.count("Papyrus")} | VirtualMachine : {logtext.count("VirtualMachine")}')                               
+            output.writelines("# Checking for Script Crash.................CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [3] | Papyrus : {logtext.count("Papyrus")} | VirtualMachine : {logtext.count("VirtualMachine")}\n')
             Buffout_Trap = True
             statC_Papyrus += 1
         # ===========================================================
         if logtext.count("tbbmalloc.dll") >= 3 or "tbbmalloc" in buff_error:
-            output.write("# Checking for Generic Crash................CULPRIT FOUND! #")
-            output.write(f'> Priority : [2] | tbbmalloc.dll : {logtext.count("tbbmalloc.dll")}')
+            output.write("# Checking for Generic Crash................CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [2] | tbbmalloc.dll : {logtext.count("tbbmalloc.dll")}\n')
             Buffout_Trap = True
             statC_Generic += 1
         # ===========================================================
         if "LooseFileAsyncStream" in logtext:
-            output.write("# Checking for BA2 Limit Crash..............CULPRIT FOUND! #")
-            output.write(f'> Priority : [5] | LooseFileAsyncStream : {logtext.count("LooseFileAsyncStream")}')
+            output.write("# Checking for BA2 Limit Crash..............CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [5] | LooseFileAsyncStream : {logtext.count("LooseFileAsyncStream")}\n')
             Buffout_Trap = True
             statC_BA2Limit += 1
         # ===========================================================
         if logtext.count("d3d11.dll") >= 3 or "d3d11" in buff_error:
-            output.write("# Checking for Rendering Crash..............CULPRIT FOUND! #")
-            output.write(f'> Priority : [4] | d3d11.dll : {logtext.count("d3d11.dll")}')
+            output.write("# Checking for Rendering Crash..............CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [4] | d3d11.dll : {logtext.count("d3d11.dll")}\n')
             Buffout_Trap = True
             statC_Rendering += 1
         # ===========================================================
         if ("GridAdjacencyMapNode" or "PowerUtils") in logtext:
-            output.write("# Checking for Grid Scrap Crash.............CULPRIT FOUND! #")
-            output.write(f'> Priority : [5] | GridAdjacencyMapNode : {logtext.count("GridAdjacencyMapNode")} | PowerUtils : {logtext.count("PowerUtils")}')
+            output.write("# Checking for Grid Scrap Crash.............CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [5] | GridAdjacencyMapNode : {logtext.count("GridAdjacencyMapNode")} | PowerUtils : {logtext.count("PowerUtils")}\n')
             Buffout_Trap = True
             statC_GridScrap += 1
         # ===========================================================
         if ("LooseFileStream" or "BSFadeNode" or "BSMultiBoundNode") in logtext and logtext.count("LooseFileAsyncStream") == 0:
-            output.write("# Checking for Mesh (NIF) Crash.............CULPRIT FOUND! #")
-            output.write(f'> Priority : [4] | LooseFileStream : {logtext.count("LooseFileStream")} | BSFadeNode : {logtext.count("BSFadeNode")}')
-            output.write(f'                   BSMultiBoundNode : {logtext.count("BSMultiBoundNode")}')
+            output.write("# Checking for Mesh (NIF) Crash.............CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [4] | LooseFileStream : {logtext.count("LooseFileStream")} | BSFadeNode : {logtext.count("BSFadeNode")}\n')
+            output.write(f'                   BSMultiBoundNode : {logtext.count("BSMultiBoundNode")}\n')
             Buffout_Trap = True
             statC_NIF += 1
         # ===========================================================
         if ("Create2DTexture" or "DefaultTexture") in logtext:
-            output.write("# Checking for Texture (DDS) Crash..........CULPRIT FOUND! #")
-            output.write(f'> Priority : [3] | Create2DTexture : {logtext.count("Create2DTexture")} | DefaultTexture : {logtext.count("DefaultTexture")}')
+            output.write("# Checking for Texture (DDS) Crash..........CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [3] | Create2DTexture : {logtext.count("Create2DTexture")} | DefaultTexture : {logtext.count("DefaultTexture")}\n')
             Buffout_Trap = True
             statlogtexture += 1
         # ===========================================================
         if ("DefaultTexture_Black" or "NiAlphaProperty") in logtext:
-            output.write("# Checking for Material (BGSM) Crash........CULPRIT FOUND! #")
+            output.write("# Checking for Material (BGSM) Crash........CULPRIT FOUND! #\n")
             output.write(f'> Priority : [3] | DefaultTexture_Black : {logtext.count("DefaultTexture_Black")} | NiAlphaProperty : {logtext.count("NiAlphaProperty")}')
             Buffout_Trap = True
             statC_BGSM += 1
         # ===========================================================
         if (logtext.count("bdhkm64.dll") or logtext.count("usvfs::hook_DeleteFileW")) >= 2:
-            output.write("# Checking for BitDefender Crash............CULPRIT FOUND! #")
-            output.write(f'> Priority : [5] | bdhkm64.dll : {logtext.count("bdhkm64.dll")} | usvfs::hook_DeleteFileW : {logtext.count("usvfs::hook_DeleteFileW")}')
+            output.write("# Checking for BitDefender Crash............CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [5] | bdhkm64.dll : {logtext.count("bdhkm64.dll")} | usvfs::hook_DeleteFileW : {logtext.count("usvfs::hook_DeleteFileW")}\n')
             Buffout_Trap = True
             statC_BitDefender += 1
         # ===========================================================
         if ("PathingCell" or "BSPathBuilder" or "PathManagerServer") in logtext:
-            output.write("# Checking for NPC Pathing Crash............CULPRIT FOUND! #")
-            output.write(f'> Priority : [3] | PathingCell : {logtext.count("PathingCell")} | BSPathBuilder : {logtext.count("BSPathBuilder")}')
-            output.write(f'                   PathManagerServer : {logtext.count("PathManagerServer")}')
+            output.write("# Checking for NPC Pathing Crash............CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [3] | PathingCell : {logtext.count("PathingCell")} | BSPathBuilder : {logtext.count("BSPathBuilder")}\n')
+            output.write(f'                   PathManagerServer : {logtext.count("PathManagerServer")}\n')
             Buffout_Trap = True
             statC_NPCPathing += 1
         elif ("NavMesh" or "BSNavmeshObstacleData" or "DynamicNavmesh") in logtext:
-            output.write("# Checking for NPC Pathing Crash............CULPRIT FOUND! #")
-            output.write(f'> Priority : [3] | NavMesh : {logtext.count("NavMesh")} | BSNavmeshObstacleData : {logtext.count("BSNavmeshObstacleData")}')
-            output.write(f'                   DynamicNavmesh : {logtext.count("DynamicNavmesh")}')
+            output.write("# Checking for NPC Pathing Crash............CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [3] | NavMesh : {logtext.count("NavMesh")} | BSNavmeshObstacleData : {logtext.count("BSNavmeshObstacleData")}\n')
+            output.write(f'                   DynamicNavmesh : {logtext.count("DynamicNavmesh")}\n')
             Buffout_Trap = True
             statC_NPCPathing += 1
         # ===========================================================
         if logtext.count("X3DAudio1_7.dll") >= 3 or logtext.count("XAudio2_7.dll") >= 3 or ("X3DAudio1_7" or "XAudio2_7") in buff_error:
-            output.write("# Checking for Audio Driver Crash...........CULPRIT FOUND! #")
-            output.write(f'> Priority : [5] | X3DAudio1_7.dll : {logtext.count("X3DAudio1_7.dll")} | XAudio2_7.dll : {logtext.count("XAudio2_7.dll")}')
+            output.write("# Checking for Audio Driver Crash...........CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [5] | X3DAudio1_7.dll : {logtext.count("X3DAudio1_7.dll")} | XAudio2_7.dll : {logtext.count("XAudio2_7.dll")}\n')
             Buffout_Trap = True
             statC_Audio += 1
         # ===========================================================
         if logtext.count("cbp.dll") >= 3 or "skeleton.nif" in logtext or "cbp.dll" in buff_error:
-            output.write("# Checking for Body Physics Crash...........CULPRIT FOUND! #")
-            output.write(f'> Priority : [4] | cbp.dll : {logtext.count("cbp.dll")} | skeleton.nif : {logtext.count("skeleton.nif")}')
+            output.write("# Checking for Body Physics Crash...........CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [4] | cbp.dll : {logtext.count("cbp.dll")} | skeleton.nif : {logtext.count("skeleton.nif")}\n')
             Buffout_Trap = True
             statC_BodyPhysics += 1
         # ===========================================================
         if ("BSMemStorage" or "DataFileHandleReaderWriter") in logtext:
-            output.write("# Checking for Plugin Limit Crash...........CULPRIT FOUND! #")
-            output.write(f'> Priority : [5] | BSMemStorage : {logtext.count("BSMemStorage")} | DataFileHandleReaderWriter : {logtext.count("DataFileHandleReaderWriter")}')
+            output.write("# Checking for Plugin Limit Crash...........CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [5] | BSMemStorage : {logtext.count("BSMemStorage")} | DataFileHandleReaderWriter : {logtext.count("DataFileHandleReaderWriter")}\n')
             Buffout_Trap = True
             statC_PluginLimit += 1
         # ===========================================================
         if "GamebryoSequenceGenerator" in logtext or "+0DB9300" in buff_error:
-            output.write("# Checking for Plugin Order Crash...........CULPRIT FOUND! #")
-            output.write(f'> Priority : [5] | GamebryoSequenceGenerator : {logtext.count("GamebryoSequenceGenerator")}')
+            output.write("# Checking for Plugin Order Crash...........CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [5] | GamebryoSequenceGenerator : {logtext.count("GamebryoSequenceGenerator")}\n')
             Buffout_Trap = True
             statC_LoadOrder += 1
         # ===========================================================
         if logtext.count("BSD3DResourceCreator") == 3 or logtext.count("BSD3DResourceCreator") == 6:
-            output.write("# Checking for MO2 Extractor Crash..........CULPRIT FOUND! #")
-            output.write(f'> Priority : [5] | BSD3DResourceCreator : {logtext.count("BSD3DResourceCreator")}')
+            output.write("# Checking for MO2 Extractor Crash..........CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [5] | BSD3DResourceCreator : {logtext.count("BSD3DResourceCreator")}\n')
             Buffout_Trap = True
             statC_MO2Unp += 1
         # ===========================================================
         if logtext.count("flexRelease_x64.dll") >= 2 or "flexRelease_x64" in buff_error:
-            output.write("# Checking for Nvidia Debris Crash..........CULPRIT FOUND! #")
-            output.write(f'> Priority : [5] | flexRelease_x64.dll : {logtext.count("flexRelease_x64.dll")}')
+            output.write("# Checking for Nvidia Debris Crash..........CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [5] | flexRelease_x64.dll : {logtext.count("flexRelease_x64.dll")}\n')
             Buffout_Trap = True
             statC_NVDebris += 1
         # ===========================================================
         if logtext.count("nvwgf2umx.dll") >= 10 or ("nvwgf2umx" or "USER32.dll") in buff_error:
-            output.write("# Checking for Nvidia Driver Crash..........CULPRIT FOUND! #")
-            output.write(f'> Priority : [5] | nvwgf2umx.dll : {logtext.count("nvwgf2umx.dll")} | USER32.dll : {logtext.count("USER32.dll")}')
+            output.write("# Checking for Nvidia Driver Crash..........CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [5] | nvwgf2umx.dll : {logtext.count("nvwgf2umx.dll")} | USER32.dll : {logtext.count("USER32.dll")}\n')
             Buffout_Trap = True
             statC_NVDriver += 1
         # ===========================================================
         if (logtext.count("KERNELBASE.dll") or logtext.count("MSVCP140.dll")) >= 3 and "DxvkSubmissionQueue" in logtext:
-            output.write("# Checking for Vulkan Memory Crash..........CULPRIT FOUND! #")
-            output.write(f'> Priority : [5] | KERNELBASE.dll : {logtext.count("KERNELBASE.dll")} | MSVCP140.dll : {logtext.count("MSVCP140.dll")}')
-            output.write(f'                   DxvkSubmissionQueue : {logtext.count("DxvkSubmissionQueue")}')
+            output.write("# Checking for Vulkan Memory Crash..........CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [5] | KERNELBASE.dll : {logtext.count("KERNELBASE.dll")} | MSVCP140.dll : {logtext.count("MSVCP140.dll")}\n')
+            output.write(f'                   DxvkSubmissionQueue : {logtext.count("DxvkSubmissionQueue")}\n')
             Buffout_Trap = True
             statC_VulkanMem += 1
         # ===========================================================
         if ("dxvk::DXGIAdapter" or "dxvk::DXGIFactory") in logtext:
-            output.write("# Checking for Vulkan Settings Crash........CULPRIT FOUND! #")
-            output.write(f'> Priority : [5] | dxvk::DXGIAdapter : {logtext.count("dxvk::DXGIAdapter")} | dxvk::DXGIFactory : {logtext.count("dxvk::DXGIFactory")}')
+            output.write("# Checking for Vulkan Settings Crash........CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [5] | dxvk::DXGIAdapter : {logtext.count("dxvk::DXGIAdapter")} | dxvk::DXGIFactory : {logtext.count("dxvk::DXGIFactory")}\n')
             Buffout_Trap = True
             statC_VulkanSet += 1
         # ===========================================================
         if ("BSXAudio2DataSrc" or "BSXAudio2GameSound") in logtext:
-            output.write("# Checking for Corrupted Audio Crash........CULPRIT FOUND! #")
-            output.write(f'> Priority : [4] | BSXAudio2DataSrc : {logtext.count("BSXAudio2DataSrc")} | BSXAudio2GameSound : {logtext.count("BSXAudio2GameSound")}')
+            output.write("# Checking for Corrupted Audio Crash........CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [4] | BSXAudio2DataSrc : {logtext.count("BSXAudio2DataSrc")} | BSXAudio2GameSound : {logtext.count("BSXAudio2GameSound")}\n')
             Buffout_Trap = True
             statC_CorruptedAudio += 1
         # ===========================================================
         if ("SysWindowCompileAndRun" or "ConsoleLogPrinter") in logtext:
-            output.write("# Checking for Console Command Crash........CULPRIT FOUND! #")
-            output.write(f'> Priority : [1] | SysWindowCompileAndRun : {logtext.count("SysWindowCompileAndRun")} | ConsoleLogPrinter : {logtext.count("ConsoleLogPrinter")}')
+            output.write("# Checking for Console Command Crash........CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [1] | SysWindowCompileAndRun : {logtext.count("SysWindowCompileAndRun")} | ConsoleLogPrinter : {logtext.count("ConsoleLogPrinter")}\n')
             Buffout_Trap = True
             statC_ConsoleCommands += 1
         # ===========================================================
         if "BGSWaterCollisionManager" in logtext:
-            output.write("# Checking for Water Collision Crash........CULPRIT FOUND! #")
-            output.write("PLEASE CONTACT ME AS SOON AS POSSIBLE! (CONTACT INFO BELOW)")
-            output.write(f'> Priority : [6] | BGSWaterCollisionManager : {logtext.count("BGSWaterCollisionManager")}')
+            output.write("# Checking for Water Collision Crash........CULPRIT FOUND! #\n")
+            output.write("PLEASE CONTACT ME AS SOON AS POSSIBLE! (CONTACT INFO BELOW)\n")
+            output.write(f'> Priority : [6] | BGSWaterCollisionManager : {logtext.count("BGSWaterCollisionManager")}\n')
             Buffout_Trap = True
             statC_Water += 1
         # ===========================================================
         if "ParticleSystem" in logtext:
-            output.write("# Checking for Particle Effects Crash.......CULPRIT FOUND! #")
-            output.write(f'> Priority : [4] | ParticleSystem : {logtext.count("ParticleSystem")}')
+            output.write("# Checking for Particle Effects Crash.......CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [4] | ParticleSystem : {logtext.count("ParticleSystem")}\n')
             Buffout_Trap = True
             statC_Particles += 1
         # ===========================================================
         if ("hkbVariableBindingSet" or "hkbHandIkControlsModifier" or "hkbBehaviorGraph" or "hkbModifierList") in logtext:
-            output.write("# Checking for Animation / Physics Crash....CULPRIT FOUND! #")
-            output.write(f'> Priority : [5] | hkbVariableBindingSet : {logtext.count("hkbVariableBindingSet")} | hkbHandIkControlsModifier : {logtext.count("hkbHandIkControlsModifier")}')
-            output.write(f'                   hkbBehaviorGraph : {logtext.count("hkbBehaviorGraph")} | hkbModifierList : {logtext.count("hkbModifierList")}')
+            output.write("# Checking for Animation / Physics Crash....CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [5] | hkbVariableBindingSet : {logtext.count("hkbVariableBindingSet")} | hkbHandIkControlsModifier : {logtext.count("hkbHandIkControlsModifier")}\n')
+            output.write(f'                   hkbBehaviorGraph : {logtext.count("hkbBehaviorGraph")} | hkbModifierList : {logtext.count("hkbModifierList")}\n')
             Buffout_Trap = True
             statC_AnimationPhysics += 1
         # ===========================================================
         if "DLCBanner05.dds" in logtext:
-            output.write("# Checking for Archive Invalidation Crash...CULPRIT FOUND! #")
-            output.write(f'> Priority : [5] | DLCBanner05.dds : {logtext.count("DLCBanner05.dds")}')
+            output.write("# Checking for Archive Invalidation Crash...CULPRIT FOUND! #\n")
+            output.write(f'> Priority : [5] | DLCBanner05.dds : {logtext.count("DLCBanner05.dds")}\n')
             Buffout_Trap = True
             statC_Invalidation += 1
 
         # ===========================================================
-        output.write("---------- Unsolved Crash Messages Below ----------")
+        output.write("---------- Unsolved Crash Messages Below ----------\n")
 
         if "+01B59A4" in buff_error:
-            output.write("Checking for *[Creation Club Crash].......DETECTED!")
-            output.write("> Priority : [5]")
+            output.write("Checking for *[Creation Club Crash].......DETECTED!\n")
+            output.write("> Priority : [5]\n")
             Buffout_Trap = True
             statU_CClub += 1
 
         if ("BGSMod::Attachment" or "BGSMod::Template" or "BGSMod::Template::Item") in logtext:
-            output.write("Checking for *[Item Crash]................DETECTED!")
-            output.write(f'> Priority : [5] | BGSMod::Attachment : {logtext.count("BGSMod::Attachment")} | BGSMod::Template : {logtext.count("BGSMod::Template")}')
+            output.write("Checking for *[Item Crash]................DETECTED!\n")
+            output.write(f'> Priority : [5] | BGSMod::Attachment : {logtext.count("BGSMod::Attachment")} | BGSMod::Template : {logtext.count("BGSMod::Template")}\n')
             output.write(f'                        BGSMod::Template::Item : {logtext.count("BGSMod::Template::Item")}')
             Buffout_Trap = True
             statU_Item += 1
         # ===========================================================
         if logtext.count("BGSSaveFormBuffer") >= 2:
-            output.write("Checking for *[Save Crash]................DETECTED!")
-            output.write(f'> Priority : [5] | BGSSaveFormBuffer : {logtext.count("BGSSaveFormBuffer")}')
+            output.write("Checking for *[Save Crash]................DETECTED!\n")
+            output.write(f'> Priority : [5] | BGSSaveFormBuffer : {logtext.count("BGSSaveFormBuffer")}\n')
             Buffout_Trap = True
             statU_Save += 1
         # ===========================================================
         if ("ButtonEvent" or "MenuControls" or "MenuOpenCloseHandler" or "PlayerControls" or "DXGISwapChain") in logtext:
-            output.write("Checking for *[Input Crash]...............DETECTED!")
+            output.write("Checking for *[Input Crash]...............DETECTED!\n")
             output.write(f'> Priority : [5] | ButtonEvent : {logtext.count("ButtonEvent")} | MenuControls : {logtext.count("MenuControls")}')
-            output.write(f'                        MenuOpenCloseHandler : {logtext.count("MenuOpenCloseHandler")} | PlayerControls : {logtext.count("PlayerControls")}')
-            output.write(f'                        DXGISwapChain : {logtext.count("DXGISwapChain")}')
+            output.write(f'                        MenuOpenCloseHandler : {logtext.count("MenuOpenCloseHandler")} | PlayerControls : {logtext.count("PlayerControls")}\n')
+            output.write(f'                        DXGISwapChain : {logtext.count("DXGISwapChain")}\n')
             Buffout_Trap = True
             statU_Input += 1
         # ===========================================================
         if ("BGSSaveLoadManager" or "BGSSaveLoadThread" or "BGSSaveFormBuffer") in logtext or ("+0CDAD30" or "+0D09AB7") in buff_error:
-            output.write("Checking for *[Bad INI Crash].............DETECTED!")
-            output.write(f'> Priority : [5] | BGSSaveLoadManager : {logtext.count("BGSSaveLoadManager")} | BGSSaveLoadThread : {logtext.count("BGSSaveLoadThread")}')
-            output.write(f'                        BGSSaveFormBuffer : {logtext.count("BGSSaveFormBuffer")}')
+            output.write("Checking for *[Bad INI Crash].............DETECTED!\n")
+            output.write(f'> Priority : [5] | BGSSaveLoadManager : {logtext.count("BGSSaveLoadManager")} | BGSSaveLoadThread : {logtext.count("BGSSaveLoadThread")}\n')
+            output.write(f'                        BGSSaveFormBuffer : {logtext.count("BGSSaveFormBuffer")}\n')
             Buffout_Trap = True
             statU_INI += 1
         # ===========================================================
         if ("BGSProcedurePatrol" or "BGSProcedurePatrolExecState" or "PatrolActorPackageData") in logtext:
-            output.write("Checking for *[NPC Patrol Crash]..........DETECTED!")
-            output.write(f'> Priority : [5] | BGSProcedurePatrol : {logtext.count("BGSProcedurePatrol")} | BGSProcedurePatrolExecStatel : {logtext.count("BGSProcedurePatrolExecState")}')
-            output.write(f'                        PatrolActorPackageData : {logtext.count("PatrolActorPackageData")}')
+            output.write("Checking for *[NPC Patrol Crash]..........DETECTED!\n")
+            output.write(f'> Priority : [5] | BGSProcedurePatrol : {logtext.count("BGSProcedurePatrol")} | BGSProcedurePatrolExecStatel : {logtext.count("BGSProcedurePatrolExecState")}\n')
+            output.write(f'                        PatrolActorPackageData : {logtext.count("PatrolActorPackageData")}\n')
             Buffout_Trap = True
             statU_Patrol += 1
         # ===========================================================
         if ("BSPackedCombinedGeomDataExtra" or "BGSCombinedCellGeometryDB" or "BGSStaticCollection" or "TESObjectCELL") in logtext:
-            output.write("Checking for *[Precombines Crash].........DETECTED!")
-            output.write(f'> Priority : [5] | BGSStaticCollection : {logtext.count("BGSStaticCollection")} | BGSCombinedCellGeometryDB : {logtext.count("BGSCombinedCellGeometryDB")}')
-            output.write(f'                        BSPackedCombinedGeomDataExtra : {logtext.count("BSPackedCombinedGeomDataExtra")} | TESObjectCELL : {logtext.count("TESObjectCELL")}')
+            output.write("Checking for *[Precombines Crash].........DETECTED!\n")
+            output.write(f'> Priority : [5] | BGSStaticCollection : {logtext.count("BGSStaticCollection")} | BGSCombinedCellGeometryDB : {logtext.count("BGSCombinedCellGeometryDB")}\n')
+            output.write(f'                        BSPackedCombinedGeomDataExtra : {logtext.count("BSPackedCombinedGeomDataExtra")} | TESObjectCELL : {logtext.count("TESObjectCELL")}\n')
             Buffout_Trap = True
             statU_Precomb += 1
         # ===========================================================
         if "HUDAmmoCounter" in logtext:
-            output.write("Checking for *[Ammo Counter Crash]........DETECTED!")
-            output.write(f'> Priority : [5] | HUDAmmoCounter : {logtext.count("HUDAmmoCounter")}')
+            output.write("Checking for *[Ammo Counter Crash]........DETECTED!\n")
+            output.write(f'> Priority : [5] | HUDAmmoCounter : {logtext.count("HUDAmmoCounter")}\n')
             Buffout_Trap = True
             statU_HUDAmmo += 1
         # ===========================================================
         if ("BGSProjectile" or "CombatProjectileAimController") in logtext:
-            output.write("Checking for *[NPC Projectile Crash].....DETECTED!")
-            output.write(f'> Priority : [5] | BGSProjectile : {logtext.count("BGSProjectile")} | CombatProjectileAimController : {logtext.count("CombatProjectileAimController")}')
+            output.write("Checking for *[NPC Projectile Crash].....DETECTED!\n")
+            output.write(f'> Priority : [5] | BGSProjectile : {logtext.count("BGSProjectile")} | CombatProjectileAimController : {logtext.count("CombatProjectileAimController")}\n')
             Buffout_Trap = True
         # ===========================================================
         if logtext.count("PlayerCharacter") >= 1 and (logtext.count("0x00000007") or logtext.count("0x00000014") or logtext.count("0x00000008")) >= 3:
-            output.write("Checking for *[Player Character Crash]....DETECTED!")
-            output.write(f'> Priority : [5] | PlayerCharacter : {logtext.count("PlayerCharacter")} | 0x00000007 : {logtext.count("0x00000007")}')
-            output.write(f'                        0x00000008 : {logtext.count("0x00000008")} | 0x000000014 : {logtext.count("0x00000014")}')
+            output.write("Checking for *[Player Character Crash]....DETECTED!\n")
+            output.write(f'> Priority : [5] | PlayerCharacter : {logtext.count("PlayerCharacter")} | 0x00000007 : {logtext.count("0x00000007")}\n')
+            output.write(f'                        0x00000008 : {logtext.count("0x00000008")} | 0x000000014 : {logtext.count("0x00000014")}\n')
             Buffout_Trap = True
             statU_Player += 1
 
         # ===========================================================
 
         if Buffout_Trap == False:  # DEFINE CHECK IF NOTHING TRIGGERED BUFFOUT TRAP
-            output.write("-----")
-            output.write("# AUTOSCAN FOUND NO CRASH ERRORS / CULPRITS THAT MATCH THE CURRENT DATABASE #")
-            output.write("Check below for mods that can cause frequent crashes and other problems.")
-            output.write("-----")
+            output.write("-----\n")
+            output.write("# AUTOSCAN FOUND NO CRASH ERRORS / CULPRITS THAT MATCH THE CURRENT DATABASE #\n")
+            output.write("Check below for mods that can cause frequent crashes and other problems.\n")
+            output.write("-----\n")
         else:
-            output.write("-----")
-            output.write("FOR DETAILED DESCRIPTIONS AND POSSIBLE SOLUTIONS TO ANY ABOVE DETECTED CRASH CULPRITS,")
-            output.write("SEE: https://docs.google.com/document/d/17FzeIMJ256xE85XdjoPvv_Zi3C5uHeSTQh6wOZugs4c")
-            output.write("-----")
+            output.write("-----\n")
+            output.write("FOR DETAILED DESCRIPTIONS AND POSSIBLE SOLUTIONS TO ANY ABOVE DETECTED CRASH CULPRITS,\n")
+            output.write("SEE: https://docs.google.com/document/d/17FzeIMJ256xE85XdjoPvv_Zi3C5uHeSTQh6wOZugs4c\n")
+            output.write("-----\n")
 
-        
-        output.write("====================================================")
-        output.write("CHECKING FOR MODS THAT CAN CAUSE FREQUENT CRASHES...")
-        output.write("====================================================")
+        output.write("====================================================\n")
+        output.write("CHECKING FOR MODS THAT CAN CAUSE FREQUENT CRASHES...\n")
+        output.write("====================================================\n")
         Mod_Trap1 = 1
 
         # Why lists and not dictionaries? So I can preserve alphabetical order in code and
@@ -864,60 +863,60 @@ for file in logs:
                 for elem in List_Mods1:
                     if "File:" not in line and "[FE" not in line and elem in line:
                         order_elem = List_Mods1.index(elem)
-                        output.write(f"[!] Found:{line[0:5].strip()} {List_Warn1[order_elem]}")
-                        output.write("-----")
+                        output.write(f"[!] Found: {line[0:5].strip()} {List_Warn1[order_elem]}\n")
+                        output.write("-----\n")
                         Mod_Trap1 = 0
                     elif "File:" not in line and "[FE" in line and elem in line:
                         order_elem = List_Mods1.index(elem)
-                        output.write(f"[!] Found:{line[0:9].strip()} {List_Warn1[order_elem]}")
-                        output.write("-----")
+                        output.write(f"[!] Found: {line[0:9].strip()} {List_Warn1[order_elem]}\n")
+                        output.write("-----\n")
                         Mod_Trap1 = 0
 
             if logtext.count("ClassicHolsteredWeapons") >= 3 or "ClassicHolsteredWeapons" in buff_error:
-                output.write("[!] Found: CLASSIC HOLSTERED WEAPONS")
-                output.write("AUTOSCAN IS PRETTY CERTAIN THAT CHW CAUSED THIS CRASH!")
-                output.write("You should disable CHW to further confirm this.")
-                output.write("Visit the main crash logs article for additional solutions.")
-                output.write("-----")
+                output.write("[!] Found: CLASSIC HOLSTERED WEAPONS\n")
+                output.write("AUTOSCAN IS PRETTY CERTAIN THAT CHW CAUSED THIS CRASH!\n")
+                output.write("You should disable CHW to further confirm this.\n")
+                output.write("Visit the main crash logs article for additional solutions.\n")
+                output.write("-----\n")
                 statM_CHW += 1
                 Mod_Trap1 = 0
                 Buffout_Trap = True
             elif logtext.count("ClassicHolsteredWeapons") >= 2 and ("UniquePlayer.esp" or "HHS.dll" or "cbp.dll" or "Body.nif") in logtext:
-                output.write("[!] Found: CLASSIC HOLSTERED WEAPONS")
-                output.write("AUTOSCAN ALSO DETECTED ONE OR SEVERAL MODS THAT WILL CRASH WITH CHW.")
-                output.write("You should disable CHW to further confirm it caused this crash.")
-                output.write("Visit the main crash logs article for additional solutions.")
-                output.write("-----")
+                output.write("[!] Found: CLASSIC HOLSTERED WEAPONS\n")
+                output.write("AUTOSCAN ALSO DETECTED ONE OR SEVERAL MODS THAT WILL CRASH WITH CHW.\n")
+                output.write("You should disable CHW to further confirm it caused this crash.\n")
+                output.write("Visit the main crash logs article for additional solutions.\n")
+                output.write("-----\n")
                 statM_CHW += 1
                 Mod_Trap1 = 0
                 Buffout_Trap = True
             elif "ClassicHolsteredWeapons" in logtext and "d3d11" in buff_error:
-                output.write("[!] Found: CLASSIC HOLSTERED WEAPONS, BUT...")
-                output.write("AUTOSCAN CANNOT ACCURATELY DETERMINE IF CHW CAUSED THIS CRASH OR NOT.")
-                output.write("You should open CHW's ini file and change IsHolsterVisibleOnNPCs to 0.")
-                output.write("This usually prevents most common crashes with Classic Holstered Weapons.")
-                output.write("-----")
+                output.write("[!] Found: CLASSIC HOLSTERED WEAPONS, BUT...\n")
+                output.write("AUTOSCAN CANNOT ACCURATELY DETERMINE IF CHW CAUSED THIS CRASH OR NOT.\n")
+                output.write("You should open CHW's ini file and change IsHolsterVisibleOnNPCs to 0.\n")
+                output.write("This usually prevents most common crashes with Classic Holstered Weapons.\n")
+                output.write("-----\n")
                 Mod_Trap1 = 0
         if "[00]" in logtext and Mod_Trap1 == 0:
-            output.write("# CAUTION: ANY ABOVE DETECTED MODS HAVE A MUCH HIGHER CHANCE TO CRASH YOUR GAME! #")
-            output.write("You can disable any/all of them temporarily to confirm they caused this crash.")
-            output.write("-----")
+            output.write("# CAUTION: ANY ABOVE DETECTED MODS HAVE A MUCH HIGHER CHANCE TO CRASH YOUR GAME! #\n")
+            output.write("You can disable any/all of them temporarily to confirm they caused this crash.\n")
+            output.write("-----\n")
             statL_scanned += 1
         elif "[00]" in logtext and Mod_Trap1 == 1:
-            output.write("# AUTOSCAN FOUND NO PROBLEMATIC MODS THAT MATCH THE CURRENT DATABASE FOR THIS LOG #")
-            output.write("THAT DOESN'T MEAN THERE AREN'T ANY! YOU SHOULD RUN PLUGIN CHECKER IN WRYE BASH.")
-            output.write("Wrye Bash Link: https://www.nexusmods.com/fallout4/mods/20032?tab=files")
-            output.write("-----")
+            output.write("# AUTOSCAN FOUND NO PROBLEMATIC MODS THAT MATCH THE CURRENT DATABASE FOR THIS LOG #\n")
+            output.write("THAT DOESN'T MEAN THERE AREN'T ANY! YOU SHOULD RUN PLUGIN CHECKER IN WRYE BASH.\n")
+            output.write("Wrye Bash Link: https://www.nexusmods.com/fallout4/mods/20032?tab=files\n")
+            output.write("-----\n")
             statL_scanned += 1
         elif not "[00]" in logtext:
-            output.write("# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #")
-            output.write("Autoscan cannot continue. Try scanning a different crash log.")
-            output.write("-----")
+            output.write("# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #\n")
+            output.write("Autoscan cannot continue. Try scanning a different crash log.\n")
+            output.write("-----\n")
             statL_incomplete += 1
 
-        output.write("====================================================")
-        output.write("CHECKING FOR MODS WITH SOLUTIONS & COMMUNITY PATCHES")
-        output.write("====================================================")
+        output.write("====================================================\n")
+        output.write("CHECKING FOR MODS WITH SOLUTIONS & COMMUNITY PATCHES\n")
+        output.write("====================================================\n")
         Mod_Trap2 = no_repeat1 = no_repeat2 = 1  # MOD TRAP 2 | NEED 8 SPACES FOR ESL [FE:XXX]
 
         # Needs 1 empty space as prefix to prevent duplicates.
@@ -1099,55 +1098,55 @@ for file in logs:
                 for elem in List_Mods2:
                     if "File:" not in line and "[FE" not in line and elem in line:
                         order_elem = List_Mods2.index(elem)
-                        output.write(f"[!] Found:{line[0:5].strip()} {List_Warn2[order_elem]}")
-                        output.write("-----")
+                        output.write(f"[!] Found: {line[0:5].strip()} {List_Warn2[order_elem]}\n")
+                        output.write("-----\n")
                         Mod_Trap2 = 0
                     elif "File:" not in line and "[FE" in line and elem in line:
                         order_elem = List_Mods2.index(elem)
-                        output.write(f"[!] Found:{line[0:9].strip()} {List_Warn2[order_elem]}")
-                        output.write("-----")
+                        output.write(f"[!] Found: {line[0:9].strip()} {List_Warn2[order_elem]}\n")
+                        output.write("-----\n")
                         Mod_Trap2 = 0
                 if no_repeat1 == 1 and "File:" not in line and ("Depravity" or "FusionCityRising" or "HotC" or "OutcastsAndRemnants" or "ProjectValkyrie") in line:
-                    output.write(f"[!] Found:{line[0:9].strip()} THUGGYSMURF QUEST MOD")
-                    output.write("If you have Depravity, Fusion City Rising, HOTC, Outcasts and Remnants and/or Project Valkyrie")
-                    output.write("install this patch with facegen data, fully generated precomb/previs data and several tweaks.")
-                    output.write("Patch Link: https://www.nexusmods.com/fallout4/mods/56876?tab=files")
-                    output.write("-----")
+                    output.write(f"[!] Found: {line[0:9].strip()} THUGGYSMURF QUEST MOD\n")
+                    output.write("If you have Depravity, Fusion City Rising, HOTC, Outcasts and Remnants and/or Project Valkyrie\n")
+                    output.write("install this patch with facegen data, fully generated precomb/previs data and several tweaks.\n")
+                    output.write("Patch Link: https://www.nexusmods.com/fallout4/mods/56876?tab=files\n")
+                    output.write("-----\n")
                     no_repeat1 = Mod_Trap2 = 0
                 if no_repeat1 == 1 and "File:" not in line and ("CaN.esm" or "AnimeRace_Nanako.esp") in line:
-                    output.write(f"[!] Found:{line[0:9].strip()} CUSTOM RACE SKELETON MOD")
-                    output.write("If you have AnimeRace NanakoChan or Crimes Against Nature, install the Race Skeleton Fixes.")
-                    output.write("Skeleton Fixes Link (READ THE DESCRIPTION): https://www.nexusmods.com/fallout4/mods/56101")
+                    output.write(f"[!] Found: {line[0:9].strip()} CUSTOM RACE SKELETON MOD\n")
+                    output.write("If you have AnimeRace NanakoChan or Crimes Against Nature, install the Race Skeleton Fixes.\n")
+                    output.write("Skeleton Fixes Link (READ THE DESCRIPTION): https://www.nexusmods.com/fallout4/mods/56101\n")
                     no_repeat2 = Mod_Trap2 = 0
 
             if "FallSouls.dll" in logtext:
-                output.write("[!] Found: FALLSOULS UNPAUSED GAME MENUS")
-                output.write("Occasionally breaks the Quests menu, can cause crashes while changing MCM settings.")
-                output.write("Advised Fix: Toggle PipboyMenu in FallSouls MCM settings or completely reinstall the mod.")
-                output.write("-----")
+                output.write("[!] Found: FALLSOULS UNPAUSED GAME MENUS\n")
+                output.write("Occasionally breaks the Quests menu, can cause crashes while changing MCM settings.\n")
+                output.write("Advised Fix: Toggle PipboyMenu in FallSouls MCM settings or completely reinstall the mod.\n")
+                output.write("-----\n")
                 Mod_Trap2 = 0
 
         # inherentlimitations= "[Due to inherent limitations, Auto-Scan will continue detecting certain mods\neven if fixes or patches for them are already installed. You can ignore these.]\n-----"
 
-        nopluginlist = "# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #\nAutoscan cannot continue. Try scanning a different crash log.\n-----"
+        nopluginlist = "# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #\nAutoscan cannot continue. Try scanning a different crash log.\n-----\n"
         if "[00]" in logtext and Mod_Trap2 == 0:
-            output.write("[Due to inherent limitations, Auto-Scan will continue detecting certain mods")
-            output.write("even if fixes or patches for them are already installed. You can ignore these.]")
-            output.write("-----")
+            output.write("[Due to inherent limitations, Auto-Scan will continue detecting certain mods\n")
+            output.write("even if fixes or patches for them are already installed. You can ignore these.]\n")
+            output.write("-----\n")
 
         elif "[00]" in logtext and Mod_Trap2 == 1:
-            output.write("# AUTOSCAN FOUND NO PROBLEMATIC MODS WITH SOLUTIONS AND COMMUNITY PATCHES #")
-            output.write("-----")
+            output.write("# AUTOSCAN FOUND NO PROBLEMATIC MODS WITH SOLUTIONS AND COMMUNITY PATCHES #\n")
+            output.write("-----\n")
         elif logtext.count("[00]") == 0:
             output.write(nopluginlist)
 
-        output.write("FOR FULL LIST OF IMPORTANT PATCHES AND FIXES FOR THE BASE GAME AND MODS,")
-        output.write("VISIT THIS ARTICLE: https://www.nexusmods.com/fallout4/articles/3769")
-        output.write("-----")
+        output.write("FOR FULL LIST OF IMPORTANT PATCHES AND FIXES FOR THE BASE GAME AND MODS,\n")
+        output.write("VISIT THIS ARTICLE: https://www.nexusmods.com/fallout4/articles/3769\n")
+        output.write("-----\n")
 
-        output.write("====================================================")
-        output.write("CHECKING FOR MODS PATCHED THROUGH OPC INSTALLER...")
-        output.write("====================================================")
+        output.write("====================================================\n")
+        output.write("CHECKING FOR MODS PATCHED THROUGH OPC INSTALLER...\n")
+        output.write("====================================================\n")
         Mod_Trap3 = 1  # MOD TRAP 3 | NEED 8 SPACES FOR ESL [FE:XXX]
 
         # Needs 1 empty space as prefix to prevent duplicates.
@@ -1228,28 +1227,28 @@ for file in logs:
                 for elem in List_Mods3:
                     if "File:" not in line and "[FE" not in line and elem in line:
                         order_elem = List_Mods3.index(elem)
-                        output.write(f"- Found:{line[0:5].strip()} {List_Warn3[order_elem]}")
+                        output.write(f"- Found: {line[0:5].strip()} {List_Warn3[order_elem]}\n")
                         Mod_Trap3 = 0
                     elif "File:" not in line and "[FE" in line and elem in line:
                         order_elem = List_Mods3.index(elem)
-                        output.write(f"- Found:{line[0:9].strip()} {List_Warn3[order_elem]}")
+                        output.write(f"- Found: {line[0:9].strip()} {List_Warn3[order_elem]}\n")
                         Mod_Trap3 = 0
         if "[00]" in logtext and Mod_Trap3 == 0:
-            output.write("-----")
-            output.write("FOR PATCH REPOSITORY THAT PREVENTS CRASHES AND FIXES PROBLEMS IN THESE AND OTHER MODS,")
-            output.write("VISIT OPTIMIZATION PATCHES COLLECTION: https://www.nexusmods.com/fallout4/mods/54872")
-            output.write("-----")
+            output.write("-----\n")
+            output.write("FOR PATCH REPOSITORY THAT PREVENTS CRASHES AND FIXES PROBLEMS IN THESE AND OTHER MODS,\n")
+            output.write("VISIT OPTIMIZATION PATCHES COLLECTION: https://www.nexusmods.com/fallout4/mods/54872\n")
+            output.write("-----\n")
         elif "[00]" in logtext and Mod_Trap3 == 1:
-            output.write("# AUTOSCAN FOUND NO PROBLEMATIC MODS THAT ARE ALREADY PATCHED THROUGH OPC INSTALLER #")
-            output.write("-----")
+            output.write("# AUTOSCAN FOUND NO PROBLEMATIC MODS THAT ARE ALREADY PATCHED THROUGH OPC INSTALLER #\n")
+            output.write("-----\n")
         elif logtext.count("[00]") == 0:
             output.write(nopluginlist)
 
         # ===========================================================
 
-        output.write("====================================================")
-        output.write("CHECKING IF IMPORTANT PATCHES & FIXES ARE INSTALLED")
-        output.write("====================================================")
+        output.write("====================================================\n")
+        output.write("CHECKING IF IMPORTANT PATCHES & FIXES ARE INSTALLED\n")
+        output.write("====================================================\n")
 
         gpu_amd = False
         gpu_nvidia = False
@@ -1261,104 +1260,104 @@ for file in logs:
                 gpu_amd = True
                 break
 
-        output.write("IF YOU'RE USING DYNAMIC PERFORMANCE TUNER AND/OR LOAD ACCELERATOR,")
-        output.write("remove these mods completely and switch to High FPS Physics Fix!")
-        output.write("Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files")
-        output.write("-----")
+        output.write("IF YOU'RE USING DYNAMIC PERFORMANCE TUNER AND/OR LOAD ACCELERATOR,\n")
+        output.write("remove these mods completely and switch to High FPS Physics Fix!\n")
+        output.write("Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files\n")
+        output.write("-----\n")
 
         if CLAS_config.getboolean("MAIN", "FCX Mode") == True:
-            output.write("* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *")
-            output.write("[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]")
-            output.write("-----")
+            output.write("* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *\n")
+            output.write("[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]\n")
+            output.write("-----\n")
 
             if info.VR_EXE.is_file() and info.VR_Buffout.is_file():
-                output.write("*Buffout 4 VR Version* is (manually) installed. \n-----")
+                output.write("*Buffout 4 VR Version* is (manually) installed. \n-----\n")
             elif info.VR_EXE.is_file() and not info.VR_Buffout.is_file():
-                output.write("# BUFFOUT 4 FOR VR VERSION ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-                output.write("# This is a mandatory Buffout 4 port for the VR Version of Fallout 4.")
-                output.write("Link: https://www.nexusmods.com/fallout4/mods/64880?tab=files")
+                output.write("# BUFFOUT 4 FOR VR VERSION ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #\n")
+                output.write("# This is a mandatory Buffout 4 port for the VR Version of Fallout 4.\n")
+                output.write("Link: https://www.nexusmods.com/fallout4/mods/64880?tab=files\n")
 
             if (info.F4CK_EXE.is_file() and os.path.exists(info.F4CK_Fixes)) or Path(info.Game_Path).joinpath("winhttp.dll").is_file():
-                output.write("*Creation Kit Fixes* is (manually) installed. \n-----")
+                output.write("*Creation Kit Fixes* is (manually) installed. \n-----\n")
             elif info.F4CK_EXE.is_file() and not os.path.exists(info.F4CK_Fixes):
-                output.write("# CREATION KIT FIXES ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-                output.write("This is a highly recommended patch for the Fallout 4 Creation Kit.")
-                output.write("Link: https://www.nexusmods.com/fallout4/mods/51165?tab=files")
-                output.write("-----")
+                output.write("# CREATION KIT FIXES ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #\n")
+                output.write("This is a highly recommended patch for the Fallout 4 Creation Kit.\n")
+                output.write("Link: https://www.nexusmods.com/fallout4/mods/51165?tab=files\n")
+                output.write("-----\n")
 
         if "[00]" in logtext:
             if any("CanarySaveFileMonitor" in elem for elem in plugin_list):
-                output.write("*Canary Save File Monitor* is installed. \n-----")
+                output.write("*Canary Save File Monitor* is installed. \n-----\n")
             else:
-                output.write("# CANARY SAVE FILE MONITOR ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-                output.write("This is a highly recommended mod that can detect save file corrpution.")
-                output.write("Link: https://www.nexusmods.com/fallout4/mods/44949?tab=files")
-                output.write("-----")
+                output.write("# CANARY SAVE FILE MONITOR ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #\n")
+                output.write("This is a highly recommended mod that can detect save file corrpution.\n")
+                output.write("Link: https://www.nexusmods.com/fallout4/mods/44949?tab=files\n")
+                output.write("-----\n")
 
             if "HighFPSPhysicsFix.dll" in logtext:
-                output.write("*High FPS Physics Fix* is installed. \n-----")
+                output.write("*High FPS Physics Fix* is installed. \n-----\n")
             else:
-                output.write("# HIGH FPS PHYSICS FIX ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-                output.write("This is a mandatory patch / fix that prevents game engine problems.")
-                output.write("Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files")
-                output.write("-----")
+                output.write("# HIGH FPS PHYSICS FIX ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #\n")
+                output.write("This is a mandatory patch / fix that prevents game engine problems.\n")
+                output.write("Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files\n")
+                output.write("-----\n")
 
             if any("PPF.esm" in elem for elem in plugin_list):
-                output.write("*Previs Repair Pack* is installed. \n-----")
+                output.write("*Previs Repair Pack* is installed. \n-----\n")
             else:
-                output.write("# PREVIS REPAIR PACK ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-                output.write("This is a highly recommended mod that can improve performance.")
-                output.write("Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files")
-                output.write("-----")
+                output.write("# PREVIS REPAIR PACK ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #\n")
+                output.write("This is a highly recommended mod that can improve performance.\n")
+                output.write("Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files\n")
+                output.write("-----\n")
 
             if any("Unofficial Fallout 4 Patch.esp" in elem for elem in plugin_list):
-                output.write("*Unofficial Fallout 4 Patch* is installed. \n-----")
+                output.write("*Unofficial Fallout 4 Patch* is installed. \n-----\n")
             else:
-                output.write("# UNOFFICIAL FALLOUT 4 PATCH ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-                output.write("If you own all DLCs, make sure that the Unofficial Patch is installed.")
-                output.write("Link: https://www.nexusmods.com/fallout4/mods/4598?tab=files")
-                output.write("-----")
+                output.write("# UNOFFICIAL FALLOUT 4 PATCH ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #\n")
+                output.write("If you own all DLCs, make sure that the Unofficial Patch is installed.\n")
+                output.write("Link: https://www.nexusmods.com/fallout4/mods/4598?tab=files\n")
+                output.write("-----\n")
 
             if "vulkan-1.dll" in logtext and gpu_amd:
-                output.write("Vulkan Renderer is installed. \n-----")
+                output.write("Vulkan Renderer is installed. \n-----\n")
             elif logtext.count("vulkan-1.dll") == 0 and gpu_amd and not gpu_nvidia:
-                output.write("# VULKAN RENDERER ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-                output.write("This is a highly recommended mod that can improve performance on AMD GPUs.")
-                output.write("-----")
-                output.write("Installation steps can be found in 'How To Read Crash Logs' PDF / Document.")
-                output.write("Link: https://www.nexusmods.com/fallout4/mods/48053?tab=files")
-                output.write("-----")
+                output.write("# VULKAN RENDERER ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #\n")
+                output.write("This is a highly recommended mod that can improve performance on AMD GPUs.\n")
+                output.write("-----\n")
+                output.write("Installation steps can be found in 'How To Read Crash Logs' PDF / Document.\n")
+                output.write("Link: https://www.nexusmods.com/fallout4/mods/48053?tab=files\n")
+                output.write("-----\n")
 
             if "WeaponDebrisCrashFix.dll" in logtext and gpu_nvidia:
-                output.write("*Weapon Debris Crash Fix* is installed. \n-----")
+                output.write("*Weapon Debris Crash Fix* is installed. \n-----\n")
             elif "WeaponDebrisCrashFix.dll" in logtext and not gpu_nvidia and gpu_amd:
-                output.write("*Weapon Debris Crash Fix* is installed, but...")
-                output.write("# YOU DON'T HAVE AN NVIDIA GPU OR BUFFOUT 4 CANNOT DETECT YOUR GPU MODEL #")
-                output.write("Weapon Debris Crash Fix is only required for Nvidia GPUs (NOT AMD / OTHER)")
-                output.write("-----")
+                output.write("*Weapon Debris Crash Fix* is installed, but...\n")
+                output.write("# YOU DON'T HAVE AN NVIDIA GPU OR BUFFOUT 4 CANNOT DETECT YOUR GPU MODEL #\n")
+                output.write("Weapon Debris Crash Fix is only required for Nvidia GPUs (NOT AMD / OTHER)\n")
+                output.write("-----\n")
             if not "WeaponDebrisCrashFix.dll" in logtext and gpu_nvidia:
-                output.write("# WEAPON DEBRIS CRASH FIX ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-                output.write("This is a mandatory patch / fix for players with Nvidia graphics cards.")
-                output.write("Link: https://www.nexusmods.com/fallout4/mods/48078?tab=files")
-                output.write("-----")
+                output.write("# WEAPON DEBRIS CRASH FIX ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #\n")
+                output.write("This is a mandatory patch / fix for players with Nvidia graphics cards.\n")
+                output.write("Link: https://www.nexusmods.com/fallout4/mods/48078?tab=files\n")
+                output.write("-----\n")
 
             if "NVIDIA_Reflex.dll" in logtext and gpu_nvidia:
-                output.write("*Nvidia Reflex Support* is installed. \n-----")
+                output.write("*Nvidia Reflex Support* is installed. \n-----\n")
             elif "NVIDIA_Reflex.dll" in logtext and not gpu_nvidia and gpu_amd:
-                output.write("*Nvidia Reflex Support* is installed, but...")
-                output.write("# YOU DON'T HAVE AN NVIDIA GPU OR BUFFOUT 4 CANNOT DETECT YOUR GPU MODEL #")
-                output.write("Nvidia Reflex Support is only required for Nvidia GPUs (NOT AMD / OTHER)")
-                output.write("-----")
+                output.write("*Nvidia Reflex Support* is installed, but...\n")
+                output.write("# YOU DON'T HAVE AN NVIDIA GPU OR BUFFOUT 4 CANNOT DETECT YOUR GPU MODEL #\n")
+                output.write("Nvidia Reflex Support is only required for Nvidia GPUs (NOT AMD / OTHER)\n")
+                output.write("-----\n")
             if not "NVIDIA_Reflex.dll" in logtext and gpu_nvidia:
-                output.write("# NVIDIA REFLEX SUPPORT ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-                output.write("This is a highly recommended mod that can reduce render latency.")
-                output.write("Link: https://www.nexusmods.com/fallout4/mods/64459?tab=files")
-                output.write("-----")
+                output.write("# NVIDIA REFLEX SUPPORT ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #\n")
+                output.write("This is a highly recommended mod that can reduce render latency.\n")
+                output.write("Link: https://www.nexusmods.com/fallout4/mods/64459?tab=files\n")
+                output.write("-----\n")
         else:
             output.write(nopluginlist)
-        output.write("====================================================")
-        output.write("SCANNING THE LOG FOR SPECIFIC (POSSIBLE) CUPLRITS...")
-        output.write("====================================================")
+        output.write("====================================================\n")
+        output.write("SCANNING THE LOG FOR SPECIFIC (POSSIBLE) CUPLRITS...\n")
+        output.write("====================================================\n")
 
         list_DETPLUGINS = []
         list_DETFORMIDS = []
@@ -1366,9 +1365,9 @@ for file in logs:
         list_ALLPLUGINS = []
 
         if not "f4se_1_10_163.dll" in logtext and "steam_api64.dll" in logtext:
-            output.write("AUTOSCAN CANNOT FIND FALLOUT 4 SCRIPT EXTENDER DLL!")
-            output.write("MAKE SURE THAT F4SE IS CORRECTLY INSTALLED!")
-            output.write("Link: https://f4se.silverlock.org")
+            output.write("AUTOSCAN CANNOT FIND FALLOUT 4 SCRIPT EXTENDER DLL!\n")
+            output.write("MAKE SURE THAT F4SE IS CORRECTLY INSTALLED!\n")
+            output.write("Link: https://f4se.silverlock.org\n")
             output.write("-----")
 
         for line in loglines:
@@ -1381,7 +1380,7 @@ for file in logs:
             if len(line) >= 11 and "]" in line[9]:
                 list_ALLPLUGINS.append(line.strip())
 
-        output.write("LIST OF (POSSIBLE) PLUGIN CULRIPTS:")
+        output.write("LIST OF (POSSIBLE) PLUGIN CULRIPTS:\n")
         for line in loglines:
             if "File:" in line:
                 line = line.replace("File: ", "")
@@ -1408,17 +1407,17 @@ for file in logs:
                 output.write(f"- {' '.join(PL_matches)}")
 
         if not PL_result:
-            output.write("* AUTOSCAN COULDN'T FIND ANY PLUGIN CULRIPTS *")
-            output.write("-----")
+            output.write("* AUTOSCAN COULDN'T FIND ANY PLUGIN CULRIPTS *\n")
+            output.write("-----\n")
         else:
-            output.write("-----")
-            output.write("These Plugins were caught by Buffout 4 and some of them might be responsible for this crash.")
-            output.write("You can try disabling these plugins and recheck your game, though this method can be unreliable.")
-            output.write("-----")
+            output.write("-----\n")
+            output.write("These Plugins were caught by Buffout 4 and some of them might be responsible for this crash.\n")
+            output.write("You can try disabling these plugins and recheck your game, though this method can be unreliable.\n")
+            output.write("-----\n")
 
         # ===========================================================
 
-        output.write("LIST OF (POSSIBLE) FORM ID CULRIPTS:")
+        output.write("LIST OF (POSSIBLE) FORM ID CULRIPTS:\n")
         for line in loglines:
             if "Form ID:" in line and not "0xFF" in line:
                 line = line.replace("0x", "")
@@ -1439,25 +1438,25 @@ for file in logs:
                 else:
                     list_DETFORMIDS.append(line.strip())
 
-            list_DETFORMIDS = list(dict.fromkeys(list_DETFORMIDS))
-            for elem in list_DETFORMIDS:
-                output.write(elem)
+                list_DETFORMIDS = list(dict.fromkeys(list_DETFORMIDS))
+                for elem in list_DETFORMIDS:
+                    output.write(f"{elem}\n")
 
-            if not list_DETFORMIDS:
-                output.write("* AUTOSCAN COULDN'T FIND ANY FORM ID CULRIPTS *")
-                output.write("-----")
+        if not list_DETFORMIDS:
+            output.write("* AUTOSCAN COULDN'T FIND ANY FORM ID CULRIPTS *\n")
+            output.write("-----\n")
         else:
-            output.write("-----")
-            output.write("These Form IDs were caught by Buffout 4 and some of them might be related to this crash.")
-            output.write("You can try searching any listed Form IDs in FO4Edit and see if they lead to relevant records.")
-            output.write("-----")
+            output.write("-----\n")
+            output.write("These Form IDs were caught by Buffout 4 and some of them might be related to this crash.\n")
+            output.write("You can try searching any listed Form IDs in FO4Edit and see if they lead to relevant records.\n")
+            output.write("-----\n")
 
         # ===========================================================
 
         List_Files = [".bgsm", ".bto", ".btr", ".dds", ".fuz", ".hkb", ".hkx", ".ini", ".nif", ".pex", ".swf", ".txt", ".uvd", ".wav", ".xwm", "data\\*"]
         List_Exclude = ['""', "...", ".esp"]
 
-        output.write("LIST OF DETECTED (NAMED) RECORDS:")
+        output.write("LIST OF DETECTED (NAMED) RECORDS:\n")
         List_Records = []
         for line in loglines:
             if "Name" in line or any(elem in line for elem in List_Files):
@@ -1470,16 +1469,16 @@ for file in logs:
             output.write(elem)
 
         if not List_Records:
-            output.write("* AUTOSCAN COULDN'T FIND ANY NAMED RECORDS *")
-            output.write("-----")
+            output.write("* AUTOSCAN COULDN'T FIND ANY NAMED RECORDS *\n")
+            output.write("-----\n")
         else:
-            output.write("-----")
-            output.write("These records were caught by Buffout 4 and some of them might be related to this crash.")
-            output.write("Named records should give extra information on involved game objects and record types.")
-            output.write("-----")
+            output.write("-----\n")
+            output.write("These records were caught by Buffout 4 and some of them might be related to this crash.\n")
+            output.write("Named records should give extra information on involved game objects and record types.\n")
+            output.write("-----\n")
 
-        output.write("FOR FULL LIST OF MODS THAT CAUSE PROBLEMS, THEIR ALTERNATIVES AND DETAILED SOLUTIONS,")
-        output.write("VISIT THE BUFFOUT 4 CRASH ARTICLE: https://www.nexusmods.com/fallout4/articles/3115")
+        output.write("FOR FULL LIST OF MODS THAT CAUSE PROBLEMS, THEIR ALTERNATIVES AND DETAILED SOLUTIONS,\n")
+        output.write("VISIT THE BUFFOUT 4 CRASH ARTICLE: https://www.nexusmods.com/fallout4/articles/3115\n")
         output.write("===============================================================================")
         output.write(f"END OF AUTOSCAN | Author/Made By: Poet#9800 (DISCORD) | {CLAS_Date}")
 

--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -273,7 +273,7 @@ for file in logs:
         loglines = lines.readlines()
     with scanpath.open("w", encoding='utf-8-sig', errors="ignore") as output:
         output.write(logname)
-        output.write("This crash log was automatically scanned.\n")
+        output.write("\nThis crash log was automatically scanned.\n")
         output.write(f"VER {CLAS_Current[-4:]} | MIGHT CONTAIN FALSE POSITIVES.\n")
         if CLAS_Update == True:
             output.write("# NOTICE: YOU NEED TO UPDATE THE AUTO-SCANNER! #\n")

--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -265,7 +265,7 @@ logs = glob("crash-*.log")  # + glob("crash-*.txt") # For people who just HAVE t
 
 for file in logs:
     logpath = Path(file).resolve()
-    scanpath = logpath.with_suffix("-AUTOSCAN.md")
+    scanpath = Path(str(logpath).replace(".log", "-AUTOSCAN.md"))
     logname = logpath.name
     output = scanpath.open("w", encoding='utf-8-sig', errors="ignore")
     logtext = logpath.read_text()

--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -321,10 +321,9 @@ for file in logs:
 
         # CHECK IF F4SE.LOG EXISTS AND REPORTS ANY ERRORS
         if CLAS_config.getboolean("MAIN", "FCX Mode") == True:
-            output.writelines(["* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *\n",
-                               "[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]\n",
-                               "-----\n"
-                               ])
+            output.write("* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *\n")
+            output.write("[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]\n")
+            output.write("-----\n")
             Error_List = []
             F4SE_Error = F4SE_Version = F4SE_Buffout = 0
             with open(info.FO4_F4SE_Path, "r") as LOG_Check:
@@ -537,7 +536,7 @@ for file in logs:
             statC_Equip += 1
         # ===========================================================
         if (logtext.count("Papyrus") or logtext.count("VirtualMachine")) >= 2:
-            output.writelines("# Checking for Script Crash.................CULPRIT FOUND! #\n")
+            output.write("# Checking for Script Crash.................CULPRIT FOUND! #\n")
             output.write(f'> Priority : [3] | Papyrus : {logtext.count("Papyrus")} | VirtualMachine : {logtext.count("VirtualMachine")}\n')
             Buffout_Trap = True
             statC_Papyrus += 1

--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -931,55 +931,61 @@ for file in logs:
             for elem in List_Mods1:
                 if "File:" not in line and "[FE" not in line and elem in line:
                     order_elem = List_Mods1.index(elem)
-                    print("[!] Found:", line[0:5].strip(), List_Warn1[order_elem])
-                    print("-----")
+                    output.writelines([f"[!] Found:{line[0:5].strip()} {List_Warn1[order_elem]}",
+                                       "-----"])
                     Mod_Trap1 = 0
                 elif "File:" not in line and "[FE" in line and elem in line:
                     order_elem = List_Mods1.index(elem)
-                    print("[!] Found:", line[0:9].strip(), List_Warn1[order_elem])
-                    print("-----")
+                    output.writelines([f"[!] Found:{line[0:9].strip()} {List_Warn1[order_elem]}",
+                    "-----"])
                     Mod_Trap1 = 0
 
         if logtext.count("ClassicHolsteredWeapons") >= 3 or "ClassicHolsteredWeapons" in buff_error:
-            print("[!] Found: CLASSIC HOLSTERED WEAPONS")
-            print("AUTOSCAN IS PRETTY CERTAIN THAT CHW CAUSED THIS CRASH!")
-            print("You should disable CHW to further confirm this.")
-            print("Visit the main crash logs article for additional solutions.")
-            print("-----")
+            output.writelines(["[!] Found: CLASSIC HOLSTERED WEAPONS",
+                               "AUTOSCAN IS PRETTY CERTAIN THAT CHW CAUSED THIS CRASH!",
+                               "You should disable CHW to further confirm this.",
+                               "Visit the main crash logs article for additional solutions.",
+                               "-----"
+                               ])
             statM_CHW += 1
             Mod_Trap1 = 0
             Buffout_Trap = True
         elif logtext.count("ClassicHolsteredWeapons") >= 2 and ("UniquePlayer.esp" or "HHS.dll" or "cbp.dll" or "Body.nif") in logtext:
-            print("[!] Found: CLASSIC HOLSTERED WEAPONS")
-            print("AUTOSCAN ALSO DETECTED ONE OR SEVERAL MODS THAT WILL CRASH WITH CHW.")
-            print("You should disable CHW to further confirm it caused this crash.")
-            print("Visit the main crash logs article for additional solutions.")
-            print("-----")
+            output.writelines(["[!] Found: CLASSIC HOLSTERED WEAPONS",
+                               "AUTOSCAN ALSO DETECTED ONE OR SEVERAL MODS THAT WILL CRASH WITH CHW.",
+                               "You should disable CHW to further confirm it caused this crash.",
+                               "Visit the main crash logs article for additional solutions.",
+                               "-----"
+                               ])
             statM_CHW += 1
             Mod_Trap1 = 0
             Buffout_Trap = True
         elif "ClassicHolsteredWeapons" in logtext and "d3d11" in buff_error:
-            print("[!] Found: CLASSIC HOLSTERED WEAPONS, BUT...")
-            print("AUTOSCAN CANNOT ACCURATELY DETERMINE IF CHW CAUSED THIS CRASH OR NOT.")
-            print("You should open CHW's ini file and change IsHolsterVisibleOnNPCs to 0.")
-            print("This usually prevents most common crashes with Classic Holstered Weapons.")
-            print("-----")
+            output.writelines(["[!] Found: CLASSIC HOLSTERED WEAPONS, BUT...",
+                               "AUTOSCAN CANNOT ACCURATELY DETERMINE IF CHW CAUSED THIS CRASH OR NOT.",
+                               "You should open CHW's ini file and change IsHolsterVisibleOnNPCs to 0.",
+                               "This usually prevents most common crashes with Classic Holstered Weapons.",
+                               "-----"
+                               ])
             Mod_Trap1 = 0
     if "[00]" in logtext and Mod_Trap1 == 0:
-        print("# CAUTION: ANY ABOVE DETECTED MODS HAVE A MUCH HIGHER CHANCE TO CRASH YOUR GAME! #")
-        print("You can disable any/all of them temporarily to confirm they caused this crash.")
-        print("-----")
+        output.writelines(["# CAUTION: ANY ABOVE DETECTED MODS HAVE A MUCH HIGHER CHANCE TO CRASH YOUR GAME! #",
+                           "You can disable any/all of them temporarily to confirm they caused this crash.",
+                           "-----"
+                           ])
         statL_scanned += 1
     elif "[00]" in logtext and Mod_Trap1 == 1:
-        print("# AUTOSCAN FOUND NO PROBLEMATIC MODS THAT MATCH THE CURRENT DATABASE FOR THIS LOG #")
-        print("THAT DOESN'T MEAN THERE AREN'T ANY! YOU SHOULD RUN PLUGIN CHECKER IN WRYE BASH.")
-        print("Wrye Bash Link: https://www.nexusmods.com/fallout4/mods/20032?tab=files")
-        print("-----")
+        output.writelines(["# AUTOSCAN FOUND NO PROBLEMATIC MODS THAT MATCH THE CURRENT DATABASE FOR THIS LOG #",
+                           "THAT DOESN'T MEAN THERE AREN'T ANY! YOU SHOULD RUN PLUGIN CHECKER IN WRYE BASH.",
+                           "Wrye Bash Link: https://www.nexusmods.com/fallout4/mods/20032?tab=files",
+                           "-----"
+                           ])
         statL_scanned += 1
     elif not "[00]" in logtext:
-        print("# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #")
-        print("Autoscan cannot continue. Try scanning a different crash log.")
-        print("-----")
+        output.writelines(["# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #",
+                           "Autoscan cannot continue. Try scanning a different crash log.",
+                           "-----"
+                           ])
         statL_incomplete += 1
 
     print("====================================================")
@@ -1166,52 +1172,65 @@ for file in logs:
             for elem in List_Mods2:
                 if "File:" not in line and "[FE" not in line and elem in line:
                     order_elem = List_Mods2.index(elem)
-                    print("[!] Found:", line[0:5].strip(), List_Warn2[order_elem])
-                    print("-----")
+                    output.writelines([f"[!] Found:{line[0:5].strip()} {List_Warn2[order_elem]}",
+                                       "-----"
+                                       ])
                     Mod_Trap2 = 0
                 elif "File:" not in line and "[FE" in line and elem in line:
                     order_elem = List_Mods2.index(elem)
-                    print("[!] Found:", line[0:9].strip(), List_Warn2[order_elem])
-                    print("-----")
+                    output.writelines([f"[!] Found:{line[0:9].strip()} {List_Warn2[order_elem]}",
+                                      "-----"
+                                      ])
                     Mod_Trap2 = 0
             if no_repeat1 == 1 and "File:" not in line and ("Depravity" or "FusionCityRising" or "HotC" or "OutcastsAndRemnants" or "ProjectValkyrie") in line:
-                print("[!] Found:", line[0:9].strip(), "THUGGYSMURF QUEST MOD")
-                print("If you have Depravity, Fusion City Rising, HOTC, Outcasts and Remnants and/or Project Valkyrie,")
-                print("install this patch with facegen data, fully generated precomb/previs data and several tweaks.")
-                print("Patch Link: https://www.nexusmods.com/fallout4/mods/56876?tab=files")
-                print("-----")
+                output.writelines([f"[!] Found:{line[0:9].strip()} THUGGYSMURF QUEST MOD",
+                                   "If you have Depravity, Fusion City Rising, HOTC, Outcasts and Remnants and/or Project Valkyrie",
+                                   "install this patch with facegen data, fully generated precomb/previs data and several tweaks.",
+                                   "Patch Link: https://www.nexusmods.com/fallout4/mods/56876?tab=files",
+                                   "-----"
+                                   ])
                 no_repeat1 = Mod_Trap2 = 0
             if no_repeat1 == 1 and "File:" not in line and ("CaN.esm" or "AnimeRace_Nanako.esp") in line:
-                print("[!] Found:", line[0:9].strip(), "CUSTOM RACE SKELETON MOD")
-                print("If you have AnimeRace NanakoChan or Crimes Against Nature, install the Race Skeleton Fixes.")
-                print("Skeleton Fixes Link (READ THE DESCRIPTION): https://www.nexusmods.com/fallout4/mods/56101")
+                output.writelines([f"[!] Found:{line[0:9].strip()} CUSTOM RACE SKELETON MOD",
+                                   "If you have AnimeRace NanakoChan or Crimes Against Nature, install the Race Skeleton Fixes.",
+                                   "Skeleton Fixes Link (READ THE DESCRIPTION): https://www.nexusmods.com/fallout4/mods/56101"
+                                   ])
                 no_repeat2 = Mod_Trap2 = 0
 
         if "FallSouls.dll" in logtext:
-            print("[!] Found: FALLSOULS UNPAUSED GAME MENUS")
-            print("Occasionally breaks the Quests menu, can cause crashes while changing MCM settings.")
-            print("Advised Fix: Toggle PipboyMenu in FallSouls MCM settings or completely reinstall the mod.")
-            print("-----")
+            output.writelines(["[!] Found: FALLSOULS UNPAUSED GAME MENUS",
+                               "Occasionally breaks the Quests menu, can cause crashes while changing MCM settings.",
+                               "Advised Fix: Toggle PipboyMenu in FallSouls MCM settings or completely reinstall the mod.",
+                               "-----"
+                               ])
             Mod_Trap2 = 0
+    
+    inherentlimitations = ["[Due to inherent limitations, Auto-Scan will continue detecting certain mods,",
+                           " even if fixes or patches for them are already installed. You can ignore these.]",
+                           "-----"
+                           ]
+    nopluginlist = ["# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #",
+                    "Autoscan cannot continue. Try scanning a different crash log.",
+                    "-----"
+                    ]
     if "[00]" in logtext and Mod_Trap2 == 0:
-        print("[Due to inherent limitations, Auto-Scan will continue detecting certain mods,")
-        print(" even if fixes or patches for them are already installed. You can ignore these.]")
-        print("-----")
+        output.writelines(inherentlimitations)
     elif "[00]" in logtext and Mod_Trap2 == 1:
-        print("# AUTOSCAN FOUND NO PROBLEMATIC MODS WITH SOLUTIONS AND COMMUNITY PATCHES #")
-        print("-----")
+        output.writelines(["# AUTOSCAN FOUND NO PROBLEMATIC MODS WITH SOLUTIONS AND COMMUNITY PATCHES #",
+                           "-----"
+                           ])
     elif logtext.count("[00]") == 0:
-        print("# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #")
-        print("Autoscan cannot continue. Try scanning a different crash log.")
-        print("-----")
+        output.writelines(nopluginlist)
 
-    print("FOR FULL LIST OF IMPORTANT PATCHES AND FIXES FOR THE BASE GAME AND MODS,")
-    print("VISIT THIS ARTICLE: https://www.nexusmods.com/fallout4/articles/3769")
-    print("-----")
+    output.writelines(["FOR FULL LIST OF IMPORTANT PATCHES AND FIXES FOR THE BASE GAME AND MODS,",
+                       "VISIT THIS ARTICLE: https://www.nexusmods.com/fallout4/articles/3769",
+                       "-----"
+                       ])
 
-    print("====================================================")
-    print("CHECKING FOR MODS PATCHED THROUGH OPC INSTALLER...")
-    print("====================================================")
+    output.writelines(["====================================================",
+                       "CHECKING FOR MODS PATCHED THROUGH OPC INSTALLER...",
+                       "===================================================="
+                       ])
     Mod_Trap3 = 1  # MOD TRAP 3 | NEED 8 SPACES FOR ESL [FE:XXX]
 
     # Needs 1 empty space as prefix to prevent duplicates.
@@ -1292,30 +1311,31 @@ for file in logs:
             for elem in List_Mods3:
                 if "File:" not in line and "[FE" not in line and elem in line:
                     order_elem = List_Mods3.index(elem)
-                    print("- Found:", line[0:5].strip(), List_Warn3[order_elem])
+                    output.write(f"- Found:{line[0:5].strip()} {List_Warn3[order_elem]}")
                     Mod_Trap3 = 0
                 elif "File:" not in line and "[FE" in line and elem in line:
                     order_elem = List_Mods3.index(elem)
-                    print("- Found:", line[0:9].strip(), List_Warn3[order_elem])
+                    output.write(f"- Found:{line[0:9].strip()} {List_Warn3[order_elem]}")
                     Mod_Trap3 = 0
     if "[00]" in logtext and Mod_Trap3 == 0:
-        print("-----")
-        print("FOR PATCH REPOSITORY THAT PREVENTS CRASHES AND FIXES PROBLEMS IN THESE AND OTHER MODS,")
-        print("VISIT OPTIMIZATION PATCHES COLLECTION: https://www.nexusmods.com/fallout4/mods/54872")
-        print("-----")
+        output.writelines(["-----",
+                           "FOR PATCH REPOSITORY THAT PREVENTS CRASHES AND FIXES PROBLEMS IN THESE AND OTHER MODS,",
+                           "VISIT OPTIMIZATION PATCHES COLLECTION: https://www.nexusmods.com/fallout4/mods/54872",
+                           "-----"
+                           ])
     elif "[00]" in logtext and Mod_Trap3 == 1:
-        print("# AUTOSCAN FOUND NO PROBLEMATIC MODS THAT ARE ALREADY PATCHED THROUGH OPC INSTALLER #")
-        print("-----")
+        output.writelines(["# AUTOSCAN FOUND NO PROBLEMATIC MODS THAT ARE ALREADY PATCHED THROUGH OPC INSTALLER #",
+                           "-----"
+                           ])
     elif logtext.count("[00]") == 0:
-        print("# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #")
-        print("Autoscan cannot continue. Try scanning a different crash log.")
-        print("-----")
+        output.writelines(nopluginlist)
 
     # ===========================================================
-
-    print("====================================================")
-    print("CHECKING IF IMPORTANT PATCHES & FIXES ARE INSTALLED")
-    print("====================================================")
+    
+    output.writelines(["====================================================",
+                       "CHECKING IF IMPORTANT PATCHES & FIXES ARE INSTALLED"
+                       "===================================================="
+                       ])
 
     gpu_amd = False
     gpu_nvidia = False
@@ -1325,103 +1345,114 @@ for file in logs:
         if "GPU" in line and "AMD" in line:
             gpu_amd = True
 
-    print("IF YOU'RE USING DYNAMIC PERFORMANCE TUNER AND/OR LOAD ACCELERATOR,")
-    print("remove these mods completely and switch to High FPS Physics Fix!")
-    print("Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files")
-    print("-----")
+    output.writelines(["IF YOU'RE USING DYNAMIC PERFORMANCE TUNER AND/OR LOAD ACCELERATOR,",
+                       "remove these mods completely and switch to High FPS Physics Fix!",
+                       "Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files",
+                       "-----"
+                       ])
 
     if CLAS_config.getboolean("MAIN", "FCX Mode") == True:
-        print("* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *")
-        print("[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]")
-        print("-----")
+        output.writelines(["* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *",
+                           "[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]",
+                           "-----"
+                           ])
 
         if info.VR_EXE.is_file() and info.VR_Buffout.is_file():
-            print("*Buffout 4 VR Version* is (manually) installed. \n-----")
+            output.write("*Buffout 4 VR Version* is (manually) installed. \n-----")
         elif info.VR_EXE.is_file() and not info.VR_Buffout.is_file():
-            print("# BUFFOUT 4 FOR VR VERSION ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-            print("# This is a mandatory Buffout 4 port for the VR Version of Fallout 4.")
-            print("Link: https://www.nexusmods.com/fallout4/mods/64880?tab=files")
+            output.writelines(["# BUFFOUT 4 FOR VR VERSION ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
+                               "# This is a mandatory Buffout 4 port for the VR Version of Fallout 4.",
+                               "Link: https://www.nexusmods.com/fallout4/mods/64880?tab=files"
+                               ])
 
         if info.F4CK_EXE.is_file() and os.path.exists(info.F4CK_Fixes):
-            print("*Creation Kit Fixes* is (manually) installed. \n-----")
+            output.write("*Creation Kit Fixes* is (manually) installed. \n-----")
         elif info.F4CK_EXE.is_file() and not os.path.exists(info.F4CK_Fixes):
-            print("# CREATION KIT FIXES ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-            print("This is a highly recommended patch for the Fallout 4 Creation Kit.")
-            print("Link: https://www.nexusmods.com/fallout4/mods/51165?tab=files")
-            print("-----")
+            output.writelines(["# CREATION KIT FIXES ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
+                               "This is a highly recommended patch for the Fallout 4 Creation Kit.",
+                               "Link: https://www.nexusmods.com/fallout4/mods/51165?tab=files",
+                               "-----"
+                               ])
 
     if "[00]" in logtext:
         if any("CanarySaveFileMonitor" in elem for elem in plugin_list):
-            print("*Canary Save File Monitor* is installed. \n-----")
+            output.write("*Canary Save File Monitor* is installed. \n-----")
         else:
-            print("# CANARY SAVE FILE MONITOR ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-            print("This is a highly recommended mod that can detect save file corrpution.")
-            print("Link: https://www.nexusmods.com/fallout4/mods/44949?tab=files")
-            print("-----")
+            output.writelines(["# CANARY SAVE FILE MONITOR ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
+                               "This is a highly recommended mod that can detect save file corrpution.",
+                               "Link: https://www.nexusmods.com/fallout4/mods/44949?tab=files",
+                               "-----"
+                               ])
 
         if "HighFPSPhysicsFix.dll" in logtext:
-            print("*High FPS Physics Fix* is installed. \n-----")
+            output.write("*High FPS Physics Fix* is installed. \n-----")
         else:
-            print("# HIGH FPS PHYSICS FIX ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-            print("This is a mandatory patch / fix that prevents game engine problems.")
-            print("Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files")
-            print("-----")
+            output.writelines(["# HIGH FPS PHYSICS FIX ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
+                               "This is a mandatory patch / fix that prevents game engine problems.",
+                               "Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files",
+                               "-----"
+                               ])
 
         if any("PPF.esm" in elem for elem in plugin_list):
-            print("*Previs Repair Pack* is installed. \n-----")
+            output.write("*Previs Repair Pack* is installed. \n-----")
         else:
-            print("# PREVIS REPAIR PACK ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-            print("This is a highly recommended mod that can improve performance.")
-            print("Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files")
-            print("-----")
+            output.writelines(["# PREVIS REPAIR PACK ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
+                               "This is a highly recommended mod that can improve performance.",
+                               "Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files",
+                               "-----"
+                               ])
 
         if any("Unofficial Fallout 4 Patch.esp" in elem for elem in plugin_list):
-            print("*Unofficial Fallout 4 Patch* is installed. \n-----")
+            output.write("*Unofficial Fallout 4 Patch* is installed. \n-----")
         else:
-            print("# UNOFFICIAL FALLOUT 4 PATCH ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-            print("If you own all DLCs, make sure that the Unofficial Patch is installed.")
-            print("Link: https://www.nexusmods.com/fallout4/mods/4598?tab=files")
-            print("-----")
+            output.writelines(["# UNOFFICIAL FALLOUT 4 PATCH ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
+                               "If you own all DLCs, make sure that the Unofficial Patch is installed.",
+                               "Link: https://www.nexusmods.com/fallout4/mods/4598?tab=files",
+                               "-----"
+                               ])
 
         if "vulkan-1.dll" in logtext and gpu_amd:
-            print("Vulkan Renderer is installed. \n-----")
+            output.write("Vulkan Renderer is installed. \n-----")
         elif logtext.count("vulkan-1.dll") == 0 and gpu_amd and not gpu_nvidia:
-            print("# VULKAN RENDERER ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-            print("This is a highly recommended mod that can improve performance on AMD GPUs.")
-            print("-----")
-            print("Installation steps can be found in 'How To Read Crash Logs' PDF / Document.")
-            print("Link: https://www.nexusmods.com/fallout4/mods/48053?tab=files")
-            print("-----")
+            output.writelines(["# VULKAN RENDERER ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
+                               "This is a highly recommended mod that can improve performance on AMD GPUs.",
+                               "-----",
+                               "Installation steps can be found in 'How To Read Crash Logs' PDF / Document.",
+                               "Link: https://www.nexusmods.com/fallout4/mods/48053?tab=files",
+                               "-----"
+                               ])
 
         if "WeaponDebrisCrashFix.dll" in logtext and gpu_nvidia:
-            print("*Weapon Debris Crash Fix* is installed. \n-----")
+            output.write("*Weapon Debris Crash Fix* is installed. \n-----")
         elif "WeaponDebrisCrashFix.dll" in logtext and not gpu_nvidia and gpu_amd:
-            print("*Weapon Debris Crash Fix* is installed, but...")
-            print("# YOU DON'T HAVE AN NVIDIA GPU OR BUFFOUT 4 CANNOT DETECT YOUR GPU MODEL #")
-            print("Weapon Debris Crash Fix is only required for Nvidia GPUs (NOT AMD / OTHER)")
-            print("-----")
+            output.writelines(["*Weapon Debris Crash Fix* is installed, but...",
+                               "# YOU DON'T HAVE AN NVIDIA GPU OR BUFFOUT 4 CANNOT DETECT YOUR GPU MODEL #",
+                               "Weapon Debris Crash Fix is only required for Nvidia GPUs (NOT AMD / OTHER)",
+                               "-----"
+                               ])
         if not "WeaponDebrisCrashFix.dll" in logtext and gpu_nvidia:
-            print("# WEAPON DEBRIS CRASH FIX ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-            print("This is a mandatory patch / fix for players with Nvidia graphics cards.")
-            print("Link: https://www.nexusmods.com/fallout4/mods/48078?tab=files")
-            print("-----")
+            output.writelines(["# WEAPON DEBRIS CRASH FIX ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
+                               "This is a mandatory patch / fix for players with Nvidia graphics cards.",
+                               "Link: https://www.nexusmods.com/fallout4/mods/48078?tab=files",
+                               "-----"
+                               ])
 
         if "NVIDIA_Reflex.dll" in logtext and gpu_nvidia:
-            print("*Nvidia Reflex Support* is installed. \n-----")
+            output.write("*Nvidia Reflex Support* is installed. \n-----")
         elif "NVIDIA_Reflex.dll" in logtext and not gpu_nvidia and gpu_amd:
-            print("*Nvidia Reflex Support* is installed, but...")
-            print("# YOU DON'T HAVE AN NVIDIA GPU OR BUFFOUT 4 CANNOT DETECT YOUR GPU MODEL #")
-            print("Nvidia Reflex Support is only required for Nvidia GPUs (NOT AMD / OTHER)")
-            print("-----")
+            output.writelines(["*Nvidia Reflex Support* is installed, but...",
+                               "# YOU DON'T HAVE AN NVIDIA GPU OR BUFFOUT 4 CANNOT DETECT YOUR GPU MODEL #",
+                               "Nvidia Reflex Support is only required for Nvidia GPUs (NOT AMD / OTHER)",
+                               "-----"
+                               ])
         if not "NVIDIA_Reflex.dll" in logtext and gpu_nvidia:
-            print("# NVIDIA REFLEX SUPPORT ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-            print("This is a highly recommended mod that can reduce render latency.")
-            print("Link: https://www.nexusmods.com/fallout4/mods/64459?tab=files")
-            print("-----")
+            output.writelines(["# NVIDIA REFLEX SUPPORT ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",
+                               "This is a highly recommended mod that can reduce render latency.",
+                               "Link: https://www.nexusmods.com/fallout4/mods/64459?tab=files",
+                               "-----"
+                               ])
     else:
-        print("# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #")
-        print("Autoscan cannot continue. Try scanning a different crash log.")
-        print("-----")
+        output.writelines(nopluginlist)
 
     print("====================================================")
     print("SCANNING THE LOG FOR SPECIFIC (POSSIBLE) CUPLRITS...")
@@ -1437,6 +1468,11 @@ for file in logs:
         print("MAKE SURE THAT F4SE IS CORRECTLY INSTALLED!")
         print("Link: https://f4se.silverlock.org")
         print("-----")
+        output.writelines(["AUTOSCAN CANNOT FIND FALLOUT 4 SCRIPT EXTENDER DLL!",
+                           "MAKE SURE THAT F4SE IS CORRECTLY INSTALLED!",
+                           "Link: https://f4se.silverlock.org",
+                           "-----"
+                           ])
 
     for line in loglines:
         if len(line) >= 6 and "]" in line[4]:
@@ -1448,7 +1484,7 @@ for file in logs:
         if len(line) >= 11 and "]" in line[9]:
             list_ALLPLUGINS.append(line.strip())
 
-    print("LIST OF (POSSIBLE) PLUGIN CULRIPTS:")
+    output.write("LIST OF (POSSIBLE) PLUGIN CULRIPTS:")
     for line in loglines:
         if "File:" in line:
             line = line.replace("File: ", "")
@@ -1472,16 +1508,22 @@ for file in logs:
                 PL_matches.append(string)
         if PL_matches:
             PL_result.append(PL_matches)
-            print("- " + ' '.join(PL_matches))
+            output.write(f"- {' '.join(PL_matches)}") # not 100% sure on this, will have to see how it works.
 
     if not PL_result:
-        print("* AUTOSCAN COULDN'T FIND ANY PLUGIN CULRIPTS *")
-        print("-----")
+        output.writelines(["* AUTOSCAN COULDN'T FIND ANY PLUGIN CULRIPTS *",
+                           "-----"
+                           ])
     else:
         print("-----")
         print("These Plugins were caught by Buffout 4 and some of them might be responsible for this crash.")
         print("You can try disabling these plugins and recheck your game, though this method can be unreliable.")
         print("-----")
+        output.writelines(["-----",
+                           "These Plugins were caught by Buffout 4 and some of them might be responsible for this crash.",
+                           "You can try disabling these plugins and recheck your game, though this method can be unreliable.",
+                           "-----"
+                           ])
 
     # ===========================================================
 
@@ -1508,23 +1550,25 @@ for file in logs:
 
     list_DETFORMIDS = list(dict.fromkeys(list_DETFORMIDS))
     for elem in list_DETFORMIDS:
-        print(elem)
+        output.write(elem)
 
     if not list_DETFORMIDS:
-        print("* AUTOSCAN COULDN'T FIND ANY FORM ID CULRIPTS *")
-        print("-----")
+        output.writelines(["* AUTOSCAN COULDN'T FIND ANY FORM ID CULRIPTS *",
+                           "-----"
+                           ])
     else:
-        print("-----")
-        print("These Form IDs were caught by Buffout 4 and some of them might be related to this crash.")
-        print("You can try searching any listed Form IDs in FO4Edit and see if they lead to relevant records.")
-        print("-----")
+        output.writelines(["-----",
+                           "These Form IDs were caught by Buffout 4 and some of them might be related to this crash.",
+                           "You can try searching any listed Form IDs in FO4Edit and see if they lead to relevant records.",
+                           "-----"
+                           ])
 
     # ===========================================================
 
     List_Files = [".bgsm", ".bto", ".btr", ".dds", ".fuz", ".hkb", ".hkx", ".ini", ".nif", ".pex", ".swf", ".txt", ".uvd", ".wav", ".xwm", "data\\*"]
     List_Exclude = ['""', "...", ".esp"]
 
-    print("LIST OF DETECTED (NAMED) RECORDS:")
+    output.write("LIST OF DETECTED (NAMED) RECORDS:")
     List_Records = []
     for line in loglines:
         if "Name" in line or any(elem in line for elem in List_Files):
@@ -1534,21 +1578,28 @@ for file in logs:
 
     List_Records = list(dict.fromkeys(List_Records))
     for elem in List_Records:
-        print(elem)
+        output.write(elem)
 
     if not List_Records:
-        print("* AUTOSCAN COULDN'T FIND ANY NAMED RECORDS *")
-        print("-----")
+        output.writelines(["* AUTOSCAN COULDN'T FIND ANY NAMED RECORDS *",
+                           "-----"
+                           ])
     else:
-        print("-----")
-        print("These records were caught by Buffout 4 and some of them might be related to this crash.")
-        print("Named records should give extra information on involved game objects and record types.")
-        print("-----")
+        output.writelines(["-----",
+                           "These records were caught by Buffout 4 and some of them might be related to this crash.",
+                           "Named records should give extra information on involved game objects and record types.",
+                           "-----"
+                           ])
 
     print("FOR FULL LIST OF MODS THAT CAUSE PROBLEMS, THEIR ALTERNATIVES AND DETAILED SOLUTIONS,")
     print("VISIT THE BUFFOUT 4 CRASH ARTICLE: https://www.nexusmods.com/fallout4/articles/3115")
     print("===============================================================================")
     print("END OF AUTOSCAN | Author/Made By: Poet#9800 (DISCORD) |", CLAS_Date)
+    output.writelines(["FOR FULL LIST OF MODS THAT CAUSE PROBLEMS, THEIR ALTERNATIVES AND DETAILED SOLUTIONS,",
+                       "VISIT THE BUFFOUT 4 CRASH ARTICLE: https://www.nexusmods.com/fallout4/articles/3115",
+                       "===============================================================================",
+                       f"END OF AUTOSCAN | Author/Made By: Poet#9800 (DISCORD) | {CLAS_Date}"
+                       ])
     output.close()
 
     # MOVE UNSOLVED LOGS TO SPECIAL FOLDER

--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -297,7 +297,7 @@ for file in logs:
                     plugin_list.append(line)
 
         # BUFFOUT VERSION CHECK
-        buff_latest = "Buffout 4 v1.26.2\n"
+        buff_latest = "Buffout 4 v1.26.2"
         output.write(f"Main Error: {buff_error}\n")
         output.write("====================================================\n")
         output.write(f"Detected Buffout Version: {buff_ver.strip()}\n")
@@ -1354,7 +1354,7 @@ for file in logs:
                 output.write("-----\n")
         else:
             output.write(nopluginlist)
-        
+
         output.write("====================================================\n")
         output.write("SCANNING THE LOG FOR SPECIFIC (POSSIBLE) CUPLRITS...\n")
         output.write("====================================================\n")

--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -1,22 +1,24 @@
-from pathlib import Path
-from glob import glob
-import os
-import sys
-import stat
-import time
-import random
-import shutil
-import logging
 import fnmatch
+import logging
+import os
 import pathlib
 import platform
+import random
+import shutil
+import stat
+import sys
+import time
+from glob import glob
+from pathlib import Path
+
 try:
     import requests
     RequestsImportFailed = False
 except ImportError:
     RequestsImportFailed = True
-import subprocess
 import configparser
+import subprocess
+
 if platform.system() == "Windows":
     import ctypes.wintypes
 
@@ -270,12 +272,15 @@ for file in logs:
     loglines: list | None = None
     with logpath.open("r+", encoding="utf-8", errors="ignore") as lines:
         loglines = lines.readlines()
-    output.write(logname)
-    output.write("This crash log was automatically scanned.")
-    output.write(f"VER {CLAS_Current[-4:]} | MIGHT CONTAIN FALSE POSITIVES.")
+
+    output.writelines([logname,
+                       "This crash log was automatically scanned.",
+                       f"VER {CLAS_Current[-4:]} | MIGHT CONTAIN FALSE POSITIVES."
+                       ])
     if CLAS_Update == True:
         output.write("# NOTICE: YOU NEED TO UPDATE THE AUTO-SCANNER! #")
     output.write("====================================================")
+
     # DEFINE LINE INDEXES FOR EVERYTHING REQUIRED HERE
     buff_ver = loglines[1].strip()
     buff_error = loglines[3].strip()
@@ -295,32 +300,35 @@ for file in logs:
 
     # BUFFOUT VERSION CHECK
     buff_latest = "Buffout 4 v1.26.2"
-    output.write(f"Main Error: {buff_error}")
-    output.write("====================================================")
-    output.write(f"Detected Buffout Version: {buff_ver.strip()}")
-    output.write(f"Latest Buffout Version: {buff_latest.strip()}")
+    output.writelines([f"Main Error: {buff_error}",
+                       "====================================================",
+                       f"Detected Buffout Version: {buff_ver.strip()}",
+                       f"Latest Buffout Version: {buff_latest.strip()}"])
 
     if buff_ver.casefold() == buff_latest.casefold():
         output.write("You have the lastest version of Buffout 4!")
     else:
-        output.write("REPORTED BUFFOUT VERSION DOES NOT MATCH THE BUFFOUT VERSION USED BY AUTOSCAN")
-        output.write("UPDATE BUFFOUT 4 IF NECESSARY: https://www.nexusmods.com/fallout4/mods/47359")
+        output.writelines(["REPORTED BUFFOUT VERSION DOES NOT MATCH THE BUFFOUT VERSION USED BY AUTOSCAN",
+                           "UPDATE BUFFOUT 4 IF NECESSARY: https://www.nexusmods.com/fallout4/mods/47359"
+                           ])
 
     if "v1." not in buff_ver:
         statL_veryold += 1
         statL_scanned -= 1
 
-    output.write("====================================================")
-    output.write("CHECKING IF BUFFOUT 4 FILES/SETTINGS ARE CORRECT...")
-    output.write("====================================================")
+    output.writelines(["====================================================",
+                       "CHECKING IF BUFFOUT 4 FILES/SETTINGS ARE CORRECT...",
+                       "===================================================="
+                       ])
 
     ALIB_Load = BUFF_Load = False
 
     # CHECK IF F4SE.LOG EXISTS AND REPORTS ANY ERRORS
     if CLAS_config.getboolean("MAIN", "FCX Mode") == True:
-        output.write("* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *")
-        output.write("[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]")
-        output.write("-----")
+        output.writelines(["* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *",
+                           "[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]",
+                           "-----"
+                           ])
         Error_List = []
         F4SE_Error = F4SE_Version = F4SE_Buffout = 0
         with open(info.FO4_F4SE_Path, "r") as LOG_Check:
@@ -337,9 +345,10 @@ for file in logs:
         if F4SE_Version == 1:
             output.write("You have the latest version of Fallout 4 Script Extender (F4SE). \n-----")
         else:
-            output.write("# REPORTED F4SE VERSION DOES NOT MATCH THE F4SE VERSION USED BY AUTOSCAN #")
-            output.write("UPDATE FALLOUT 4 SCRIPT EXTENDER IF NECESSARY: https://f4se.silverlock.org")
-            output.write("-----")
+            output.writelines(["# REPORTED F4SE VERSION DOES NOT MATCH THE F4SE VERSION USED BY AUTOSCAN #",
+                               "UPDATE FALLOUT 4 SCRIPT EXTENDER IF NECESSARY: https://f4se.silverlock.org",
+                               "-----"
+                               ])
 
         if F4SE_Error == 1:
             output.write("# SCRIPT EXTENDER REPORTS THAT THE FOLLOWING PLUGINS FAILED TO LOAD! #")
@@ -352,10 +361,11 @@ for file in logs:
             output.write("Script Extender reports that Buffout 4.dll was found and loaded correctly. \n-----")
             ALIB_Load = BUFF_Load = True
         else:
-            output.write("# SCRIPT EXTENDER REPORTS THAT BUFFOUT 4.DLL FAILED TO LOAD OR IS MISSING! #")
-            output.write("Follow Buffout 4 installation steps here: https://www.nexusmods.com/fallout4/articles/3115")
-            output.write("Buffout 4: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47359")
-            output.write("-----")
+            output.writelines(["# SCRIPT EXTENDER REPORTS THAT BUFFOUT 4.DLL FAILED TO LOAD OR IS MISSING! #",
+                               "Follow Buffout 4 installation steps here: https://www.nexusmods.com/fallout4/articles/3115",
+                               "Buffout 4: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47359",
+                               "-----"
+                               ])
 
         list_ERRORLOG = []
         for file in info.FO4_F4SE_Logs:
@@ -368,8 +378,9 @@ for file in logs:
                             list_ERRORLOG.append(logname)
 
         if len(list_ERRORLOG) >= 1:
-            output.write("# CAUTION: THE FOLLOWING DLL LOGS ALSO REPORT ONE OR MORE ERRORS : #")
-            output.write("[These are located in your Documents/My Games/Fallout4/F4SE folder.]")
+            output.writelines(["# CAUTION: THE FOLLOWING DLL LOGS ALSO REPORT ONE OR MORE ERRORS : #",
+                               "[These are located in your Documents/My Games/Fallout4/F4SE folder.]"
+                               ])
             for elem in list_ERRORLOG:
                 output.write(f"{elem}\n-----")
         else:
@@ -377,90 +388,99 @@ for file in logs:
 
     # CHECK BUFFOUT 4 REQUIREMENTS AND TOML SETTINGS
         if info.Preloader_XML.is_file() and info.Preloader_DLL.is_file():
-            output.write('OPTIONAL: Plugin Preloader is (manually) installed.\n')
-            output.write('NOTICE: If the game fails to start after installing this mod, open xSE PluginPreloader.xml with a text editor and CHANGE')
-            output.write('<LoadMethod Name="ImportAddressHook"> TO <LoadMethod Name="OnThreadAttach"> OR <LoadMethod Name="OnProcessAttach">')
-            output.write('IF THE GAME STILL REFUSES TO START, COMPLETELY REMOVE xSE PluginPreloader.xml AND IpHlpAPI.dll FROM YOUR FO4 GAME FOLDER')
-            output.write("-----")
+            output.writelines(['OPTIONAL: Plugin Preloader is (manually) installed.\n',
+                               'NOTICE: If the game fails to start after installing this mod, open xSE PluginPreloader.xml with a text editor and CHANGE',
+                               '<LoadMethod Name="ImportAddressHook"> TO <LoadMethod Name="OnThreadAttach"> OR <LoadMethod Name="OnProcessAttach">',
+                               'IF THE GAME STILL REFUSES TO START, COMPLETELY REMOVE xSE PluginPreloader.xml AND IpHlpAPI.dll FROM YOUR FO4 GAME FOLDER',
+                               "-----"
+                               ])
         else:
             output.write('OPTIONAL: Plugin Preloader is not (manually) installed.\n-----')
 
         if info.F4SE_Loader.is_file() and info.F4SE_DLL.is_file() and info.F4SE_SDLL.is_file():
             output.write("REQUIRED: Fallout 4 Script Extender is (manually) installed. \n-----")
         else:
-            output.write("# CAUTION: Auto-Scanner cannot find Script Extender files or they aren't (manually) installed! #")
-            output.write("FIX: Extract all files inside *f4se_0_06_21* folder into your Fallout 4 game folder.")
-            output.write("FALLOUT 4 SCRIPT EXTENDER: (Download Build 0.6.23) https://f4se.silverlock.org")
-            output.write("-----")
+            output.writelines(["# CAUTION: Auto-Scanner cannot find Script Extender files or they aren't (manually) installed! #",
+                               "FIX: Extract all files inside *f4se_0_06_21* folder into your Fallout 4 game folder.",
+                               "FALLOUT 4 SCRIPT EXTENDER: (Download Build 0.6.23) https://f4se.silverlock.org",
+                               "-----"
+                               ])
 
         if info.Address_Library.is_file() or ALIB_Load == True:
             output.write("REQUIRED: Address Library is (manually) installed. \n-----")
         else:
-            output.write("# CAUTION: Auto-Scanner cannot find the Adress Library file or it isn't (manually) installed! #")
-            output.write("FIX: Place the *version-1-10-163-0.bin* file manually into Fallout 4/Data/F4SE/Plugins folder.")
-            output.write("ADDRESS LIBRARY: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47327?tab=files")
-            output.write("-----")
+            output.writelines(["# CAUTION: Auto-Scanner cannot find the Adress Library file or it isn't (manually) installed! #",
+                               "FIX: Place the *version-1-10-163-0.bin* file manually into Fallout 4/Data/F4SE/Plugins folder.",
+                               "ADDRESS LIBRARY: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47327?tab=files",
+                               "-----"
+                               ])
 
         if info.Buffout_INI.is_file() and info.Buffout_DLL.is_file() or BUFF_Load == True:
             with open(info.Buffout_INI, "r+") as BUFF_Custom:
                 BUFF_config = BUFF_Custom.read()
                 output.write("REQUIRED: Buffout 4 is (manually) installed. Checking configuration...\n-----")
                 if ("achievements.dll" or "UnlimitedSurvivalMode.dll") in logtext and "Achievements = true" in BUFF_config:
-                    output.write("# CAUTION: Achievements Mod and/or Unlimited Survival Mode is installed, but Achievements parameter is set to TRUE #")
-                    output.write("Auto-Scanner will change this parameter to FALSE to prevent conflicts with Buffout 4.")
-                    output.write("-----")
+                    output.writelines(["# CAUTION: Achievements Mod and/or Unlimited Survival Mode is installed, but Achievements parameter is set to TRUE #",
+                                       "Auto-Scanner will change this parameter to FALSE to prevent conflicts with Buffout 4.",
+                                       "-----"
+                                       ])
                     BUFF_config = BUFF_config.replace("Achievements = true", "Achievements = false")
                 else:
                     output.write("Achievements parameter in *Buffout4.toml* is correctly configured. \n-----")
 
                 if "BakaScrapHeap.dll" in logtext and "MemoryManager = true" in BUFF_config:
-                    output.write("# CAUTION: Baka ScrapHeap is installed, but MemoryManager parameter is set to TRUE #")
-                    output.write("Auto-Scanner will change this parameter to FALSE to prevent conflicts with Buffout 4.")
-                    output.write("-----")
+                    output.writelines(["# CAUTION: Baka ScrapHeap is installed, but MemoryManager parameter is set to TRUE #",
+                                       "Auto-Scanner will change this parameter to FALSE to prevent conflicts with Buffout 4.",
+                                       "-----"])
                     BUFF_config = BUFF_config.replace("MemoryManager = true", "MemoryManager = false")
                 else:
                     output.write("Memory Manager parameter in *Buffout4.toml* is correctly configured. \n-----")
 
                 if "f4ee.dll" in logtext and "F4EE = false" in BUFF_config:
-                    output.write("# CAUTION: Looks Menu is installed, but F4EE parameter under [Compatibility] is set to FALSE #")
-                    output.write("Auto-Scanner will change this parameter to TRUE to prevent bugs and crashes from Looks Menu.")
-                    output.write("-----")
+                    output.writelines(["# CAUTION: Looks Menu is installed, but F4EE parameter under [Compatibility] is set to FALSE #",
+                                       "Auto-Scanner will change this parameter to TRUE to prevent bugs and crashes from Looks Menu.",
+                                       "-----"
+                                       ])
                     BUFF_config = BUFF_config.replace("F4EE = false", "F4EE = true")
                 else:
                     output.write("Looks Menu (F4EE) parameter in *Buffout4.toml* is correctly configured. \n-----")
             with open(info.Buffout_INI, "w+") as BUFF_Custom:
                 BUFF_Custom.write(BUFF_config)
         else:
-            output.write("# CAUTION: Auto-Scanner cannot find Buffout 4 files or they aren't (manually) installed! #")
-            output.write("FIX: Follow Buffout 4 installation steps here: https://www.nexusmods.com/fallout4/articles/3115")
-            output.write("BUFFOUT 4: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47359?tab=files")
-            output.write("-----")
+            output.writelines(["# CAUTION: Auto-Scanner cannot find Buffout 4 files or they aren't (manually) installed! #",
+                               "FIX: Follow Buffout 4 installation steps here: https://www.nexusmods.com/fallout4/articles/3115",
+                               "BUFFOUT 4: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47359?tab=files",
+                               "-----"
+                               ])
 
     else:  # INSTRUCTIONS FOR MANUAL FIXING WHEN FCX MODE IS FALSE
         if ("Achievements: true" in logtext and "achievements.dll" in logtext) or ("Achievements: true" in logtext and "UnlimitedSurvivalMode.dll" in logtext):
-            output.write("# CAUTION: Achievements Mod and/or Unlimited Survival Mode is installed, but Achievements parameter is set to TRUE #")
-            output.write("FIX: Open *Buffout4.toml* and change Achievements parameter to FALSE, this prevents conflicts with Buffout 4.")
-            output.write("-----")
+            output.writelines(["# CAUTION: Achievements Mod and/or Unlimited Survival Mode is installed, but Achievements parameter is set to TRUE #",
+                               "FIX: Open *Buffout4.toml* and change Achievements parameter to FALSE, this prevents conflicts with Buffout 4.",
+                               "-----"
+                               ])
         else:
             output.write("Achievements parameter in *Buffout4.toml* is correctly configured. \n-----")
 
         if "MemoryManager: true" in logtext and "BakaScrapHeap.dll" in logtext:
-            output.write("# CAUTION: Baka ScrapHeap is installed, but MemoryManager parameter is set to TRUE #")
-            output.write("FIX: Open *Buffout4.toml* and change MemoryManager parameter to FALSE, this prevents conflicts with Buffout 4.")
-            output.write("-----")
+            output.writelines(["# CAUTION: Baka ScrapHeap is installed, but MemoryManager parameter is set to TRUE #",
+                               "FIX: Open *Buffout4.toml* and change MemoryManager parameter to FALSE, this prevents conflicts with Buffout 4.",
+                               "-----"])
         else:
             output.write("Memory Manager parameter in *Buffout4.toml* is correctly configured. \n-----")
 
         if "F4EE: false" in logtext and "f4ee.dll" in logtext:
-            output.write("# CAUTION: Looks Menu is installed, but F4EE parameter under [Compatibility] is set to FALSE #")
-            output.write("FIX: Open *Buffout4.toml* and change F4EE parameter to TRUE, this prevents bugs and crashes from Looks Menu.")
-            output.write("-----")
+            output.writelines(["# CAUTION: Looks Menu is installed, but F4EE parameter under [Compatibility] is set to FALSE #",
+                               "FIX: Open *Buffout4.toml* and change F4EE parameter to TRUE, this prevents bugs and crashes from Looks Menu.",
+                               "-----"
+                               ])
         else:
             output.write("Looks Menu (F4EE) parameter in *Buffout4.toml* is correctly configured. \n-----")
 
-    output.write("====================================================")
-    output.write("CHECKING IF LOG MATCHES ANY KNOWN CRASH MESSAGES...")
-    output.write("====================================================")
+    output.writelines(["====================================================",
+                       "CHECKING IF LOG MATCHES ANY KNOWN CRASH MESSAGES...",
+                       "===================================================="
+                       ])
     Buffout_Trap = False  # RETURN TRUE IF KNOWN CRASH MESSAGE WAS FOUND
 
     # ====================== HEADER ERRORS ======================
@@ -469,22 +489,30 @@ for file in logs:
         output.write("# MAIN ERROR REPORTS A DLL WAS INVLOVED IN THIS CRASH! # \n-----")
 
     if "EXCEPTION_STACK_OVERFLOW" in buff_error:
-        output.writelines(["# Checking for Stack Overflow Crash.........CULPRIT FOUND! #", "> Priority : [5]"])
+        output.writelines(["# Checking for Stack Overflow Crash.........CULPRIT FOUND! #",
+                           "> Priority : [5]"
+                           ])
         Buffout_Trap = True
         statC_Overflow += 1
 
     if "0x000100000000" in buff_error:
-        output.writelines(["# Checking for Active Effects Crash.........CULPRIT FOUND! #", "> Priority : [5]"])
+        output.writelines(["# Checking for Active Effects Crash.........CULPRIT FOUND! #",
+                           "> Priority : [5]"
+                           ])
         Buffout_Trap = True
         statC_ActiveEffect += 1
 
     if "EXCEPTION_INT_DIVIDE_BY_ZERO" in buff_error:
-        output.writelines(["# Checking for Bad Math Crash...............CULPRIT FOUND! #", "> Priority : [5]"])
+        output.writelines(["# Checking for Bad Math Crash...............CULPRIT FOUND! #",
+                           "> Priority : [5]"
+                           ])
         Buffout_Trap = True
         statC_BadMath += 1
 
     if "0x000000000000" in buff_error:
-        output.writelines(["# Checking for Null Crash...................CULPRIT FOUND! #", "> Priority : [5]"])
+        output.writelines(["# Checking for Null Crash...................CULPRIT FOUND! #",
+                           "> Priority : [5]"
+                           ])
         Buffout_Trap = True
         statC_Null += 1
 
@@ -498,192 +526,223 @@ for file in logs:
 
     # ===========================================================
     if "DLCBannerDLC01.dds" in logtext:
-        output.writelines(["# Checking for DLL Crash....................CULPRIT FOUND! #", f'> Priority : [5] | DLCBannerDLC01.dds : {logtext.count("DLCBannerDLC01.dds")}'])
+        output.writelines(["# Checking for DLL Crash....................CULPRIT FOUND! #",
+                           f'> Priority : [5] | DLCBannerDLC01.dds : {logtext.count("DLCBannerDLC01.dds")}'
+                           ])
         Buffout_Trap = True
         statC_DLL += 1
     # ===========================================================
     if "BGSLocation" in logtext and "BGSQueuedTerrainInitialLoad" in logtext:
-        output.write('# Checking for LOD Crash....................CULPRIT FOUND! #')
-        output.write(f'> Priority : [5] | BGSLocation : {logtext.count("BGSLocation")} | BGSQueuedTerrainInitialLoad : {logtext.count("BGSQueuedTerrainInitialLoad")}')
+        output.writelines(['# Checking for LOD Crash....................CULPRIT FOUND! #',
+                           f'> Priority : [5] | BGSLocation : {logtext.count("BGSLocation")} | BGSQueuedTerrainInitialLoad : {logtext.count("BGSQueuedTerrainInitialLoad")}'
+                           ])
         Buffout_Trap = True
         statC_LOD += 1
     # ===========================================================
     if ("FaderData" or "FaderMenu" or "UIMessage") in logtext:
-        output.write("# Checking for MCM Crash....................CULPRIT FOUND! #")
-        output.write(f'> Priority : [3] | FaderData : {logtext.count("FaderData")} | FaderMenu : {logtext.count("FaderMenu")} | UIMessage : {logtext.count("UIMessage")}')
+        output.writelines(["# Checking for MCM Crash....................CULPRIT FOUND! #",
+                           f'> Priority : [3] | FaderData : {logtext.count("FaderData")} | FaderMenu : {logtext.count("FaderMenu")} | UIMessage : {logtext.count("UIMessage")}'
+                           ])
         Buffout_Trap = True
         statC_MCM += 1
     # ===========================================================
     if ("BGSDecalManager" or "BSTempEffectGeometryDecal") in logtext:
-        output.write("# Checking for Decal Crash..................CULPRIT FOUND! #")
-        output.write(f'> Priority : [5] | BGSDecalManager : {logtext.count("BGSDecalManager")} | BSTempEffectGeometryDecal : {logtext.count("BSTempEffectGeometryDecal")}')
+        output.writelines(["# Checking for Decal Crash..................CULPRIT FOUND! #",
+                           f'> Priority : [5] | BGSDecalManager : {logtext.count("BGSDecalManager")} | BSTempEffectGeometryDecal : {logtext.count("BSTempEffectGeometryDecal")}'
+                           ])
         Buffout_Trap = True
         statC_Decal += 1
     # ===========================================================
     if logtext.count("PipboyMapData") >= 2:
-        output.write("# Checking for Equip Crash..................CULPRIT FOUND! #")
-        output.write(f'> Priority : [2] | PipboyMapData : {logtext.count("PipboyMapData")}')
+        output.writelines(["# Checking for Equip Crash..................CULPRIT FOUND! #",
+                           f'> Priority : [2] | PipboyMapData : {logtext.count("PipboyMapData")}'
+                           ])
         Buffout_Trap = True
         statC_Equip += 1
     # ===========================================================
     if (logtext.count("Papyrus") or logtext.count("VirtualMachine")) >= 2:
-        output.write("# Checking for Script Crash.................CULPRIT FOUND! #")
-        output.write(f'> Priority : [3] | Papyrus : {logtext.count("Papyrus")} | VirtualMachine : {logtext.count("VirtualMachine")}')
+        output.writelines(["# Checking for Script Crash.................CULPRIT FOUND! #",
+                           f'> Priority : [3] | Papyrus : {logtext.count("Papyrus")} | VirtualMachine : {logtext.count("VirtualMachine")}'
+                           ])
         Buffout_Trap = True
         statC_Papyrus += 1
     # ===========================================================
     if logtext.count("tbbmalloc.dll") >= 3 or "tbbmalloc" in buff_error:
-        output.write("# Checking for Generic Crash................CULPRIT FOUND! #")
-        output.write(f'> Priority : [2] | tbbmalloc.dll : {logtext.count("tbbmalloc.dll")}')
+        output.writelines(["# Checking for Generic Crash................CULPRIT FOUND! #",
+                           f'> Priority : [2] | tbbmalloc.dll : {logtext.count("tbbmalloc.dll")}'
+                           ])
         Buffout_Trap = True
         statC_Generic += 1
     # ===========================================================
     if "LooseFileAsyncStream" in logtext:
-        output.write("# Checking for BA2 Limit Crash..............CULPRIT FOUND! #")
-        output.write(f'> Priority : [5] | LooseFileAsyncStream : {logtext.count("LooseFileAsyncStream")}')
+        output.writelines(["# Checking for BA2 Limit Crash..............CULPRIT FOUND! #",
+                           f'> Priority : [5] | LooseFileAsyncStream : {logtext.count("LooseFileAsyncStream")}'
+                           ])
         Buffout_Trap = True
         statC_BA2Limit += 1
     # ===========================================================
     if logtext.count("d3d11.dll") >= 3 or "d3d11" in buff_error:
-        output.write("# Checking for Rendering Crash..............CULPRIT FOUND! #")
-        output.write(f'> Priority : [4] | d3d11.dll : {logtext.count("d3d11.dll")}')
+        output.writelines(["# Checking for Rendering Crash..............CULPRIT FOUND! #",
+                           f'> Priority : [4] | d3d11.dll : {logtext.count("d3d11.dll")}'
+                           ])
         Buffout_Trap = True
         statC_Rendering += 1
     # ===========================================================
     if ("GridAdjacencyMapNode" or "PowerUtils") in logtext:
-        output.write("# Checking for Grid Scrap Crash.............CULPRIT FOUND! #")
-        output.write(f'> Priority : [5] | GridAdjacencyMapNode : {logtext.count("GridAdjacencyMapNode")} | PowerUtils : {logtext.count("PowerUtils")}')
+        output.writelines(["# Checking for Grid Scrap Crash.............CULPRIT FOUND! #",
+                           f'> Priority : [5] | GridAdjacencyMapNode : {logtext.count("GridAdjacencyMapNode")} | PowerUtils : {logtext.count("PowerUtils")}'
+                           ])
         Buffout_Trap = True
         statC_GridScrap += 1
     # ===========================================================
     if ("LooseFileStream" or "BSFadeNode" or "BSMultiBoundNode") in logtext and logtext.count("LooseFileAsyncStream") == 0:
-        output.write("# Checking for Mesh (NIF) Crash.............CULPRIT FOUND! #")
-        output.write(f'> Priority : [4] | LooseFileStream : {logtext.count("LooseFileStream")} | BSFadeNode : {logtext.count("BSFadeNode")}')
-        output.write(f'                   BSMultiBoundNode : {logtext.count("BSMultiBoundNode")}')
+        output.writelines(["# Checking for Mesh (NIF) Crash.............CULPRIT FOUND! #",
+                           f'> Priority : [4] | LooseFileStream : {logtext.count("LooseFileStream")} | BSFadeNode : {logtext.count("BSFadeNode")}',
+                           f'                   BSMultiBoundNode : {logtext.count("BSMultiBoundNode")}'
+                           ])
         Buffout_Trap = True
         statC_NIF += 1
     # ===========================================================
     if ("Create2DTexture" or "DefaultTexture") in logtext:
-        output.write("# Checking for Texture (DDS) Crash..........CULPRIT FOUND! #")
-        output.write(f'> Priority : [3] | Create2DTexture : {logtext.count("Create2DTexture")} | DefaultTexture : {logtext.count("DefaultTexture")}')
+        output.writelines(["# Checking for Texture (DDS) Crash..........CULPRIT FOUND! #",
+                           f'> Priority : [3] | Create2DTexture : {logtext.count("Create2DTexture")} | DefaultTexture : {logtext.count("DefaultTexture")}'
+                           ])
         Buffout_Trap = True
         statlogtexture += 1
     # ===========================================================
     if ("DefaultTexture_Black" or "NiAlphaProperty") in logtext:
-        output.write("# Checking for Material (BGSM) Crash........CULPRIT FOUND! #")
-        output.write(f'> Priority : [3] | DefaultTexture_Black : {logtext.count("DefaultTexture_Black")} | NiAlphaProperty : {logtext.count("NiAlphaProperty")}')
+        output.writelines(["# Checking for Material (BGSM) Crash........CULPRIT FOUND! #",
+                           f'> Priority : [3] | DefaultTexture_Black : {logtext.count("DefaultTexture_Black")} | NiAlphaProperty : {logtext.count("NiAlphaProperty")}'
+                           ])
         Buffout_Trap = True
         statC_BGSM += 1
     # ===========================================================
     if (logtext.count("bdhkm64.dll") or logtext.count("usvfs::hook_DeleteFileW")) >= 2:
-        output.write("# Checking for BitDefender Crash............CULPRIT FOUND! #")
-        output.write(f'> Priority : [5] | bdhkm64.dll : {logtext.count("bdhkm64.dll")} | usvfs::hook_DeleteFileW : {logtext.count("usvfs::hook_DeleteFileW")}')
+        output.writelines(["# Checking for BitDefender Crash............CULPRIT FOUND! #",
+                           f'> Priority : [5] | bdhkm64.dll : {logtext.count("bdhkm64.dll")} | usvfs::hook_DeleteFileW : {logtext.count("usvfs::hook_DeleteFileW")}'
+                           ])
         Buffout_Trap = True
         statC_BitDefender += 1
     # ===========================================================
     if ("PathingCell" or "BSPathBuilder" or "PathManagerServer") in logtext:
-        output.write("# Checking for NPC Pathing Crash............CULPRIT FOUND! #")
-        output.write(f'> Priority : [3] | PathingCell : {logtext.count("PathingCell")} | BSPathBuilder : {logtext.count("BSPathBuilder")}')
-        output.write(f'                   PathManagerServer : {logtext.count("PathManagerServer")}')
+        output.writelines(["# Checking for NPC Pathing Crash............CULPRIT FOUND! #",
+                           f'> Priority : [3] | PathingCell : {logtext.count("PathingCell")} | BSPathBuilder : {logtext.count("BSPathBuilder")}',
+                           f'                   PathManagerServer : {logtext.count("PathManagerServer")}'
+                           ])
         Buffout_Trap = True
         statC_NPCPathing += 1
     elif ("NavMesh" or "BSNavmeshObstacleData" or "DynamicNavmesh") in logtext:
-        output.write("# Checking for NPC Pathing Crash............CULPRIT FOUND! #")
-        output.write(f'> Priority : [3] | NavMesh : {logtext.count("NavMesh")} | BSNavmeshObstacleData : {logtext.count("BSNavmeshObstacleData")}')
-        output.write(f'                   DynamicNavmesh : {logtext.count("DynamicNavmesh")}')
+        output.writelines(["# Checking for NPC Pathing Crash............CULPRIT FOUND! #",
+                           f'> Priority : [3] | NavMesh : {logtext.count("NavMesh")} | BSNavmeshObstacleData : {logtext.count("BSNavmeshObstacleData")}',
+                           f'                   DynamicNavmesh : {logtext.count("DynamicNavmesh")}'
+                           ])
         Buffout_Trap = True
         statC_NPCPathing += 1
     # ===========================================================
     if logtext.count("X3DAudio1_7.dll") >= 3 or logtext.count("XAudio2_7.dll") >= 3 or ("X3DAudio1_7" or "XAudio2_7") in buff_error:
-        output.write("# Checking for Audio Driver Crash...........CULPRIT FOUND! #")
-        output.write(f'> Priority : [5] | X3DAudio1_7.dll : {logtext.count("X3DAudio1_7.dll")} | XAudio2_7.dll : {logtext.count("XAudio2_7.dll")}')
+        output.writelines(["# Checking for Audio Driver Crash...........CULPRIT FOUND! #",
+                           f'> Priority : [5] | X3DAudio1_7.dll : {logtext.count("X3DAudio1_7.dll")} | XAudio2_7.dll : {logtext.count("XAudio2_7.dll")}'
+                           ])
         Buffout_Trap = True
         statC_Audio += 1
     # ===========================================================
     if logtext.count("cbp.dll") >= 3 or "skeleton.nif" in logtext or "cbp.dll" in buff_error:
-        output.write("# Checking for Body Physics Crash...........CULPRIT FOUND! #")
-        output.write(f'> Priority : [4] | cbp.dll : {logtext.count("cbp.dll")} | skeleton.nif : {logtext.count("skeleton.nif")}')
+        output.writelines(["# Checking for Body Physics Crash...........CULPRIT FOUND! #",
+                           f'> Priority : [4] | cbp.dll : {logtext.count("cbp.dll")} | skeleton.nif : {logtext.count("skeleton.nif")}'
+                           ])
         Buffout_Trap = True
         statC_BodyPhysics += 1
     # ===========================================================
     if ("BSMemStorage" or "DataFileHandleReaderWriter") in logtext:
-        output.write("# Checking for Plugin Limit Crash...........CULPRIT FOUND! #")
-        output.write(f'> Priority : [5] | BSMemStorage : {logtext.count("BSMemStorage")} | DataFileHandleReaderWriter : {logtext.count("DataFileHandleReaderWriter")}')
+        output.writelines(["# Checking for Plugin Limit Crash...........CULPRIT FOUND! #",
+                           f'> Priority : [5] | BSMemStorage : {logtext.count("BSMemStorage")} | DataFileHandleReaderWriter : {logtext.count("DataFileHandleReaderWriter")}'])
         Buffout_Trap = True
         statC_PluginLimit += 1
     # ===========================================================
     if "GamebryoSequenceGenerator" in logtext or "+0DB9300" in buff_error:
-        output.write("# Checking for Plugin Order Crash...........CULPRIT FOUND! #")
-        output.write(f'> Priority : [5] | GamebryoSequenceGenerator : {logtext.count("GamebryoSequenceGenerator")}')
+        output.writelines(["# Checking for Plugin Order Crash...........CULPRIT FOUND! #",
+                           f'> Priority : [5] | GamebryoSequenceGenerator : {logtext.count("GamebryoSequenceGenerator")}'
+                           ])
         Buffout_Trap = True
         statC_LoadOrder += 1
     # ===========================================================
     if logtext.count("BSD3DResourceCreator") == 3 or logtext.count("BSD3DResourceCreator") == 6:
-        output.write("# Checking for MO2 Extractor Crash..........CULPRIT FOUND! #")
-        output.write(f'> Priority : [5] | BSD3DResourceCreator : {logtext.count("BSD3DResourceCreator")}')
+        output.writelines(["# Checking for MO2 Extractor Crash..........CULPRIT FOUND! #",
+                           f'> Priority : [5] | BSD3DResourceCreator : {logtext.count("BSD3DResourceCreator")}'
+                           ])
         Buffout_Trap = True
         statC_MO2Unp += 1
     # ===========================================================
     if logtext.count("flexRelease_x64.dll") >= 2 or "flexRelease_x64" in buff_error:
-        output.write("# Checking for Nvidia Debris Crash..........CULPRIT FOUND! #")
-        output.write(f'> Priority : [5] | flexRelease_x64.dll : {logtext.count("flexRelease_x64.dll")}')
+        output.writelines(["# Checking for Nvidia Debris Crash..........CULPRIT FOUND! #",
+                           f'> Priority : [5] | flexRelease_x64.dll : {logtext.count("flexRelease_x64.dll")}'
+                           ])
         Buffout_Trap = True
         statC_NVDebris += 1
     # ===========================================================
     if logtext.count("nvwgf2umx.dll") >= 10 or ("nvwgf2umx" or "USER32.dll") in buff_error:
-        output.write("# Checking for Nvidia Driver Crash..........CULPRIT FOUND! #")
-        output.write(f'> Priority : [5] | nvwgf2umx.dll : {logtext.count("nvwgf2umx.dll")} | USER32.dll : {logtext.count("USER32.dll")}')
+        output.writelines(["# Checking for Nvidia Driver Crash..........CULPRIT FOUND! #",
+                           f'> Priority : [5] | nvwgf2umx.dll : {logtext.count("nvwgf2umx.dll")} | USER32.dll : {logtext.count("USER32.dll")}'
+                           ])
         Buffout_Trap = True
         statC_NVDriver += 1
     # ===========================================================
     if (logtext.count("KERNELBASE.dll") or logtext.count("MSVCP140.dll")) >= 3 and "DxvkSubmissionQueue" in logtext:
-        output.write("# Checking for Vulkan Memory Crash..........CULPRIT FOUND! #")
-        output.write(f'> Priority : [5] | KERNELBASE.dll : {logtext.count("KERNELBASE.dll")} | MSVCP140.dll : {logtext.count("MSVCP140.dll")}')
-        output.write(f'                   DxvkSubmissionQueue : {logtext.count("DxvkSubmissionQueue")}')
+        output.writelines(["# Checking for Vulkan Memory Crash..........CULPRIT FOUND! #",
+                           f'> Priority : [5] | KERNELBASE.dll : {logtext.count("KERNELBASE.dll")} | MSVCP140.dll : {logtext.count("MSVCP140.dll")}',
+                           f'                   DxvkSubmissionQueue : {logtext.count("DxvkSubmissionQueue")}'
+                           ])
         Buffout_Trap = True
         statC_VulkanMem += 1
     # ===========================================================
     if ("dxvk::DXGIAdapter" or "dxvk::DXGIFactory") in logtext:
-        output.write("# Checking for Vulkan Settings Crash........CULPRIT FOUND! #")
-        output.write(f'> Priority : [5] | dxvk::DXGIAdapter : {logtext.count("dxvk::DXGIAdapter")} | dxvk::DXGIFactory : {logtext.count("dxvk::DXGIFactory")}')
+        output.writelines(["# Checking for Vulkan Settings Crash........CULPRIT FOUND! #",
+                           f'> Priority : [5] | dxvk::DXGIAdapter : {logtext.count("dxvk::DXGIAdapter")} | dxvk::DXGIFactory : {logtext.count("dxvk::DXGIFactory")}'
+                           ])
         Buffout_Trap = True
         statC_VulkanSet += 1
     # ===========================================================
     if ("BSXAudio2DataSrc" or "BSXAudio2GameSound") in logtext:
-        output.write("# Checking for Corrupted Audio Crash........CULPRIT FOUND! #")
-        output.write(f'> Priority : [4] | BSXAudio2DataSrc : {logtext.count("BSXAudio2DataSrc")} | BSXAudio2GameSound : {logtext.count("BSXAudio2GameSound")}')
+        output.writelines(["# Checking for Corrupted Audio Crash........CULPRIT FOUND! #",
+                           f'> Priority : [4] | BSXAudio2DataSrc : {logtext.count("BSXAudio2DataSrc")} | BSXAudio2GameSound : {logtext.count("BSXAudio2GameSound")}'
+                           ])
         Buffout_Trap = True
         statC_CorruptedAudio += 1
     # ===========================================================
     if ("SysWindowCompileAndRun" or "ConsoleLogPrinter") in logtext:
-        output.write("# Checking for Console Command Crash........CULPRIT FOUND! #")
-        output.write(f'> Priority : [1] | SysWindowCompileAndRun : {logtext.count("SysWindowCompileAndRun")} | ConsoleLogPrinter : {logtext.count("ConsoleLogPrinter")}')
+        output.writelines(["# Checking for Console Command Crash........CULPRIT FOUND! #",
+                           f'> Priority : [1] | SysWindowCompileAndRun : {logtext.count("SysWindowCompileAndRun")} | ConsoleLogPrinter : {logtext.count("ConsoleLogPrinter")}'
+                           ])
         Buffout_Trap = True
         statC_ConsoleCommands += 1
     # ===========================================================
     if "BGSWaterCollisionManager" in logtext:
-        output.write("# Checking for Water Collision Crash........CULPRIT FOUND! #")
-        output.write("PLEASE CONTACT ME AS SOON AS POSSIBLE! (CONTACT INFO BELOW)")
-        output.write(f'> Priority : [6] | BGSWaterCollisionManager : {logtext.count("BGSWaterCollisionManager")}')
+        output.writelines(["# Checking for Water Collision Crash........CULPRIT FOUND! #",
+                           "PLEASE CONTACT ME AS SOON AS POSSIBLE! (CONTACT INFO BELOW)",
+                           f'> Priority : [6] | BGSWaterCollisionManager : {logtext.count("BGSWaterCollisionManager")}'
+                           ])
         Buffout_Trap = True
         statC_Water += 1
     # ===========================================================
     if "ParticleSystem" in logtext:
-        output.write("# Checking for Particle Effects Crash.......CULPRIT FOUND! #")
-        output.write(f'> Priority : [4] | ParticleSystem : {logtext.count("ParticleSystem")}')
+        output.writelines(["# Checking for Particle Effects Crash.......CULPRIT FOUND! #",
+                           f'> Priority : [4] | ParticleSystem : {logtext.count("ParticleSystem")}'
+                           ])
         Buffout_Trap = True
         statC_Particles += 1
     # ===========================================================
     if ("hkbVariableBindingSet" or "hkbHandIkControlsModifier" or "hkbBehaviorGraph" or "hkbModifierList") in logtext:
-        output.write("# Checking for Animation / Physics Crash....CULPRIT FOUND! #")
-        output.write(f'> Priority : [5] | hkbVariableBindingSet : {logtext.count("hkbVariableBindingSet")} | hkbHandIkControlsModifier : {logtext.count("hkbHandIkControlsModifier")}')
-        print("                   hkbBehaviorGraph : ", logtext.count("hkbBehaviorGraph"), " | hkbModifierList : ", logtext.count("hkbModifierList"))
+        output.writelines(["# Checking for Animation / Physics Crash....CULPRIT FOUND! #",
+                           f'> Priority : [5] | hkbVariableBindingSet : {logtext.count("hkbVariableBindingSet")} | hkbHandIkControlsModifier : {logtext.count("hkbHandIkControlsModifier")}',
+                           f'                   hkbBehaviorGraph : {logtext.count("hkbBehaviorGraph")} | hkbModifierList : {logtext.count("hkbModifierList")}'
+                           ])
         Buffout_Trap = True
         statC_AnimationPhysics += 1
     # ===========================================================
     if "DLCBanner05.dds" in logtext:
-        output.write("# Checking for Archive Invalidation Crash...CULPRIT FOUND! #")
-        output.write(f'> Priority : [5] | DLCBanner05.dds : {logtext.count("DLCBanner05.dds")}')
+        output.writelines(["# Checking for Archive Invalidation Crash...CULPRIT FOUND! #",
+                           f'> Priority : [5] | DLCBanner05.dds : {logtext.count("DLCBanner05.dds")}'
+                           ])
         Buffout_Trap = True
         statC_Invalidation += 1
 
@@ -691,86 +750,106 @@ for file in logs:
     output.write("---------- Unsolved Crash Messages Below ----------")
 
     if "+01B59A4" in buff_error:
-        output.writelines(["Checking for *[Creation Club Crash].......DETECTED!", "> Priority : [5]"])
+        output.writelines(["Checking for *[Creation Club Crash].......DETECTED!",
+                           "> Priority : [5]"
+                           ])
         Buffout_Trap = True
         statU_CClub += 1
 
     if ("BGSMod::Attachment" or "BGSMod::Template" or "BGSMod::Template::Item") in logtext:
-        output.write("Checking for *[Item Crash]................DETECTED!")
-        output.write(f'> Priority : [5] | BGSMod::Attachment : {logtext.count("BGSMod::Attachment")} | BGSMod::Template : {logtext.count("BGSMod::Template")}')
-        output.write(f'                        BGSMod::Template::Item : {logtext.count("BGSMod::Template::Item")}')
+        output.writelines(["Checking for *[Item Crash]................DETECTED!",
+                           f'> Priority : [5] | BGSMod::Attachment : {logtext.count("BGSMod::Attachment")} | BGSMod::Template : {logtext.count("BGSMod::Template")}',
+                           f'                        BGSMod::Template::Item : {logtext.count("BGSMod::Template::Item")}'
+                           ])
         Buffout_Trap = True
         statU_Item += 1
     # ===========================================================
     if logtext.count("BGSSaveFormBuffer") >= 2:
-        output.write("Checking for *[Save Crash]................DETECTED!")
-        output.write(f'> Priority : [5] | BGSSaveFormBuffer : {logtext.count("BGSSaveFormBuffer")}')
+        output.writelines(["Checking for *[Save Crash]................DETECTED!",
+                           f'> Priority : [5] | BGSSaveFormBuffer : {logtext.count("BGSSaveFormBuffer")}'
+                           ])
         Buffout_Trap = True
         statU_Save += 1
     # ===========================================================
     if ("ButtonEvent" or "MenuControls" or "MenuOpenCloseHandler" or "PlayerControls" or "DXGISwapChain") in logtext:
-        output.write("Checking for *[Input Crash]...............DETECTED!")
-        output.write(f'> Priority : [5] | ButtonEvent : {logtext.count("ButtonEvent")} | MenuControls : {logtext.count("MenuControls")}')
-        output.write(f'                        MenuOpenCloseHandler : {logtext.count("MenuOpenCloseHandler")} | PlayerControls : {logtext.count("PlayerControls")}')
-        output.write(f'                        DXGISwapChain : {logtext.count("DXGISwapChain")}')
+        output.writelines(["Checking for *[Input Crash]...............DETECTED!",
+                           f'> Priority : [5] | ButtonEvent : {logtext.count("ButtonEvent")} | MenuControls : {logtext.count("MenuControls")}',
+                           f'                        MenuOpenCloseHandler : {logtext.count("MenuOpenCloseHandler")} | PlayerControls : {logtext.count("PlayerControls")}',
+                           f'                        DXGISwapChain : {logtext.count("DXGISwapChain")}'
+                           ])
         Buffout_Trap = True
         statU_Input += 1
     # ===========================================================
     if ("BGSSaveLoadManager" or "BGSSaveLoadThread" or "BGSSaveFormBuffer") in logtext or ("+0CDAD30" or "+0D09AB7") in buff_error:
-        output.write("Checking for *[Bad INI Crash].............DETECTED!")
-        output.write(f'> Priority : [5] | BGSSaveLoadManager : {logtext.count("BGSSaveLoadManager")} | BGSSaveLoadThread : {logtext.count("BGSSaveLoadThread")}')
-        output.write(f'                        BGSSaveFormBuffer : {logtext.count("BGSSaveFormBuffer")}')
+        output.writelines(["Checking for *[Bad INI Crash].............DETECTED!",
+                           f'> Priority : [5] | BGSSaveLoadManager : {logtext.count("BGSSaveLoadManager")} | BGSSaveLoadThread : {logtext.count("BGSSaveLoadThread")}',
+                           f'                        BGSSaveFormBuffer : {logtext.count("BGSSaveFormBuffer")}'
+                           ])
         Buffout_Trap = True
         statU_INI += 1
     # ===========================================================
     if ("BGSProcedurePatrol" or "BGSProcedurePatrolExecState" or "PatrolActorPackageData") in logtext:
-        output.write("Checking for *[NPC Patrol Crash]..........DETECTED!")
-        output.write(f'> Priority : [5] | BGSProcedurePatrol : {logtext.count("BGSProcedurePatrol")} | BGSProcedurePatrolExecStatel : {logtext.count("BGSProcedurePatrolExecState")}')
-        output.write(f'                        PatrolActorPackageData : {logtext.count("PatrolActorPackageData")}')
+        output.writelines(["Checking for *[NPC Patrol Crash]..........DETECTED!",
+                           f'> Priority : [5] | BGSProcedurePatrol : {logtext.count("BGSProcedurePatrol")} | BGSProcedurePatrolExecStatel : {logtext.count("BGSProcedurePatrolExecState")}',
+                           f'                        PatrolActorPackageData : {logtext.count("PatrolActorPackageData")}'
+                           ])
         Buffout_Trap = True
         statU_Patrol += 1
     # ===========================================================
     if ("BSPackedCombinedGeomDataExtra" or "BGSCombinedCellGeometryDB" or "BGSStaticCollection" or "TESObjectCELL") in logtext:
-        output.write("Checking for *[Precombines Crash].........DETECTED!")
-        output.write(f'> Priority : [5] | BGSStaticCollection : {logtext.count("BGSStaticCollection")} | BGSCombinedCellGeometryDB : {logtext.count("BGSCombinedCellGeometryDB")}')
-        output.write(f'                        BSPackedCombinedGeomDataExtra : {logtext.count("BSPackedCombinedGeomDataExtra")} | TESObjectCELL : {logtext.count("TESObjectCELL")}')
+        output.writelines(["Checking for *[Precombines Crash].........DETECTED!",
+                           f'> Priority : [5] | BGSStaticCollection : {logtext.count("BGSStaticCollection")} | BGSCombinedCellGeometryDB : {logtext.count("BGSCombinedCellGeometryDB")}',
+                           f'                        BSPackedCombinedGeomDataExtra : {logtext.count("BSPackedCombinedGeomDataExtra")} | TESObjectCELL : {logtext.count("TESObjectCELL")}'
+                           ])
         Buffout_Trap = True
         statU_Precomb += 1
     # ===========================================================
     if "HUDAmmoCounter" in logtext:
-        output.write("Checking for *[Ammo Counter Crash]........DETECTED!")
-        output.write(f'> Priority : [5] | HUDAmmoCounter : {logtext.count("HUDAmmoCounter")}')
+        output.writelines(["Checking for *[Ammo Counter Crash]........DETECTED!",
+                           f'> Priority : [5] | HUDAmmoCounter : {logtext.count("HUDAmmoCounter")}'
+                           ])
         Buffout_Trap = True
         statU_HUDAmmo += 1
     # ===========================================================
     if ("BGSProjectile" or "CombatProjectileAimController") in logtext:
-        output.write("Checking for *[NPC Projectile Crash].....DETECTED!")
-        output.write(f'> Priority : [5] | BGSProjectile : {logtext.count("BGSProjectile")} | CombatProjectileAimController : {logtext.count("CombatProjectileAimController")}')
+        output.writelines(["Checking for *[NPC Projectile Crash].....DETECTED!",
+                           f'> Priority : [5] | BGSProjectile : {logtext.count("BGSProjectile")} | CombatProjectileAimController : {logtext.count("CombatProjectileAimController")}'
+                           ])
         Buffout_Trap = True
     # ===========================================================
     if logtext.count("PlayerCharacter") >= 1 and (logtext.count("0x00000007") or logtext.count("0x00000014") or logtext.count("0x00000008")) >= 3:
         output.write("Checking for *[Player Character Crash]....DETECTED!")
         output.write(f'> Priority : [5] | PlayerCharacter : {logtext.count("PlayerCharacter")} | 0x00000007 : {logtext.count("0x00000007")}')
         output.write(f'                        0x00000008 : {logtext.count("0x00000008")} | 0x000000014 : {logtext.count("0x00000014")}')
+        output.writelines(["Checking for *[Player Character Crash]....DETECTED!",
+                           f'> Priority : [5] | PlayerCharacter : {logtext.count("PlayerCharacter")} | 0x00000007 : {logtext.count("0x00000007")}',
+                           f'                        0x00000008 : {logtext.count("0x00000008")} | 0x000000014 : {logtext.count("0x00000014")}'
+                           ])
         Buffout_Trap = True
         statU_Player += 1
 
     # ===========================================================
 
     if Buffout_Trap == False:  # DEFINE CHECK IF NOTHING TRIGGERED BUFFOUT TRAP
-        print("-----")
-        print("# AUTOSCAN FOUND NO CRASH ERRORS / CULPRITS THAT MATCH THE CURRENT DATABASE #")
-        print("Check below for mods that can cause frequent crashes and other problems.")
-        print("-----")
+        output.writelines([
+            "-----",
+            "# AUTOSCAN FOUND NO CRASH ERRORS / CULPRITS THAT MATCH THE CURRENT DATABASE #",
+            "Check below for mods that can cause frequent crashes and other problems.",
+            "-----"
+        ])
     else:
-        print("-----")
-        print("FOR DETAILED DESCRIPTIONS AND POSSIBLE SOLUTIONS TO ANY ABOVE DETECTED CRASH CULPRITS,")
-        print("SEE: https://docs.google.com/document/d/17FzeIMJ256xE85XdjoPvv_Zi3C5uHeSTQh6wOZugs4c")
-        print("-----")
+        output.writelines([
+            "-----",
+            "FOR DETAILED DESCRIPTIONS AND POSSIBLE SOLUTIONS TO ANY ABOVE DETECTED CRASH CULPRITS,",
+            "SEE: https://docs.google.com/document/d/17FzeIMJ256xE85XdjoPvv_Zi3C5uHeSTQh6wOZugs4c",
+            "-----"
+        ])
 
-    print("====================================================")
-    print("CHECKING FOR MODS THAT CAN CAUSE FREQUENT CRASHES...")
-    print("====================================================")
+    output.writelines([
+        "====================================================",
+        "CHECKING FOR MODS THAT CAN CAUSE FREQUENT CRASHES...",
+        "===================================================="
+    ])
     Mod_Trap1 = 1
 
     # Why lists and not dictionaries? So I can preserve alphabetical order in code and

--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from glob import glob
 import os
 import sys
 import stat
@@ -16,7 +17,8 @@ except ImportError:
     RequestsImportFailed = True
 import subprocess
 import configparser
-import ctypes.wintypes
+if platform.system() == "Windows":
+    import ctypes.wintypes
 
 if not os.path.exists("Scan Crashlogs.ini"):  # INI FILE FOR AUTO-SCANNER
     INI_Settings = ["[MAIN]\n",
@@ -47,6 +49,7 @@ CLAS_Date = "051122"  # DDMMYY
 CLAS_Current = "CLAS v5.90"
 CLAS_Update = False
 
+
 def run_update():
     print("CHECKING FOR PACKAGE & CRASH LOG AUTO-SCANNER UPDATES...")
     print("(You can disable this check in Scan Crashlogs.ini) \n")
@@ -64,6 +67,7 @@ def run_update():
     # print("===============================================================================")
     response = requests.get("https://api.github.com/repos/GuidanceOfGrace/Buffout4-CLAS/releases/latest")
     return response.json()["name"]
+
 
 if CLAS_config.getboolean("MAIN", "Update Check") == True:
     CLAS_Received = run_update()
@@ -100,7 +104,7 @@ statL_scanned = statL_incomplete = statL_failed = statL_veryold = 0
 # KNOWN CRASH MESSAGES
 statC_ActiveEffect = statC_AnimationPhysics = statC_Audio = statC_BA2Limit = statC_BGSM = statC_BitDefender = statC_BodyPhysics = statC_ConsoleCommands = statC_CorruptedTex = 0
 statC_DLL = statC_Equip = statC_Generic = statC_GridScrap = statC_Invalidation = statC_LoadOrder = statC_MCM = statC_BadMath = statC_NIF = statC_NPCPathing = statC_NVDebris = 0
-statC_NVDriver = statC_Null = statC_Overflow = statC_Papyrus = statC_Particles = statC_PluginLimit = statC_Rendering = statC_Texture = statC_CorruptedAudio = statC_LOD = 0
+statC_NVDriver = statC_Null = statC_Overflow = statC_Papyrus = statC_Particles = statC_PluginLimit = statC_Rendering = statlogtexture = statC_CorruptedAudio = statC_LOD = 0
 statC_Decal = statC_MO2Unp = statC_VulkanMem = statC_VulkanSet = statC_Water = 0
 # UNSOLVED CRASH MESSAGES
 statU_Precomb = statU_Player = statU_Save = statU_HUDAmmo = statU_Patrol = statU_Projectile = statU_Item = statU_Input = statU_INI = statU_CClub = 0
@@ -118,6 +122,7 @@ print("For Win 7, install this Py version: https://github.com/adang1345/PythonWi
 print("Click on the green Code button and Download Zip, then extract and install.")
 print("===============================================================================")
 FO4_STEAM_ID = 377160
+
 
 class Info:
     def __init__(self):
@@ -187,6 +192,7 @@ class Info:
                 with open("Scan Crashlogs.ini", "w+") as INI_Autoscan:
                     CLAS_config.write(INI_Autoscan)
 
+
 info = Info()
 # Create/Open Fallout4Custom.ini and check Archive Invalidaton & other settings.
 if CLAS_config.getboolean("MAIN", "FCX Mode") == True:
@@ -251,1243 +257,1230 @@ if info.Buffout_TOML.is_file():  # RENAME BECAUSE PYTHON CAN'T WRITE TO TOML
 
 print("\n PERFORMING SCAN... \n")
 start_time = time.time()
-orig_stdout = sys.stdout
+# orig_stdout = sys.stdout
 
-for file in os.listdir("."):
-    if fnmatch.fnmatch(file, "crash-*.log"):  # or fnmatch.fnmatch(file, "crash-*.txt") | RESERVED
-        logname = str(file)[:len(str(file)) - 4]
-        sys.stdout = open(logname + "-AUTOSCAN.md", "w", encoding='utf-8-sig', errors="ignore")
-        crashlog = str(logname + ".log")
-        if info.Steam_INI.is_file():
-            print(logname + ".log \U0001F480")
+logs = glob("crash-*.log")  # + glob("crash-*.txt") # For people who just HAVE to post their logs on pastebin.
+
+for file in logs:
+    logpath = Path(file).resolve()
+    scanpath = logpath.with_suffix("-AUTOSCAN.md")
+    logname = logpath.name
+    output = scanpath.open("w", encoding='utf-8-sig', errors="ignore")
+    logtext = logpath.read_text()
+    loglines: list | None = None
+    with logpath.open("r+", encoding="utf-8", errors="ignore") as lines:
+        loglines = lines.readlines()
+    output.write(logname)
+    output.write("This crash log was automatically scanned.")
+    output.write(f"VER {CLAS_Current[-4:]} | MIGHT CONTAIN FALSE POSITIVES.")
+    if CLAS_Update == True:
+        output.write("# NOTICE: YOU NEED TO UPDATE THE AUTO-SCANNER! #")
+    output.write("====================================================")
+    # DEFINE LINE INDEXES FOR EVERYTHING REQUIRED HERE
+    buff_ver = loglines[1].strip()
+    buff_error = loglines[3].strip()
+    plugin_idx = 1
+    for line in loglines:
+        if not "F4SE" in line and "PLUGINS:" in line:
+            plugin_idx = loglines.index(line)
+
+    plugin_list = loglines[plugin_idx:]
+    if os.path.exists("loadorder.txt"):
+        plugin_list = []
+        with open("loadorder.txt", "r", errors="ignore") as loadorder_check:
+            plugin_format = loadorder_check.readlines()
+            for line in plugin_format:
+                line = "[LO] " + line.strip()
+                plugin_list.append(line)
+
+    # BUFFOUT VERSION CHECK
+    buff_latest = "Buffout 4 v1.26.2"
+    output.write(f"Main Error: {buff_error}")
+    output.write("====================================================")
+    output.write(f"Detected Buffout Version: {buff_ver.strip()}")
+    output.write(f"Latest Buffout Version: {buff_latest.strip()}")
+
+    if buff_ver.casefold() == buff_latest.casefold():
+        output.write("You have the lastest version of Buffout 4!")
+    else:
+        output.write("REPORTED BUFFOUT VERSION DOES NOT MATCH THE BUFFOUT VERSION USED BY AUTOSCAN")
+        output.write("UPDATE BUFFOUT 4 IF NECESSARY: https://www.nexusmods.com/fallout4/mods/47359")
+
+    if "v1." not in buff_ver:
+        statL_veryold += 1
+        statL_scanned -= 1
+
+    output.write("====================================================")
+    output.write("CHECKING IF BUFFOUT 4 FILES/SETTINGS ARE CORRECT...")
+    output.write("====================================================")
+
+    ALIB_Load = BUFF_Load = False
+
+    # CHECK IF F4SE.LOG EXISTS AND REPORTS ANY ERRORS
+    if CLAS_config.getboolean("MAIN", "FCX Mode") == True:
+        output.write("* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *")
+        output.write("[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]")
+        output.write("-----")
+        Error_List = []
+        F4SE_Error = F4SE_Version = F4SE_Buffout = 0
+        with open(info.FO4_F4SE_Path, "r") as LOG_Check:
+            Error_Check = LOG_Check.readlines()
+            for line in Error_Check:
+                if "0.6.23" in line:
+                    F4SE_Version = 1
+                if "Error" in line:
+                    F4SE_Error = 1
+                    Error_List.append(line)
+                if "Buffout4.dll" in line and "loaded correctly" in line:
+                    F4SE_Buffout = 1
+
+        if F4SE_Version == 1:
+            output.write("You have the latest version of Fallout 4 Script Extender (F4SE). \n-----")
         else:
-            print(logname + ".log")
-        print("This crash log was automatically scanned.")
-        print("VER", CLAS_Current[-4:], "| MIGHT CONTAIN FALSE POSITIVES.")
-        if CLAS_Update == True:
-            print("# NOTICE: YOU NEED TO UPDATE THE AUTO-SCANNER! #")
-        print("====================================================")
+            output.write("# REPORTED F4SE VERSION DOES NOT MATCH THE F4SE VERSION USED BY AUTOSCAN #")
+            output.write("UPDATE FALLOUT 4 SCRIPT EXTENDER IF NECESSARY: https://f4se.silverlock.org")
+            output.write("-----")
 
-        # OPEN FILE TO CHECK LINE INDEXES AND EVERYTHING ELSE
-        crash_version = open(crashlog, "r", errors="ignore")
-        # DEFINE LINE INDEXES FOR EVERYTHING REQUIRED HERE
-        all_lines = crash_version.readlines()
-        buff_ver = str(all_lines[1].strip())
-        buff_error = str(all_lines[3].strip())
-        plugin_idx = 1
-        for line in all_lines:
-            if not "F4SE" in line and "PLUGINS:" in line:
-                plugin_idx = all_lines.index(line)
-
-        plugin_list = all_lines[plugin_idx:]
-        if os.path.exists("loadorder.txt"):
-            plugin_list = []
-            with open("loadorder.txt", "r", errors="ignore") as loadorder_check:
-                plugin_format = loadorder_check.readlines()
-                for line in plugin_format:
-                    line = "[LO] " + line.strip()
-                    plugin_list.append(line)
-
-        # BUFFOUT VERSION CHECK
-        buff_latest = "Buffout 4 v1.26.2"
-        print("Main Error:", buff_error)
-        print("====================================================")
-        print("Detected Buffout Version:", buff_ver.strip())
-        print("Latest Buffout Version:", buff_latest.strip())
-
-        if buff_ver.casefold() == buff_latest.casefold():
-            print("You have the lastest version of Buffout 4!")
+        if F4SE_Error == 1:
+            output.write("# SCRIPT EXTENDER REPORTS THAT THE FOLLOWING PLUGINS FAILED TO LOAD! #")
+            for elem in Error_List:
+                output.write(f"{elem}\n-----")
         else:
-            print("REPORTED BUFFOUT VERSION DOES NOT MATCH THE BUFFOUT VERSION USED BY AUTOSCAN")
-            print("UPDATE BUFFOUT 4 IF NECESSARY: https://www.nexusmods.com/fallout4/mods/47359")
+            output.write("Script Extender reports that all DLL mod plugins have loaded correctly. \n-----")
 
-        if "v1." not in buff_ver:
-            statL_veryold += 1
-            statL_scanned -= 1
-
-        # CLOSE CURRENT FILE & OPEN FILE AGAIN FOR ANOTHER CHECK
-        crash_version.close()
-        c_log = open(crashlog, "r", errors="ignore")
-        c_text = c_log.read()
-
-        print("====================================================")
-        print("CHECKING IF BUFFOUT 4 FILES/SETTINGS ARE CORRECT...")
-        print("====================================================")
-
-        ALIB_Load = BUFF_Load = False
-
-        # CHECK IF F4SE.LOG EXISTS AND REPORTS ANY ERRORS
-        if CLAS_config.getboolean("MAIN", "FCX Mode") == True:
-            print("* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *")
-            print("[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]")
-            print("-----")
-            Error_List = []
-            F4SE_Error = F4SE_Version = F4SE_Buffout = 0
-            with open(info.FO4_F4SE_Path, "r") as LOG_Check:
-                Error_Check = LOG_Check.readlines()
-                for line in Error_Check:
-                    if "0.6.23" in line:
-                        F4SE_Version = 1
-                    if "Error" in line:
-                        F4SE_Error = 1
-                        Error_List.append(line)
-                    if "Buffout4.dll" in line and "loaded correctly" in line:
-                        F4SE_Buffout = 1
-
-            if F4SE_Version == 1:
-                print("You have the latest version of Fallout 4 Script Extender (F4SE). \n-----")
-            else:
-                print("# REPORTED F4SE VERSION DOES NOT MATCH THE F4SE VERSION USED BY AUTOSCAN #")
-                print("UPDATE FALLOUT 4 SCRIPT EXTENDER IF NECESSARY: https://f4se.silverlock.org")
-                print("-----")
-
-            if F4SE_Error == 1:
-                print("# SCRIPT EXTENDER REPORTS THAT THE FOLLOWING PLUGINS FAILED TO LOAD! #")
-                for elem in Error_List:
-                    print(elem + "\n-----")
-            else:
-                print("Script Extender reports that all DLL mod plugins have loaded correctly. \n-----")
-
-            if F4SE_Buffout == 1:
-                print("Script Extender reports that Buffout 4.dll was found and loaded correctly. \n-----")
-                ALIB_Load = BUFF_Load = True
-            else:
-                print("# SCRIPT EXTENDER REPORTS THAT BUFFOUT 4.DLL FAILED TO LOAD OR IS MISSING! #")
-                print("Follow Buffout 4 installation steps here: https://www.nexusmods.com/fallout4/articles/3115")
-                print("Buffout 4: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47359")
-                print("-----")
-
-            list_ERRORLOG = []
-            for file in info.FO4_F4SE_Logs:
-                if fnmatch.fnmatch(file, ".log"):
-                    with open(file, "r+") as LOG_Check:
-                        Log_Errors = LOG_Check.read()
-                        if "error" in Log_Errors.lower():
-                            logname = str(file)
-                            if not logname == "f4se.log":
-                                list_ERRORLOG.append(logname)
-
-            if len(list_ERRORLOG) >= 1:
-                print("# CAUTION: THE FOLLOWING DLL LOGS ALSO REPORT ONE OR MORE ERRORS : #")
-                print("[These are located in your Documents/My Games/Fallout4/F4SE folder.]")
-                for elem in list_ERRORLOG:
-                    print(elem + "\n-----")
-            else:
-                print("Available DLL logs do not report any additional errors, all is well. \n-----")
-
-        # CHECK BUFFOUT 4 REQUIREMENTS AND TOML SETTINGS
-            if info.Preloader_XML.is_file() and info.Preloader_DLL.is_file():
-                print('OPTIONAL: Plugin Preloader is (manually) installed.')
-                print('NOTICE: If the game fails to start after installing this mod, open xSE PluginPreloader.xml with a text editor and CHANGE')
-                print('<LoadMethod Name="ImportAddressHook"> TO <LoadMethod Name="OnThreadAttach"> OR <LoadMethod Name="OnProcessAttach">')
-                print('IF THE GAME STILL REFUSES TO START, COMPLETELY REMOVE xSE PluginPreloader.xml AND IpHlpAPI.dll FROM YOUR FO4 GAME FOLDER')
-                print("-----")
-            else:
-                print('OPTIONAL: Plugin Preloader is not (manually) installed.\n-----')
-
-            if info.F4SE_Loader.is_file() and info.F4SE_DLL.is_file() and info.F4SE_SDLL.is_file():
-                print("REQUIRED: Fallout 4 Script Extender is (manually) installed. \n-----")
-            else:
-                print("# CAUTION: Auto-Scanner cannot find Script Extender files or they aren't (manually) installed! #")
-                print("FIX: Extract all files inside *f4se_0_06_21* folder into your Fallout 4 game folder.")
-                print("FALLOUT 4 SCRIPT EXTENDER: (Download Build 0.6.23) https://f4se.silverlock.org")
-                print("-----")
-
-            if info.Address_Library.is_file() or ALIB_Load == True:
-                print("REQUIRED: Address Library is (manually) installed. \n-----")
-            else:
-                print("# CAUTION: Auto-Scanner cannot find the Adress Library file or it isn't (manually) installed! #")
-                print("FIX: Place the *version-1-10-163-0.bin* file manually into Fallout 4/Data/F4SE/Plugins folder.")
-                print("ADDRESS LIBRARY: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47327?tab=files")
-                print("-----")
-
-            if info.Buffout_INI.is_file() and info.Buffout_DLL.is_file() or BUFF_Load == True:
-                with open(info.Buffout_INI, "r+") as BUFF_Custom:
-                    BUFF_config = BUFF_Custom.read()
-                    print("REQUIRED: Buffout 4 is (manually) installed. Checking configuration...\n-----")
-                    if ("achievements.dll" or "UnlimitedSurvivalMode.dll") in c_text and "Achievements = true" in BUFF_config:
-                        print("# CAUTION: Achievements Mod and/or Unlimited Survival Mode is installed, but Achievements parameter is set to TRUE #")
-                        print("Auto-Scanner will change this parameter to FALSE to prevent conflicts with Buffout 4.")
-                        print("-----")
-                        BUFF_config = BUFF_config.replace("Achievements = true", "Achievements = false")
-                    else:
-                        print("Achievements parameter in *Buffout4.toml* is correctly configured. \n-----")
-
-                    if "BakaScrapHeap.dll" in c_text and "MemoryManager = true" in BUFF_config:
-                        print("# CAUTION: Baka ScrapHeap is installed, but MemoryManager parameter is set to TRUE #")
-                        print("Auto-Scanner will change this parameter to FALSE to prevent conflicts with Buffout 4.")
-                        print("-----")
-                        BUFF_config = BUFF_config.replace("MemoryManager = true", "MemoryManager = false")
-                    else:
-                        print("Memory Manager parameter in *Buffout4.toml* is correctly configured. \n-----")
-
-                    if "f4ee.dll" in c_text and "F4EE = false" in BUFF_config:
-                        print("# CAUTION: Looks Menu is installed, but F4EE parameter under [Compatibility] is set to FALSE #")
-                        print("Auto-Scanner will change this parameter to TRUE to prevent bugs and crashes from Looks Menu.")
-                        print("-----")
-                        BUFF_config = BUFF_config.replace("F4EE = false", "F4EE = true")
-                    else:
-                        print("Looks Menu (F4EE) parameter in *Buffout4.toml* is correctly configured. \n-----")
-                with open(info.Buffout_INI, "w+") as BUFF_Custom:
-                    BUFF_Custom.write(BUFF_config)
-            else:
-                print("# CAUTION: Auto-Scanner cannot find Buffout 4 files or they aren't (manually) installed! #")
-                print("FIX: Follow Buffout 4 installation steps here: https://www.nexusmods.com/fallout4/articles/3115")
-                print("BUFFOUT 4: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47359?tab=files")
-                print("-----")
-
-        else:  # INSTRUCTIONS FOR MANUAL FIXING WHEN FCX MODE IS FALSE
-            if ("Achievements: true" in c_text and "achievements.dll" in c_text) or ("Achievements: true" in c_text and "UnlimitedSurvivalMode.dll" in c_text):
-                print("# CAUTION: Achievements Mod and/or Unlimited Survival Mode is installed, but Achievements parameter is set to TRUE #")
-                print("FIX: Open *Buffout4.toml* and change Achievements parameter to FALSE, this prevents conflicts with Buffout 4.")
-                print("-----")
-            else:
-                print("Achievements parameter in *Buffout4.toml* is correctly configured. \n-----")
-
-            if "MemoryManager: true" in c_text and "BakaScrapHeap.dll" in c_text:
-                print("# CAUTION: Baka ScrapHeap is installed, but MemoryManager parameter is set to TRUE #")
-                print("FIX: Open *Buffout4.toml* and change MemoryManager parameter to FALSE, this prevents conflicts with Buffout 4.")
-                print("-----")
-            else:
-                print("Memory Manager parameter in *Buffout4.toml* is correctly configured. \n-----")
-
-            if "F4EE: false" in c_text and "f4ee.dll" in c_text:
-                print("# CAUTION: Looks Menu is installed, but F4EE parameter under [Compatibility] is set to FALSE #")
-                print("FIX: Open *Buffout4.toml* and change F4EE parameter to TRUE, this prevents bugs and crashes from Looks Menu.")
-                print("-----")
-            else:
-                print("Looks Menu (F4EE) parameter in *Buffout4.toml* is correctly configured. \n-----")
-
-        print("====================================================")
-        print("CHECKING IF LOG MATCHES ANY KNOWN CRASH MESSAGES...")
-        print("====================================================")
-        Buffout_Trap = False  # RETURN TRUE IF KNOWN CRASH MESSAGE WAS FOUND
-
-        # ====================== HEADER ERRORS ======================
-
-        if ".dll" in buff_error and "tbbmalloc" not in buff_error:
-            print("# MAIN ERROR REPORTS A DLL WAS INVLOVED IN THIS CRASH! # \n-----")
-
-        if "EXCEPTION_STACK_OVERFLOW" in buff_error:
-            print("# Checking for Stack Overflow Crash.........CULPRIT FOUND! #")
-            print("> Priority : [5]")
-            Buffout_Trap = True
-            statC_Overflow += 1
-
-        if "0x000100000000" in buff_error:
-            print("# Checking for Active Effects Crash.........CULPRIT FOUND! #")
-            print("> Priority : [5]")
-            Buffout_Trap = True
-            statC_ActiveEffect += 1
-
-        if "EXCEPTION_INT_DIVIDE_BY_ZERO" in buff_error:
-            print("# Checking for Bad Math Crash...............CULPRIT FOUND! #")
-            print("> Priority : [5]")
-            Buffout_Trap = True
-            statC_BadMath += 1
-
-        if "0x000000000000" in buff_error:
-            print("# Checking for Null Crash...................CULPRIT FOUND! #")
-            print("> Priority : [5]")
-            Buffout_Trap = True
-            statC_Null += 1
-
-        # ======================= MAIN ERRORS =======================
-
-        # OTHER | RESERVED
-        # *[Creation Club Crash] | +01B59A4
-        # Uneducated Shooter (56789) | c_text.count("std::invalid_argument")
-        # c_text.count("BSResourceNiBinaryStream")
-        # c_text.count("ObjectBindPolicy")
-
-        # ===========================================================
-        if "DLCBannerDLC01.dds" in c_text:
-            print("# Checking for DLL Crash....................CULPRIT FOUND! #")
-            print("> Priority : [5] | DLCBannerDLC01.dds : ", c_text.count("DLCBannerDLC01.dds"))
-            Buffout_Trap = True
-            statC_DLL += 1
-        # ===========================================================
-        if "BGSLocation" in c_text and "BGSQueuedTerrainInitialLoad" in c_text:
-            print("# Checking for LOD Crash....................CULPRIT FOUND! #")
-            print("> Priority : [5] | BGSLocation : ", c_text.count("BGSLocation"), " | BGSQueuedTerrainInitialLoad : ", c_text.count("BGSQueuedTerrainInitialLoad"))
-            Buffout_Trap = True
-            statC_LOD += 1
-        # ===========================================================
-        if ("FaderData" or "FaderMenu" or "UIMessage") in c_text:
-            print("# Checking for MCM Crash....................CULPRIT FOUND! #")
-            print("> Priority : [3] | FaderData : ", c_text.count("FaderData"), " | FaderMenu : ", c_text.count("FaderMenu"), " | UIMessage : ", c_text.count("UIMessage"))
-            Buffout_Trap = True
-            statC_MCM += 1
-        # ===========================================================
-        if ("BGSDecalManager" or "BSTempEffectGeometryDecal") in c_text:
-            print("# Checking for Decal Crash..................CULPRIT FOUND! #")
-            print("> Priority : [5] | BGSDecalManager : ", c_text.count("BGSDecalManager"), " | BSTempEffectGeometryDecal : ", c_text.count("BSTempEffectGeometryDecal"))
-            Buffout_Trap = True
-            statC_Decal += 1
-        # ===========================================================
-        if c_text.count("PipboyMapData") >= 2:
-            print("# Checking for Equip Crash..................CULPRIT FOUND! #")
-            print("> Priority : [2] | PipboyMapData : ", c_text.count("PipboyMapData"))
-            Buffout_Trap = True
-            statC_Equip += 1
-        # ===========================================================
-        if (c_text.count("Papyrus") or c_text.count("VirtualMachine")) >= 2:
-            print("# Checking for Script Crash.................CULPRIT FOUND! #")
-            print("> Priority : [3] | Papyrus : ", c_text.count("Papyrus"), " | VirtualMachine : ", c_text.count("VirtualMachine"))
-            Buffout_Trap = True
-            statC_Papyrus += 1
-        # ===========================================================
-        if c_text.count("tbbmalloc.dll") >= 3 or "tbbmalloc" in buff_error:
-            print("# Checking for Generic Crash................CULPRIT FOUND! #")
-            print("> Priority : [2] | tbbmalloc.dll : ", c_text.count("tbbmalloc.dll"))
-            Buffout_Trap = True
-            statC_Generic += 1
-        # ===========================================================
-        if "LooseFileAsyncStream" in c_text:
-            print("# Checking for BA2 Limit Crash..............CULPRIT FOUND! #")
-            print("> Priority : [5] | LooseFileAsyncStream : ", c_text.count("LooseFileAsyncStream"))
-            Buffout_Trap = True
-            statC_BA2Limit += 1
-        # ===========================================================
-        if c_text.count("d3d11.dll") >= 3 or "d3d11" in buff_error:
-            print("# Checking for Rendering Crash..............CULPRIT FOUND! #")
-            print("> Priority : [4] | d3d11.dll : ", c_text.count("d3d11.dll"))
-            Buffout_Trap = True
-            statC_Rendering += 1
-        # ===========================================================
-        if ("GridAdjacencyMapNode" or "PowerUtils") in c_text:
-            print("# Checking for Grid Scrap Crash.............CULPRIT FOUND! #")
-            print("> Priority : [5] | GridAdjacencyMapNode : ", c_text.count("GridAdjacencyMapNode"), " | PowerUtils : ", c_text.count("PowerUtils"))
-            Buffout_Trap = True
-            statC_GridScrap += 1
-        # ===========================================================
-        if ("LooseFileStream" or "BSFadeNode" or "BSMultiBoundNode") in c_text and c_text.count("LooseFileAsyncStream") == 0:
-            print("# Checking for Mesh (NIF) Crash.............CULPRIT FOUND! #")
-            print("> Priority : [4] | LooseFileStream : ", c_text.count("LooseFileStream"), " | BSFadeNode : ", c_text.count("BSFadeNode"))
-            print("                   BSMultiBoundNode : ", c_text.count("BSMultiBoundNode"))
-            Buffout_Trap = True
-            statC_NIF += 1
-        # ===========================================================
-        if ("Create2DTexture" or "DefaultTexture") in c_text:
-            print("# Checking for Texture (DDS) Crash..........CULPRIT FOUND! #")
-            print("> Priority : [3] | Create2DTexture : ", c_text.count("Create2DTexture"), " | DefaultTexture : ", c_text.count("DefaultTexture"))
-            Buffout_Trap = True
-            statC_Texture += 1
-        # ===========================================================
-        if ("DefaultTexture_Black" or "NiAlphaProperty") in c_text:
-            print("# Checking for Material (BGSM) Crash........CULPRIT FOUND! #")
-            print("> Priority : [3] | DefaultTexture_Black : ", c_text.count("DefaultTexture_Black"), " | NiAlphaProperty : ", c_text.count("NiAlphaProperty"))
-            Buffout_Trap = True
-            statC_BGSM += 1
-        # ===========================================================
-        if (c_text.count("bdhkm64.dll") or c_text.count("usvfs::hook_DeleteFileW")) >= 2:
-            print("# Checking for BitDefender Crash............CULPRIT FOUND! #")
-            print("> Priority : [5] | bdhkm64.dll : ", c_text.count("bdhkm64.dll"), " | usvfs::hook_DeleteFileW : ", c_text.count("usvfs::hook_DeleteFileW"))
-            Buffout_Trap = True
-            statC_BitDefender += 1
-        # ===========================================================
-        if ("PathingCell" or "BSPathBuilder" or "PathManagerServer") in c_text:
-            print("# Checking for NPC Pathing Crash............CULPRIT FOUND! #")
-            print("> Priority : [3] | PathingCell : ", c_text.count("PathingCell"), " | BSPathBuilder : ", c_text.count("BSPathBuilder"))
-            print("                   PathManagerServer : ", c_text.count("PathManagerServer"))
-            Buffout_Trap = True
-            statC_NPCPathing += 1
-        elif ("NavMesh" or "BSNavmeshObstacleData" or "DynamicNavmesh") in c_text:
-            print("# Checking for NPC Pathing Crash............CULPRIT FOUND! #")
-            print("> Priority : [3] | NavMesh : ", c_text.count("NavMesh"), " | BSNavmeshObstacleData : ", c_text.count("BSNavmeshObstacleData"))
-            print("                   DynamicNavmesh : ", c_text.count("DynamicNavmesh"))
-            Buffout_Trap = True
-            statC_NPCPathing += 1
-        # ===========================================================
-        if c_text.count("X3DAudio1_7.dll") >= 3 or c_text.count("XAudio2_7.dll") >= 3 or ("X3DAudio1_7" or "XAudio2_7") in buff_error:
-            print("# Checking for Audio Driver Crash...........CULPRIT FOUND! #")
-            print("> Priority : [5] | X3DAudio1_7.dll : ", c_text.count("X3DAudio1_7.dll"), " | XAudio2_7.dll : ", c_text.count("XAudio2_7.dll"))
-            Buffout_Trap = True
-            statC_Audio += 1
-        # ===========================================================
-        if c_text.count("cbp.dll") >= 3 or "skeleton.nif" in c_text or "cbp.dll" in buff_error:
-            print("# Checking for Body Physics Crash...........CULPRIT FOUND! #")
-            print("> Priority : [4] | cbp.dll : ", c_text.count("cbp.dll"), " | skeleton.nif : ", c_text.count("skeleton.nif"))
-            Buffout_Trap = True
-            statC_BodyPhysics += 1
-        # ===========================================================
-        if ("BSMemStorage" or "DataFileHandleReaderWriter") in c_text:
-            print("# Checking for Plugin Limit Crash...........CULPRIT FOUND! #")
-            print("> Priority : [5] | BSMemStorage : ", c_text.count("BSMemStorage"), " | DataFileHandleReaderWriter : ", c_text.count("DataFileHandleReaderWriter"))
-            Buffout_Trap = True
-            statC_PluginLimit += 1
-        # ===========================================================
-        if "GamebryoSequenceGenerator" in c_text or "+0DB9300" in buff_error:
-            print("# Checking for Plugin Order Crash...........CULPRIT FOUND! #")
-            print("> Priority : [5] | GamebryoSequenceGenerator : ", c_text.count("GamebryoSequenceGenerator"))
-            Buffout_Trap = True
-            statC_LoadOrder += 1
-        # ===========================================================
-        if c_text.count("BSD3DResourceCreator") == 3 or c_text.count("BSD3DResourceCreator") == 6:
-            print("# Checking for MO2 Extractor Crash..........CULPRIT FOUND! #")
-            print("> Priority : [5] | BSD3DResourceCreator : ", c_text.count("BSD3DResourceCreator"))
-            Buffout_Trap = True
-            statC_MO2Unp += 1
-        # ===========================================================
-        if c_text.count("flexRelease_x64.dll") >= 2 or "flexRelease_x64" in buff_error:
-            print("# Checking for Nvidia Debris Crash..........CULPRIT FOUND! #")
-            print("> Priority : [5] | flexRelease_x64.dll : ", c_text.count("flexRelease_x64.dll"))
-            Buffout_Trap = True
-            statC_NVDebris += 1
-        # ===========================================================
-        if c_text.count("nvwgf2umx.dll") >= 10 or ("nvwgf2umx" or "USER32.dll") in buff_error:
-            print("# Checking for Nvidia Driver Crash..........CULPRIT FOUND! #")
-            print("> Priority : [5] | nvwgf2umx.dll : ", c_text.count("nvwgf2umx.dll"), " | USER32.dll : ", c_text.count("USER32.dll"))
-            Buffout_Trap = True
-            statC_NVDriver += 1
-        # ===========================================================
-        if (c_text.count("KERNELBASE.dll") or c_text.count("MSVCP140.dll")) >= 3 and "DxvkSubmissionQueue" in c_text:
-            print("# Checking for Vulkan Memory Crash..........CULPRIT FOUND! #")
-            print("> Priority : [5] | KERNELBASE.dll : ", c_text.count("KERNELBASE.dll"), " | MSVCP140.dll : ", c_text.count("MSVCP140.dll"))
-            print("                   DxvkSubmissionQueue : ", c_text.count("DxvkSubmissionQueue"))
-            Buffout_Trap = True
-            statC_VulkanMem += 1
-        # ===========================================================
-        if ("dxvk::DXGIAdapter" or "dxvk::DXGIFactory") in c_text:
-            print("# Checking for Vulkan Settings Crash........CULPRIT FOUND! #")
-            print("> Priority : [5] | dxvk::DXGIAdapter : ", c_text.count("dxvk::DXGIAdapter"), " | dxvk::DXGIFactory : ", c_text.count("dxvk::DXGIFactory"))
-            Buffout_Trap = True
-            statC_VulkanSet += 1
-        # ===========================================================
-        if ("BSXAudio2DataSrc" or "BSXAudio2GameSound") in c_text:
-            print("# Checking for Corrupted Audio Crash........CULPRIT FOUND! #")
-            print("> Priority : [4] | BSXAudio2DataSrc : ", c_text.count("BSXAudio2DataSrc"), " | BSXAudio2GameSound : ", c_text.count("BSXAudio2GameSound"))
-            Buffout_Trap = True
-            statC_CorruptedAudio += 1
-        # ===========================================================
-        if ("SysWindowCompileAndRun" or "ConsoleLogPrinter") in c_text:
-            print("# Checking for Console Command Crash........CULPRIT FOUND! #")
-            print("> Priority : [1] | SysWindowCompileAndRun : ", c_text.count("SysWindowCompileAndRun"), " | ConsoleLogPrinter : ", c_text.count("ConsoleLogPrinter"))
-            Buffout_Trap = True
-            statC_ConsoleCommands += 1
-        # ===========================================================
-        if "BGSWaterCollisionManager" in c_text:
-            print("# Checking for Water Collision Crash........CULPRIT FOUND! #")
-            print("PLEASE CONTACT ME AS SOON AS POSSIBLE! (CONTACT INFO BELOW)")
-            print("> Priority : [6] | BGSWaterCollisionManager : ", c_text.count("BGSWaterCollisionManager"))
-            Buffout_Trap = True
-            statC_Water += 1
-        # ===========================================================
-        if "ParticleSystem" in c_text:
-            print("# Checking for Particle Effects Crash.......CULPRIT FOUND! #")
-            print("> Priority : [4] | ParticleSystem : ", c_text.count("ParticleSystem"))
-            Buffout_Trap = True
-            statC_Particles += 1
-        # ===========================================================
-        if ("hkbVariableBindingSet" or "hkbHandIkControlsModifier" or "hkbBehaviorGraph" or "hkbModifierList") in c_text:
-            print("# Checking for Animation / Physics Crash....CULPRIT FOUND! #")
-            print("> Priority : [5] | hkbVariableBindingSet : ", c_text.count("hkbVariableBindingSet"), " | hkbHandIkControlsModifier : ", c_text.count("hkbHandIkControlsModifier"))
-            print("                   hkbBehaviorGraph : ", c_text.count("hkbBehaviorGraph"), " | hkbModifierList : ", c_text.count("hkbModifierList"))
-            Buffout_Trap = True
-            statC_AnimationPhysics += 1
-        # ===========================================================
-        if "DLCBanner05.dds" in c_text:
-            print("# Checking for Archive Invalidation Crash...CULPRIT FOUND! #")
-            print("> Priority : [5] | DLCBanner05.dds : ", c_text.count("DLCBanner05.dds"))
-            Buffout_Trap = True
-            statC_Invalidation += 1
-
-        # ===========================================================
-        print("---------- Unsolved Crash Messages Below ----------")
-
-        if "+01B59A4" in buff_error:
-            print("Checking for *[Creation Club Crash].......DETECTED!")
-            print("> Priority : [5]")
-            Buffout_Trap = True
-            statU_CClub += 1
-
-        if ("BGSMod::Attachment" or "BGSMod::Template" or "BGSMod::Template::Item") in c_text:
-            print("Checking for *[Item Crash]................DETECTED!")
-            print("> Priority : [5] | BGSMod::Attachment : ", c_text.count("BGSMod::Attachment"), " | BGSMod::Template : ", c_text.count("BGSMod::Template"))
-            print("                        BGSMod::Template::Item : ", c_text.count("BGSMod::Template::Item"))
-            Buffout_Trap = True
-            statU_Item += 1
-        # ===========================================================
-        if c_text.count("BGSSaveFormBuffer") >= 2:
-            print("Checking for *[Save Crash]................DETECTED!")
-            print("> Priority : [5] | BGSSaveFormBuffer : ", c_text.count("BGSSaveFormBuffer"))
-            Buffout_Trap = True
-            statU_Save += 1
-        # ===========================================================
-        if ("ButtonEvent" or "MenuControls" or "MenuOpenCloseHandler" or "PlayerControls" or "DXGISwapChain") in c_text:
-            print("Checking for *[Input Crash]...............DETECTED!")
-            print("> Priority : [5] | ButtonEvent : ", c_text.count("ButtonEvent"), " | MenuControls : ", c_text.count("MenuControls"))
-            print("                        MenuOpenCloseHandler : ", c_text.count("MenuOpenCloseHandler"), " | PlayerControls : ", c_text.count("PlayerControls"))
-            print("                        DXGISwapChain : ", c_text.count("DXGISwapChain"))
-            Buffout_Trap = True
-            statU_Input += 1
-        # ===========================================================
-        if ("BGSSaveLoadManager" or "BGSSaveLoadThread" or "BGSSaveFormBuffer") in c_text or ("+0CDAD30" or "+0D09AB7") in buff_error:
-            print("Checking for *[Bad INI Crash].............DETECTED!")
-            print("> Priority : [5] | BGSSaveLoadManager : ", c_text.count("BGSSaveLoadManager"), " | BGSSaveLoadThread : ", c_text.count("BGSSaveLoadThread"))
-            print("                        BGSSaveFormBuffer : ", c_text.count("BGSSaveFormBuffer"))
-            Buffout_Trap = True
-            statU_INI += 1
-        # ===========================================================
-        if ("BGSProcedurePatrol" or "BGSProcedurePatrolExecState" or "PatrolActorPackageData") in c_text:
-            print("Checking for *[NPC Patrol Crash]..........DETECTED!")
-            print("> Priority : [5] | BGSProcedurePatrol : ", c_text.count("BGSProcedurePatrol"), " | BGSProcedurePatrolExecStatel : ", c_text.count("BGSProcedurePatrolExecState"))
-            print("                        PatrolActorPackageData : ", c_text.count("PatrolActorPackageData"))
-            Buffout_Trap = True
-            statU_Patrol += 1
-        # ===========================================================
-        if ("BSPackedCombinedGeomDataExtra" or "BGSCombinedCellGeometryDB" or "BGSStaticCollection" or "TESObjectCELL") in c_text:
-            print("Checking for *[Precombines Crash].........DETECTED!")
-            print("> Priority : [5] | BGSStaticCollection : ", c_text.count("BGSStaticCollection"), " | BGSCombinedCellGeometryDB : ", c_text.count("BGSCombinedCellGeometryDB"))
-            print("                        BSPackedCombinedGeomDataExtra : ", c_text.count("BSPackedCombinedGeomDataExtra"), " | TESObjectCELL : ", c_text.count("TESObjectCELL"))
-            Buffout_Trap = True
-            statU_Precomb += 1
-        # ===========================================================
-        if "HUDAmmoCounter" in c_text:
-            print("Checking for *[Ammo Counter Crash]........DETECTED!")
-            print("> Priority : [5] | HUDAmmoCounter : ", c_text.count("HUDAmmoCounter"))
-            Buffout_Trap = True
-            statU_HUDAmmo += 1
-        # ===========================================================
-        if ("BGSProjectile" or "CombatProjectileAimController") in c_text:
-            print("Checking for *[NPC Projectile Crash].....DETECTED!")
-            print("> Priority : [5] | BGSProjectile : ", c_text.count("BGSProjectile"), " | CombatProjectileAimController : ", c_text.count("CombatProjectileAimController"))
-            Buffout_Trap = True
-        # ===========================================================
-        if c_text.count("PlayerCharacter") >= 1 and (c_text.count("0x00000007") or c_text.count("0x00000014") or c_text.count("0x00000008")) >= 3:
-            print("Checking for *[Player Character Crash]....DETECTED!")
-            print("> Priority : [5] | PlayerCharacter : ", c_text.count("PlayerCharacter"), " | 0x00000007 : ", c_text.count("0x00000007"))
-            print("                        0x00000008 : ", c_text.count("0x00000008"), " | 0x000000014 : ", c_text.count("0x00000014"))
-            Buffout_Trap = True
-            statU_Player += 1
-
-        # ===========================================================
-
-        if Buffout_Trap == False:  # DEFINE CHECK IF NOTHING TRIGGERED BUFFOUT TRAP
-            print("-----")
-            print("# AUTOSCAN FOUND NO CRASH ERRORS / CULPRITS THAT MATCH THE CURRENT DATABASE #")
-            print("Check below for mods that can cause frequent crashes and other problems.")
-            print("-----")
+        if F4SE_Buffout == 1:
+            output.write("Script Extender reports that Buffout 4.dll was found and loaded correctly. \n-----")
+            ALIB_Load = BUFF_Load = True
         else:
-            print("-----")
-            print("FOR DETAILED DESCRIPTIONS AND POSSIBLE SOLUTIONS TO ANY ABOVE DETECTED CRASH CULPRITS,")
-            print("SEE: https://docs.google.com/document/d/17FzeIMJ256xE85XdjoPvv_Zi3C5uHeSTQh6wOZugs4c")
-            print("-----")
+            output.write("# SCRIPT EXTENDER REPORTS THAT BUFFOUT 4.DLL FAILED TO LOAD OR IS MISSING! #")
+            output.write("Follow Buffout 4 installation steps here: https://www.nexusmods.com/fallout4/articles/3115")
+            output.write("Buffout 4: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47359")
+            output.write("-----")
 
-        print("====================================================")
-        print("CHECKING FOR MODS THAT CAN CAUSE FREQUENT CRASHES...")
-        print("====================================================")
-        Mod_Trap1 = 1
+        list_ERRORLOG = []
+        for file in info.FO4_F4SE_Logs:
+            if fnmatch.fnmatch(file, ".log"):
+                with open(file, "r+") as LOG_Check:
+                    Log_Errors = LOG_Check.read()
+                    if "error" in Log_Errors.lower():
+                        logname = str(file)
+                        if not logname == "f4se.log":
+                            list_ERRORLOG.append(logname)
 
-        # Why lists and not dictionaries? So I can preserve alphabetical order in code and
-        # numerical order in output without having to rename a bunch of variables.
-        # Needs 1 empty space as prefix to prevent duplicates.
-        List_Mods1 = [" DamageThresholdFramework.esm",
-                      " Endless Warfare.esm",
-                      " ExtendedWeaponSystem.esm",
-                      " EPO",
-                      " SakhalinWasteland",
-                      " 76HUD",
-                      " NCRenegade",
-                      " Respawnable Legendary Bosses",
-                      " Scrap Everything - Core",
-                      " Scrap Everything - Ultimate",
-                      " Shade Girl Leather Outfits",
-                      " SpringCleaning.esm",
-                      " (STO) NO",
-                      " TacticalTablet.esp",
-                      " True Nights v03.esp",
-                      " WeaponsFramework",
-                      " WOTC.esp"]
-
-        List_Warn1 = ["DAMAGE THRESHOLD FRAMEWORK \n"
-                      "- Can cause crashes in combat on some occasions due to how damage calculations are done.",
-
-                      "ENDLESS WARFARE \n"
-                      "- Some enemy spawn points could be bugged or crash the game due to scripts or pathfinding.",
-
-                      "EXTENDED WEAPON SYSTEMS \n"
-                      "- Alternative to Tactical Reload that suffers from similar weapon related problems and crashes.",
-
-                      "EXTREME PARTICLES OVERHAUL \n"
-                      "- Can cause particle effects related crashes, its INI file raises particle count to 500000. \n"
-                      "  Consider switching to Burst Impact Blast FX: https://www.nexusmods.com/fallout4/mods/57789",
-
-                      "FALLOUT SAKHALIN \n"
-                      "- Breaks the precombine system all across Far Harbor which will randomly crash your game.",
-
-                      "HUD76 HUD REPLACER \n"
-                      "- Can sometimes cause interface and pip-boy related bugs, glitches and crashes.",
-
-                      "NCR RENEGADE ARMOR \n"
-                      "- Broken outfit mesh that crashes the game in 3rd person or when NPCs wearing it are hit.",
-
-                      "RESPAWNABLE LEGENDARY BOSSES \n"
-                      "- Can sometimes cause Deathclaw / Behmoth boulder projectile crashes for unknown reasons.",
-
-                      "SCRAP EVERYTHING (CORE) \n"
-                      "- Weird crashes and issues due to multiple unknown problems. This mod must be always last in your load order.",
-
-                      "SCRAP EVERYTHING (ULTIMATE) \n"
-                      "- Weird crashes and issues due to multiple unknown problems. This mod must be always last in your load order.",
-
-                      "SHADE GIRL LEATHER OUTFITS \n"
-                      "- Outfits can crash the game while browsing the armor workbench or upon starting a new game due to bad meshes.",
-
-                      "SPRING CLEANING \n"
-                      "- Abandoned and severely outdated mod that breaks precombines and could potentially even break your save file.",
-
-                      "STALKER TEXTURE OVERHAUL \n"
-                      "- Doesn't work due to incorrect folder structure and has a corrupted dds file that causes Create2DTexture crashes.",
-
-                      "TACTICAL TABLET \n"
-                      "- Can cause flickering with certain scopes or crashes while browsing workbenches, most commonly with ECO.",
-
-                      "TRUE NIGHTS \n"
-                      "- Has an invalid Image Space Adapter (IMAD) Record that will corrupt your save memory and has to be manually fixed.",
-
-                      "WEAPONS FRAMEWORK BETA \n"
-                      "- Will randomly cause crashes when used with Tactical Reload and possibly other weapon or combat related mods. \n"
-                      "  Visit Important Patches List article for possible solutions: https://www.nexusmods.com/fallout4/articles/3769",
-
-                      "WAR OF THE COMMONWEALTH \n"
-                      "- Seems responsible for consistent crashes with specific spawn points or randomly during settlement attacks."]
-
-        if "[00]" in c_text:
-            for line in plugin_list:
-                for elem in List_Mods1:
-                    if "File:" not in line and "[FE" not in line and elem in line:
-                        order_elem = List_Mods1.index(elem)
-                        print("[!] Found:", line[0:5].strip(), List_Warn1[order_elem])
-                        print("-----")
-                        Mod_Trap1 = 0
-                    elif "File:" not in line and "[FE" in line and elem in line:
-                        order_elem = List_Mods1.index(elem)
-                        print("[!] Found:", line[0:9].strip(), List_Warn1[order_elem])
-                        print("-----")
-                        Mod_Trap1 = 0
-
-            if c_text.count("ClassicHolsteredWeapons") >= 3 or "ClassicHolsteredWeapons" in buff_error:
-                print("[!] Found: CLASSIC HOLSTERED WEAPONS")
-                print("AUTOSCAN IS PRETTY CERTAIN THAT CHW CAUSED THIS CRASH!")
-                print("You should disable CHW to further confirm this.")
-                print("Visit the main crash logs article for additional solutions.")
-                print("-----")
-                statM_CHW += 1
-                Mod_Trap1 = 0
-                Buffout_Trap = True
-            elif c_text.count("ClassicHolsteredWeapons") >= 2 and ("UniquePlayer.esp" or "HHS.dll" or "cbp.dll" or "Body.nif") in c_text:
-                print("[!] Found: CLASSIC HOLSTERED WEAPONS")
-                print("AUTOSCAN ALSO DETECTED ONE OR SEVERAL MODS THAT WILL CRASH WITH CHW.")
-                print("You should disable CHW to further confirm it caused this crash.")
-                print("Visit the main crash logs article for additional solutions.")
-                print("-----")
-                statM_CHW += 1
-                Mod_Trap1 = 0
-                Buffout_Trap = True
-            elif "ClassicHolsteredWeapons" in c_text and "d3d11" in buff_error:
-                print("[!] Found: CLASSIC HOLSTERED WEAPONS, BUT...")
-                print("AUTOSCAN CANNOT ACCURATELY DETERMINE IF CHW CAUSED THIS CRASH OR NOT.")
-                print("You should open CHW's ini file and change IsHolsterVisibleOnNPCs to 0.")
-                print("This usually prevents most common crashes with Classic Holstered Weapons.")
-                print("-----")
-                Mod_Trap1 = 0
-        if "[00]" in c_text and Mod_Trap1 == 0:
-            print("# CAUTION: ANY ABOVE DETECTED MODS HAVE A MUCH HIGHER CHANCE TO CRASH YOUR GAME! #")
-            print("You can disable any/all of them temporarily to confirm they caused this crash.")
-            print("-----")
-            statL_scanned += 1
-        elif "[00]" in c_text and Mod_Trap1 == 1:
-            print("# AUTOSCAN FOUND NO PROBLEMATIC MODS THAT MATCH THE CURRENT DATABASE FOR THIS LOG #")
-            print("THAT DOESN'T MEAN THERE AREN'T ANY! YOU SHOULD RUN PLUGIN CHECKER IN WRYE BASH.")
-            print("Wrye Bash Link: https://www.nexusmods.com/fallout4/mods/20032?tab=files")
-            print("-----")
-            statL_scanned += 1
-        elif not "[00]" in c_text:
-            print("# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #")
-            print("Autoscan cannot continue. Try scanning a different crash log.")
-            print("-----")
-            statL_incomplete += 1
-
-        print("====================================================")
-        print("CHECKING FOR MODS WITH SOLUTIONS & COMMUNITY PATCHES")
-        print("====================================================")
-        Mod_Trap2 = no_repeat1 = no_repeat2 = 1  # MOD TRAP 2 | NEED 8 SPACES FOR ESL [FE:XXX]
-
-        # Needs 1 empty space as prefix to prevent duplicates.
-        List_Mods2 = [" DLCUltraHighResolution.esm",
-                      " AAF.esm",
-                      " ArmorKeywords.esm",
-                      " BTInteriors_Project.esp",
-                      " CombatZoneRestored.esp",
-                      " D.E.C.A.Y.esp",
-                      " EveryonesBestFriend",
-                      " M8r_Item_Tags",
-                      " Fo4FI_FPS_fix",
-                      " BostonFPSFixAIO.esp",
-                      " FunctionalDisplays.esp",
-                      " skeletonmaleplayer",
-                      " skeletonfemaleplayer",
-                      " CapsWidget",
-                      " Homemaker.esm",
-                      " Horizon.esm",
-                      " ESPExplorerFO4.esp",
-                      " LegendaryModification.esp",
-                      " LooksMenu Customization Compendium.esp",
-                      " MilitarizedMinutemen.esp",
-                      " MoreUniques",
-                      " NAC.es",
-                      " Northland Diggers New.esp",
-                      " ProjectZeta.esm",
-                      " RaiderOverhaul.esp",
-                      " Rusty Face Fix",
-                      " SKKCraftableWeaponsAmmo",
-                      " SOTS.esp",
-                      " StartMeUp.esp",
-                      " SuperMutantRedux.esp",
-                      " TacticalReload.esm",
-                      " Creatures and Monsters.esp",
-                      " ZombieWalkers"]
-
-        List_Warn2 = ["HIGH RESOLUTION DLC. I STRONGLY ADVISE NOT USING IT! \n"
-                      "Right click on Fallout 4 in your Steam Library folder, then select Properties \n"
-                      "Switch to the DLC tab and uncheck / disable the High Resolution Texture Pack",
-                      #
-                      "ADVANCED ANIMATION FRAMEWORK \n"
-                      "Newest AAF version only available on Moddingham | AAF Tech Support: https://discord.gg/gWZuhMC \n"
-                      "Newest AAF Link (register / login to download): https://www.moddingham.com/viewtopic.php?t=2 \n"
-                      "-----\n"
-                      "Looks Menu versions 1.6.20 & 1.6.19 can frequently break adult mod related (erection) morphs \n"
-                      "If you notice AAF realted problems, remove latest version of Looks Menu and switch to 1.6.18",
-                      #
-                      "ARMOR AND WEAPON KEYWORDS \n"
-                      "If you don't rely on AWKCR, consider switching to Equipment and Crafting Overhaul \n"
-                      "Better Alternative: https://www.nexusmods.com/fallout4/mods/55503?tab=files",
-                      #
-                      "BEANTOWN INTERIORS PROJECT \n"
-                      "Usually causes fps drops, stuttering, crashing and culling issues in multiple locations. \n"
-                      "Patch Link: https://www.nexusmods.com/fallout4/mods/53894?tab=files",
-                      #
-                      "COMBAT ZONE RESTORED \n"
-                      "Contains few small issues and NPCs usually have trouble navigating the interior space. \n"
-                      "Patch Link: https://www.nexusmods.com/fallout4/mods/59329?tab=files",
-                      #
-                      "DECAY BETTER GHOULS \n"
-                      "You have to install DECAY Redux patch to prevent its audio files from crashing the game. \n"
-                      "Patch Link: https://www.nexusmods.com/fallout4/mods/59025?tab=files",
-                      #
-                      "EVERYONE'S BEST FRIEND \n"
-                      "This mod needs a compatibility patch to properly work with the Unofficial Patch (UFO4P). \n"
-                      "Patch Link: https://www.nexusmods.com/fallout4/mods/43409?tab=files",
-                      #
-                      "FALLUI ITEM SORTER (OLD) \n"
-                      "This is an outdated item tagging / sorting patch that can cause crashes or conflicts in all kinds of situations. \n"
-                      "I strongly recommend to instead generate your own sorting patch and place it last in your load order. \n"
-                      "That way, you won't experience any conflicts / crashes and even modded items will be sorted. \n"
-                      "Generate Sorting Patch With This: https://www.nexusmods.com/fallout4/mods/48826?tab=files",
-                      #
-                      "FO4FI FPS FIX \n"
-                      "This mod is severely outdated and will cause crashes even with compatibility patches. \n"
-                      "Better Alternative: https://www.nexusmods.com/fallout4/mods/46403?tab=files",
-                      #
-                      "BOSTON FPS FIX \n"
-                      "This mod is severely outdated and will cause crashes even with compatibility patches. \n"
-                      "Better Alternative: https://www.nexusmods.com/fallout4/mods/46403?tab=files",
-                      #
-                      "FUNCTIONAL DISPLAYS \n"
-                      "Frequently causes object model (nif) related crashes and this needs to be manually corrected. \n"
-                      "Advised Fix: Open its Meshes folder and delete everything inside EXCEPT for the Functional Displays folder.",
-                      #
-                      "GENDER SPECIFIC SKELETONS (MALE) \n"
-                      "High chance to cause a crash when starting a new game or during the game intro sequence. \n"
-                      "Advised Fix: Enable the mod only after leaving Vault 111. Existing saves shouldn't be affected.",
-                      #
-                      "GENDER SPECIFIC SKELETONS (FEMALE) \n"
-                      "High chance to cause a crash when starting a new game or during the game intro sequence. \n"
-                      "Advised Fix: Enable the mod only after leaving Vault 111. Existing saves shouldn't be affected.",
-                      #
-                      "HUD CAPS \n"
-                      "Often breaks the Save / Quicksave function due to poor script implementation. \n"
-                      "Advised Fix: Download fixed pex file and place it into HUDCaps/Scripts folder. \n"
-                      "Fix Link: https://drive.google.com/file/d/1egmtKVR7mSbjRgo106UbXv_ySKBg5az2",
-                      #
-                      "HOMEMAKER \n"
-                      "Causes a crash while scrolling over Military / BoS fences in the Settlement Menu. \n"
-                      "Patch Link: https://www.nexusmods.com/fallout4/mods/41434?tab=files",
-                      #
-                      "HORIZON \n"
-                      "Use the mod specific unofficial patch for 1.8.7 until a newer version gets released. \n"
-                      "Patch Link: https://www.nexusmods.com/fallout4/mods/61998?tab=files",
-                      #
-                      "IN GAME ESP EXPLORER \n"
-                      "Can cause a crash when pressing F10 due to a typo in the INI settings. \n"
-                      "Fix Link: https://www.nexusmods.com/fallout4/mods/64752?tab=files \n"
-                      "OR Switch To: https://www.nexusmods.com/fallout4/mods/56922?tab=files",
-                      #
-                      "LEGENDARY MODIFICATION \n"
-                      "Old mod plagued with all kinds of bugs and crashes, can conflict with some modded weapons. \n"
-                      "Better Alternative: https://www.nexusmods.com/fallout4/mods/55503?tab=files",
-                      #
-                      "LOOKS MENU CUSTOMIZATION COMPENDIUM \n"
-                      "Apparently breaks the original Looks Menu mod by turning off some important values. \n"
-                      "Fix Link: https://www.nexusmods.com/fallout4/mods/56465?tab=files",
-                      #
-                      "MILITARIZED MINUTEMEN \n"
-                      "Can occasionally crash the game due to a broken mesh on some minutemen outfits. \n"
-                      "Patch Link: https://www.nexusmods.com/fallout4/mods/55301?tab=files",
-                      #
-                      "MORE UNIQUE WEAPONS EXPANSION \n"
-                      "Causes crashes due to broken precombines and compatibility issues with other weapon mods. \n"
-                      "Patch Link: https://www.nexusmods.com/fallout4/mods/54848?tab=files",
-                      #
-                      "NATURAL AND ATMOSPHERIC COMMONWEALTH \n"
-                      "If you notice weird looking skin tones with either NAC or NACX, install this patch. \n"
-                      "Patch Link: https://www.nexusmods.com/fallout4/mods/57052?tab=files",
-                      #
-                      "NORTHLAND DIGGERS RESOURCES \n"
-                      "Contains various bugs and issues that can cause crashes or negatively affect other mods. \n"
-                      "Fix Link: https://www.nexusmods.com/fallout4/mods/53395?tab=files",
-                      #
-                      "PROJECT ZETA \n"
-                      "Invasion quests seem overly buggy or trigger too frequently, minor sound issues. \n"
-                      "Fix Link: https://www.nexusmods.com/fallout4/mods/65166?tab=files",
-                      #
-                      "RAIDER OVERHAUL \n"
-                      "Old mod that requires several patches to function as intended. Use ONE Version instead. \n"
-                      "Upated ONE Version: https://www.nexusmods.com/fallout4/mods/51658?tab=files",
-                      #
-                      "RUSTY FACE FIX \n"
-                      "Can cause script lag or even crash the game in very rare cases. Switch to REDUX Version instead. \n"
-                      "Updated REDUX Version: https://www.nexusmods.com/fallout4/mods/64270?tab=files",
-                      #
-                      "SKK CRAFT WEAPONS AND SCRAP AMMO \n"
-                      "Version 008 is incompatible with AWKCR and will cause crashes while saving the game. \n"
-                      "Advised Fix: Use Version 007 or remove AWKCR and switch to Equipment and Crafting Overhaul.",
-                      #
-                      "SOUTH OF THE SEA \n"
-                      "Very unstable mod that consistently and frequently causes strange problems and crashes. \n"
-                      "Patch Link: https://www.nexusmods.com/fallout4/mods/59792?tab=files",
-                      #
-                      "START ME UP \n"
-                      "Abandoned mod that can cause infinite loading and other problems. Switch to REDUX Version instead. \n"
-                      "Updated REDUX Version: https://www.nexusmods.com/fallout4/mods/56984?tab=files",
-                      #
-                      "SUPER MUTANT REDUX \n"
-                      "Causes crashes at specific locations or with certain Super Muntant enemies and items. \n"
-                      "Patch Link: https://www.nexusmods.com/fallout4/mods/51353?tab=files",
-                      #
-                      "TACTICAL RELOAD \n"
-                      "Can cause weapon and combat related crashes. TR Expansion For ECO is highly recommended. \n"
-                      "TR Expansion For ECO Link: https://www.nexusmods.com/fallout4/mods/62737",
-                      #
-                      "UNIQUE NPCs CREATURES AND MONSTERS \n"
-                      "Causes crashes and breaks precombines at specific locations, some creature spawns are too frequent. \n"
-                      "Patch Link: https://www.nexusmods.com/fallout4/mods/48637?tab=files",
-                      #
-                      "ZOMBIE WALKERS \n"
-                      "Version 2.6.3 contains a resurrection script that will regularly crash the game. \n"
-                      "Advised Fix: Make sure you're using the 3.0 Beta version of this mod or newer."]
-
-        if "[00]" in c_text:
-            for line in plugin_list:
-                for elem in List_Mods2:
-                    if "File:" not in line and "[FE" not in line and elem in line:
-                        order_elem = List_Mods2.index(elem)
-                        print("[!] Found:", line[0:5].strip(), List_Warn2[order_elem])
-                        print("-----")
-                        Mod_Trap2 = 0
-                    elif "File:" not in line and "[FE" in line and elem in line:
-                        order_elem = List_Mods2.index(elem)
-                        print("[!] Found:", line[0:9].strip(), List_Warn2[order_elem])
-                        print("-----")
-                        Mod_Trap2 = 0
-                if no_repeat1 == 1 and "File:" not in line and ("Depravity" or "FusionCityRising" or "HotC" or "OutcastsAndRemnants" or "ProjectValkyrie") in line:
-                    print("[!] Found:", line[0:9].strip(), "THUGGYSMURF QUEST MOD")
-                    print("If you have Depravity, Fusion City Rising, HOTC, Outcasts and Remnants and/or Project Valkyrie,")
-                    print("install this patch with facegen data, fully generated precomb/previs data and several tweaks.")
-                    print("Patch Link: https://www.nexusmods.com/fallout4/mods/56876?tab=files")
-                    print("-----")
-                    no_repeat1 = Mod_Trap2 = 0
-                if no_repeat1 == 1 and "File:" not in line and ("CaN.esm" or "AnimeRace_Nanako.esp") in line:
-                    print("[!] Found:", line[0:9].strip(), "CUSTOM RACE SKELETON MOD")
-                    print("If you have AnimeRace NanakoChan or Crimes Against Nature, install the Race Skeleton Fixes.")
-                    print("Skeleton Fixes Link (READ THE DESCRIPTION): https://www.nexusmods.com/fallout4/mods/56101")
-                    no_repeat2 = Mod_Trap2 = 0
-
-            if "FallSouls.dll" in c_text:
-                print("[!] Found: FALLSOULS UNPAUSED GAME MENUS")
-                print("Occasionally breaks the Quests menu, can cause crashes while changing MCM settings.")
-                print("Advised Fix: Toggle PipboyMenu in FallSouls MCM settings or completely reinstall the mod.")
-                print("-----")
-                Mod_Trap2 = 0
-        if "[00]" in c_text and Mod_Trap2 == 0:
-            print("[Due to inherent limitations, Auto-Scan will continue detecting certain mods,")
-            print(" even if fixes or patches for them are already installed. You can ignore these.]")
-            print("-----")
-        elif "[00]" in c_text and Mod_Trap2 == 1:
-            print("# AUTOSCAN FOUND NO PROBLEMATIC MODS WITH SOLUTIONS AND COMMUNITY PATCHES #")
-            print("-----")
-        elif c_text.count("[00]") == 0:
-            print("# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #")
-            print("Autoscan cannot continue. Try scanning a different crash log.")
-            print("-----")
-
-        print("FOR FULL LIST OF IMPORTANT PATCHES AND FIXES FOR THE BASE GAME AND MODS,")
-        print("VISIT THIS ARTICLE: https://www.nexusmods.com/fallout4/articles/3769")
-        print("-----")
-
-        print("====================================================")
-        print("CHECKING FOR MODS PATCHED THROUGH OPC INSTALLER...")
-        print("====================================================")
-        Mod_Trap3 = 1  # MOD TRAP 3 | NEED 8 SPACES FOR ESL [FE:XXX]
-
-        # Needs 1 empty space as prefix to prevent duplicates.
-        List_Mods3 = [" Beyond the Borders",
-                      " Deadly Commonwealth Expansion",
-                      " Dogmeat and Strong Armor",
-                      " DoYourDamnJobCodsworth",
-                      " ConcordEXPANDED",
-                      " HagenEXPANDED",
-                      " GlowingSeaEXPANDED",
-                      " SalemEXPANDED",
-                      " SwampsEXPANDED",
-                      " _hod",
-                      " ImmersiveBeantown",
-                      " CovenantComplex",
-                      " GunnersPlazaInterior",
-                      " ImmersiveHubCity",
-                      " Immersive_Lexington",
-                      " Immersive Nahant",
-                      " Immersive S Boston",
-                      " MutilatedDeadBodies",
-                      " Vault4.esp",
-                      " atlanticofficesf23",
-                      " Minutemen Supply Caches",
-                      " moreXplore",
-                      " NEST_BUNKER_PROJECT",
-                      " Raider Children.esp",
-                      " sectorv",
-                      " SettlementShelters",
-                      " subwayrunnnerdynamiclighting",
-                      " 3DNPC_FO4Settler.esp",
-                      " 3DNPC_FO4.esp",
-                      " The Hollow",
-                      " nvvault1080",
-                      " Vertibird Faction Paint Schemes",
-                      " MojaveImports.esp",
-                      " Firelance2.5",
-                      " zxcMicroAdditions"]
-
-        List_Warn3 = ["Beyond the Borders",
-                      "Deadly Commonwealth Expansion",
-                      "Dogmeat and Strong Armor",
-                      "Do Your Damn Job Codsworth",
-                      "Concord Expanded",
-                      "Fort Hagen Expanded",
-                      "Glowing Sea Expanded",
-                      "Salem Expanded",
-                      "Swamps Expanded",
-                      "Hearts Of Darkness",
-                      "Immersive Beantown Brewery",
-                      "Immersive Covenant Compound",
-                      "Immersive Gunners Plaza",
-                      "Immersive Hub City",
-                      "Immersive & Extended Lexington",
-                      "Immersive & Extended Nahant",
-                      "Immersive Military Checkpoint",
-                      "Mutilated Dead Bodies",
-                      "Fourville (Vault 4)",
-                      "Lost Building of Atlantic",
-                      "Minutemen Supply Caches",
-                      "MoreXplore",
-                      "NEST Survival Bunkers",
-                      "Raider Children & Other Horrors",
-                      "Sector Five - Rise and Fall",
-                      "Settlement Shelters",
-                      "Subway Runner (Dynamic Lights)",
-                      "Settlers of the Commonwealth",
-                      "Tales from the Commonwealth",
-                      "The Hollow",
-                      "Vault 1080 (Vault 80)",
-                      "Vertibird Faction Paint Schemes",
-                      "Wasteland Imports (Mojave Imports)",
-                      "Xander's Aid",
-                      "ZXC Micro Additions"]
-
-        if "[00]" in c_text:
-            for line in plugin_list:
-                for elem in List_Mods3:
-                    if "File:" not in line and "[FE" not in line and elem in line:
-                        order_elem = List_Mods3.index(elem)
-                        print("- Found:", line[0:5].strip(), List_Warn3[order_elem])
-                        Mod_Trap3 = 0
-                    elif "File:" not in line and "[FE" in line and elem in line:
-                        order_elem = List_Mods3.index(elem)
-                        print("- Found:", line[0:9].strip(), List_Warn3[order_elem])
-                        Mod_Trap3 = 0
-        if "[00]" in c_text and Mod_Trap3 == 0:
-            print("-----")
-            print("FOR PATCH REPOSITORY THAT PREVENTS CRASHES AND FIXES PROBLEMS IN THESE AND OTHER MODS,")
-            print("VISIT OPTIMIZATION PATCHES COLLECTION: https://www.nexusmods.com/fallout4/mods/54872")
-            print("-----")
-        elif "[00]" in c_text and Mod_Trap3 == 1:
-            print("# AUTOSCAN FOUND NO PROBLEMATIC MODS THAT ARE ALREADY PATCHED THROUGH OPC INSTALLER #")
-            print("-----")
-        elif c_text.count("[00]") == 0:
-            print("# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #")
-            print("Autoscan cannot continue. Try scanning a different crash log.")
-            print("-----")
-
-        # ===========================================================
-
-        print("====================================================")
-        print("CHECKING IF IMPORTANT PATCHES & FIXES ARE INSTALLED")
-        print("====================================================")
-
-        gpu_amd = False
-        gpu_nvidia = False
-        for line in all_lines:
-            if "GPU" in line and "Nvidia" in line:
-                gpu_nvidia = True
-            if "GPU" in line and "AMD" in line:
-                gpu_amd = True
-
-        print("IF YOU'RE USING DYNAMIC PERFORMANCE TUNER AND/OR LOAD ACCELERATOR,")
-        print("remove these mods completely and switch to High FPS Physics Fix!")
-        print("Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files")
-        print("-----")
-
-        if CLAS_config.getboolean("MAIN", "FCX Mode") == True:
-            print("* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *")
-            print("[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]")
-            print("-----")
-
-            if info.VR_EXE.is_file() and info.VR_Buffout.is_file():
-                print("*Buffout 4 VR Version* is (manually) installed. \n-----")
-            elif info.VR_EXE.is_file() and not info.VR_Buffout.is_file():
-                print("# BUFFOUT 4 FOR VR VERSION ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-                print("# This is a mandatory Buffout 4 port for the VR Version of Fallout 4.")
-                print("Link: https://www.nexusmods.com/fallout4/mods/64880?tab=files")
-
-            if info.F4CK_EXE.is_file() and os.path.exists(info.F4CK_Fixes):
-                print("*Creation Kit Fixes* is (manually) installed. \n-----")
-            elif info.F4CK_EXE.is_file() and not os.path.exists(info.F4CK_Fixes):
-                print("# CREATION KIT FIXES ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-                print("This is a highly recommended patch for the Fallout 4 Creation Kit.")
-                print("Link: https://www.nexusmods.com/fallout4/mods/51165?tab=files")
-                print("-----")
-
-        if "[00]" in c_text:
-            if any("CanarySaveFileMonitor" in elem for elem in plugin_list):
-                print("*Canary Save File Monitor* is installed. \n-----")
-            else:
-                print("# CANARY SAVE FILE MONITOR ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-                print("This is a highly recommended mod that can detect save file corrpution.")
-                print("Link: https://www.nexusmods.com/fallout4/mods/44949?tab=files")
-                print("-----")
-
-            if "HighFPSPhysicsFix.dll" in c_text:
-                print("*High FPS Physics Fix* is installed. \n-----")
-            else:
-                print("# HIGH FPS PHYSICS FIX ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-                print("This is a mandatory patch / fix that prevents game engine problems.")
-                print("Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files")
-                print("-----")
-
-            if any("PPF.esm" in elem for elem in plugin_list):
-                print("*Previs Repair Pack* is installed. \n-----")
-            else:
-                print("# PREVIS REPAIR PACK ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-                print("This is a highly recommended mod that can improve performance.")
-                print("Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files")
-                print("-----")
-
-            if any("Unofficial Fallout 4 Patch.esp" in elem for elem in plugin_list):
-                print("*Unofficial Fallout 4 Patch* is installed. \n-----")
-            else:
-                print("# UNOFFICIAL FALLOUT 4 PATCH ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-                print("If you own all DLCs, make sure that the Unofficial Patch is installed.")
-                print("Link: https://www.nexusmods.com/fallout4/mods/4598?tab=files")
-                print("-----")
-
-            if "vulkan-1.dll" in c_text and gpu_amd:
-                print("Vulkan Renderer is installed. \n-----")
-            elif c_text.count("vulkan-1.dll") == 0 and gpu_amd and not gpu_nvidia:
-                print("# VULKAN RENDERER ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-                print("This is a highly recommended mod that can improve performance on AMD GPUs.")
-                print("-----")
-                print("Installation steps can be found in 'How To Read Crash Logs' PDF / Document.")
-                print("Link: https://www.nexusmods.com/fallout4/mods/48053?tab=files")
-                print("-----")
-
-            if "WeaponDebrisCrashFix.dll" in c_text and gpu_nvidia:
-                print("*Weapon Debris Crash Fix* is installed. \n-----")
-            elif "WeaponDebrisCrashFix.dll" in c_text and not gpu_nvidia and gpu_amd:
-                print("*Weapon Debris Crash Fix* is installed, but...")
-                print("# YOU DON'T HAVE AN NVIDIA GPU OR BUFFOUT 4 CANNOT DETECT YOUR GPU MODEL #")
-                print("Weapon Debris Crash Fix is only required for Nvidia GPUs (NOT AMD / OTHER)")
-                print("-----")
-            if not "WeaponDebrisCrashFix.dll" in c_text and gpu_nvidia:
-                print("# WEAPON DEBRIS CRASH FIX ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-                print("This is a mandatory patch / fix for players with Nvidia graphics cards.")
-                print("Link: https://www.nexusmods.com/fallout4/mods/48078?tab=files")
-                print("-----")
-
-            if "NVIDIA_Reflex.dll" in c_text and gpu_nvidia:
-                print("*Nvidia Reflex Support* is installed. \n-----")
-            elif "NVIDIA_Reflex.dll" in c_text and not gpu_nvidia and gpu_amd:
-                print("*Nvidia Reflex Support* is installed, but...")
-                print("# YOU DON'T HAVE AN NVIDIA GPU OR BUFFOUT 4 CANNOT DETECT YOUR GPU MODEL #")
-                print("Nvidia Reflex Support is only required for Nvidia GPUs (NOT AMD / OTHER)")
-                print("-----")
-            if not "NVIDIA_Reflex.dll" in c_text and gpu_nvidia:
-                print("# NVIDIA REFLEX SUPPORT ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
-                print("This is a highly recommended mod that can reduce render latency.")
-                print("Link: https://www.nexusmods.com/fallout4/mods/64459?tab=files")
-                print("-----")
+        if len(list_ERRORLOG) >= 1:
+            output.write("# CAUTION: THE FOLLOWING DLL LOGS ALSO REPORT ONE OR MORE ERRORS : #")
+            output.write("[These are located in your Documents/My Games/Fallout4/F4SE folder.]")
+            for elem in list_ERRORLOG:
+                output.write(f"{elem}\n-----")
         else:
-            print("# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #")
-            print("Autoscan cannot continue. Try scanning a different crash log.")
-            print("-----")
+            output.write("Available DLL logs do not report any additional errors, all is well. \n-----")
 
-        print("====================================================")
-        print("SCANNING THE LOG FOR SPECIFIC (POSSIBLE) CUPLRITS...")
-        print("====================================================")
-
-        list_DETPLUGINS = []
-        list_DETFORMIDS = []
-        list_DETFILES = []
-        list_ALLPLUGINS = []
-
-        if not "f4se_1_10_163.dll" in c_text and "steam_api64.dll" in c_text:
-            print("AUTOSCAN CANNOT FIND FALLOUT 4 SCRIPT EXTENDER DLL!")
-            print("MAKE SURE THAT F4SE IS CORRECTLY INSTALLED!")
-            print("Link: https://f4se.silverlock.org")
-            print("-----")
-
-        for line in all_lines:
-            if len(line) >= 6 and "]" in line[4]:
-                list_ALLPLUGINS.append(line.strip())
-            if len(line) >= 7 and "]" in line[5]:
-                list_ALLPLUGINS.append(line.strip())
-            if len(line) >= 10 and "]" in line[8]:
-                list_ALLPLUGINS.append(line.strip())
-            if len(line) >= 11 and "]" in line[9]:
-                list_ALLPLUGINS.append(line.strip())
-
-        print("LIST OF (POSSIBLE) PLUGIN CULRIPTS:")
-        for line in all_lines:
-            if "File:" in line:
-                line = line.replace("File: ", "")
-                line = line.replace('"', '')
-                list_DETPLUGINS.append(line.strip())
-
-        list_DETPLUGINS = list(dict.fromkeys(list_DETPLUGINS))
-        list_remove = ["Fallout4.esm", "DLCCoast.esm", "DLCNukaWorld.esm", "DLCRobot.esm", "DLCworkshop01.esm", "DLCworkshop02.esm", "DLCworkshop03.esm", ""]
-        for elem in list_remove:
-            if elem in list_DETPLUGINS:
-                list_DETPLUGINS.remove(elem)
-
-        PL_strings = list_ALLPLUGINS
-        PL_substrings = list_DETPLUGINS
-        PL_result = []
-
-        for string in PL_strings:
-            PL_matches = []
-            for substring in PL_substrings:
-                if substring in string:
-                    PL_matches.append(string)
-            if PL_matches:
-                PL_result.append(PL_matches)
-                print("- " + ' '.join(PL_matches))
-
-        if not PL_result:
-            print("* AUTOSCAN COULDN'T FIND ANY PLUGIN CULRIPTS *")
-            print("-----")
+    # CHECK BUFFOUT 4 REQUIREMENTS AND TOML SETTINGS
+        if info.Preloader_XML.is_file() and info.Preloader_DLL.is_file():
+            output.write('OPTIONAL: Plugin Preloader is (manually) installed.\n')
+            output.write('NOTICE: If the game fails to start after installing this mod, open xSE PluginPreloader.xml with a text editor and CHANGE')
+            output.write('<LoadMethod Name="ImportAddressHook"> TO <LoadMethod Name="OnThreadAttach"> OR <LoadMethod Name="OnProcessAttach">')
+            output.write('IF THE GAME STILL REFUSES TO START, COMPLETELY REMOVE xSE PluginPreloader.xml AND IpHlpAPI.dll FROM YOUR FO4 GAME FOLDER')
+            output.write("-----")
         else:
-            print("-----")
-            print("These Plugins were caught by Buffout 4 and some of them might be responsible for this crash.")
-            print("You can try disabling these plugins and recheck your game, though this method can be unreliable.")
-            print("-----")
+            output.write('OPTIONAL: Plugin Preloader is not (manually) installed.\n-----')
 
-        # ===========================================================
+        if info.F4SE_Loader.is_file() and info.F4SE_DLL.is_file() and info.F4SE_SDLL.is_file():
+            output.write("REQUIRED: Fallout 4 Script Extender is (manually) installed. \n-----")
+        else:
+            output.write("# CAUTION: Auto-Scanner cannot find Script Extender files or they aren't (manually) installed! #")
+            output.write("FIX: Extract all files inside *f4se_0_06_21* folder into your Fallout 4 game folder.")
+            output.write("FALLOUT 4 SCRIPT EXTENDER: (Download Build 0.6.23) https://f4se.silverlock.org")
+            output.write("-----")
 
-        print("LIST OF (POSSIBLE) FORM ID CULRIPTS:")
-        for line in all_lines:
-            if "Form ID:" in line and not "0xFF" in line:
-                line = line.replace("0x", "")
-                if "[00]" in c_text:
-                    line = line.replace("Form ID: ", "")
-                    line = line.strip()
-                    ID_Only = line
-                    for elem in plugin_list:
-                        if "]" in elem and "[FE" not in elem:
-                            if elem[2:4].strip() == ID_Only[:2]:
-                                Full_Line = "Form ID: " + ID_Only + " | " + elem.strip()
-                                list_DETFORMIDS.append(Full_Line.replace("    ", ""))
-                        if "[FE" in elem:
-                            elem = elem.replace(":", "")
-                            if elem[2:7] == ID_Only[:5]:
-                                Full_Line = "Form ID: " + ID_Only + " | " + elem.strip()
-                                list_DETFORMIDS.append(Full_Line.replace("    ", ""))
+        if info.Address_Library.is_file() or ALIB_Load == True:
+            output.write("REQUIRED: Address Library is (manually) installed. \n-----")
+        else:
+            output.write("# CAUTION: Auto-Scanner cannot find the Adress Library file or it isn't (manually) installed! #")
+            output.write("FIX: Place the *version-1-10-163-0.bin* file manually into Fallout 4/Data/F4SE/Plugins folder.")
+            output.write("ADDRESS LIBRARY: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47327?tab=files")
+            output.write("-----")
+
+        if info.Buffout_INI.is_file() and info.Buffout_DLL.is_file() or BUFF_Load == True:
+            with open(info.Buffout_INI, "r+") as BUFF_Custom:
+                BUFF_config = BUFF_Custom.read()
+                output.write("REQUIRED: Buffout 4 is (manually) installed. Checking configuration...\n-----")
+                if ("achievements.dll" or "UnlimitedSurvivalMode.dll") in logtext and "Achievements = true" in BUFF_config:
+                    output.write("# CAUTION: Achievements Mod and/or Unlimited Survival Mode is installed, but Achievements parameter is set to TRUE #")
+                    output.write("Auto-Scanner will change this parameter to FALSE to prevent conflicts with Buffout 4.")
+                    output.write("-----")
+                    BUFF_config = BUFF_config.replace("Achievements = true", "Achievements = false")
                 else:
-                    list_DETFORMIDS.append(line.strip())
+                    output.write("Achievements parameter in *Buffout4.toml* is correctly configured. \n-----")
 
-        list_DETFORMIDS = list(dict.fromkeys(list_DETFORMIDS))
-        for elem in list_DETFORMIDS:
-            print(elem)
+                if "BakaScrapHeap.dll" in logtext and "MemoryManager = true" in BUFF_config:
+                    output.write("# CAUTION: Baka ScrapHeap is installed, but MemoryManager parameter is set to TRUE #")
+                    output.write("Auto-Scanner will change this parameter to FALSE to prevent conflicts with Buffout 4.")
+                    output.write("-----")
+                    BUFF_config = BUFF_config.replace("MemoryManager = true", "MemoryManager = false")
+                else:
+                    output.write("Memory Manager parameter in *Buffout4.toml* is correctly configured. \n-----")
 
-        if not list_DETFORMIDS:
-            print("* AUTOSCAN COULDN'T FIND ANY FORM ID CULRIPTS *")
-            print("-----")
+                if "f4ee.dll" in logtext and "F4EE = false" in BUFF_config:
+                    output.write("# CAUTION: Looks Menu is installed, but F4EE parameter under [Compatibility] is set to FALSE #")
+                    output.write("Auto-Scanner will change this parameter to TRUE to prevent bugs and crashes from Looks Menu.")
+                    output.write("-----")
+                    BUFF_config = BUFF_config.replace("F4EE = false", "F4EE = true")
+                else:
+                    output.write("Looks Menu (F4EE) parameter in *Buffout4.toml* is correctly configured. \n-----")
+            with open(info.Buffout_INI, "w+") as BUFF_Custom:
+                BUFF_Custom.write(BUFF_config)
         else:
-            print("-----")
-            print("These Form IDs were caught by Buffout 4 and some of them might be related to this crash.")
-            print("You can try searching any listed Form IDs in FO4Edit and see if they lead to relevant records.")
-            print("-----")
+            output.write("# CAUTION: Auto-Scanner cannot find Buffout 4 files or they aren't (manually) installed! #")
+            output.write("FIX: Follow Buffout 4 installation steps here: https://www.nexusmods.com/fallout4/articles/3115")
+            output.write("BUFFOUT 4: (ONLY Use Manual Download Option) https://www.nexusmods.com/fallout4/mods/47359?tab=files")
+            output.write("-----")
 
-        # ===========================================================
-
-        List_Files = [".bgsm", ".bto", ".btr", ".dds", ".fuz", ".hkb", ".hkx", ".ini", ".nif", ".pex", ".swf", ".txt", ".uvd", ".wav", ".xwm", "data\\*"]
-        List_Exclude = ['""', "...", ".esp"]
-
-        print("LIST OF DETECTED (NAMED) RECORDS:")
-        List_Records = []
-        for line in all_lines:
-            if "Name" in line or any(elem in line for elem in List_Files):
-                if not any(elem in line for elem in List_Exclude):
-                    line = line.replace('"', '')
-                    List_Records.append(line.strip())
-
-        List_Records = list(dict.fromkeys(List_Records))
-        for elem in List_Records:
-            print(elem)
-
-        if not List_Records:
-            print("* AUTOSCAN COULDN'T FIND ANY NAMED RECORDS *")
-            print("-----")
+    else:  # INSTRUCTIONS FOR MANUAL FIXING WHEN FCX MODE IS FALSE
+        if ("Achievements: true" in logtext and "achievements.dll" in logtext) or ("Achievements: true" in logtext and "UnlimitedSurvivalMode.dll" in logtext):
+            output.write("# CAUTION: Achievements Mod and/or Unlimited Survival Mode is installed, but Achievements parameter is set to TRUE #")
+            output.write("FIX: Open *Buffout4.toml* and change Achievements parameter to FALSE, this prevents conflicts with Buffout 4.")
+            output.write("-----")
         else:
+            output.write("Achievements parameter in *Buffout4.toml* is correctly configured. \n-----")
+
+        if "MemoryManager: true" in logtext and "BakaScrapHeap.dll" in logtext:
+            output.write("# CAUTION: Baka ScrapHeap is installed, but MemoryManager parameter is set to TRUE #")
+            output.write("FIX: Open *Buffout4.toml* and change MemoryManager parameter to FALSE, this prevents conflicts with Buffout 4.")
+            output.write("-----")
+        else:
+            output.write("Memory Manager parameter in *Buffout4.toml* is correctly configured. \n-----")
+
+        if "F4EE: false" in logtext and "f4ee.dll" in logtext:
+            output.write("# CAUTION: Looks Menu is installed, but F4EE parameter under [Compatibility] is set to FALSE #")
+            output.write("FIX: Open *Buffout4.toml* and change F4EE parameter to TRUE, this prevents bugs and crashes from Looks Menu.")
+            output.write("-----")
+        else:
+            output.write("Looks Menu (F4EE) parameter in *Buffout4.toml* is correctly configured. \n-----")
+
+    output.write("====================================================")
+    output.write("CHECKING IF LOG MATCHES ANY KNOWN CRASH MESSAGES...")
+    output.write("====================================================")
+    Buffout_Trap = False  # RETURN TRUE IF KNOWN CRASH MESSAGE WAS FOUND
+
+    # ====================== HEADER ERRORS ======================
+
+    if ".dll" in buff_error and "tbbmalloc" not in buff_error:
+        output.write("# MAIN ERROR REPORTS A DLL WAS INVLOVED IN THIS CRASH! # \n-----")
+
+    if "EXCEPTION_STACK_OVERFLOW" in buff_error:
+        output.writelines(["# Checking for Stack Overflow Crash.........CULPRIT FOUND! #", "> Priority : [5]"])
+        Buffout_Trap = True
+        statC_Overflow += 1
+
+    if "0x000100000000" in buff_error:
+        output.writelines(["# Checking for Active Effects Crash.........CULPRIT FOUND! #", "> Priority : [5]"])
+        Buffout_Trap = True
+        statC_ActiveEffect += 1
+
+    if "EXCEPTION_INT_DIVIDE_BY_ZERO" in buff_error:
+        output.writelines(["# Checking for Bad Math Crash...............CULPRIT FOUND! #", "> Priority : [5]"])
+        Buffout_Trap = True
+        statC_BadMath += 1
+
+    if "0x000000000000" in buff_error:
+        output.writelines(["# Checking for Null Crash...................CULPRIT FOUND! #", "> Priority : [5]"])
+        Buffout_Trap = True
+        statC_Null += 1
+
+    # ======================= MAIN ERRORS =======================
+
+    # OTHER | RESERVED
+    # *[Creation Club Crash] | +01B59A4
+    # Uneducated Shooter (56789) | logtext.count("std::invalid_argument")
+    # logtext.count("BSResourceNiBinaryStream")
+    # logtext.count("ObjectBindPolicy")
+
+    # ===========================================================
+    if "DLCBannerDLC01.dds" in logtext:
+        output.writelines(["# Checking for DLL Crash....................CULPRIT FOUND! #", f'> Priority : [5] | DLCBannerDLC01.dds : {logtext.count("DLCBannerDLC01.dds")}'])
+        Buffout_Trap = True
+        statC_DLL += 1
+    # ===========================================================
+    if "BGSLocation" in logtext and "BGSQueuedTerrainInitialLoad" in logtext:
+        output.write('# Checking for LOD Crash....................CULPRIT FOUND! #')
+        output.write(f'> Priority : [5] | BGSLocation : {logtext.count("BGSLocation")} | BGSQueuedTerrainInitialLoad : {logtext.count("BGSQueuedTerrainInitialLoad")}')
+        Buffout_Trap = True
+        statC_LOD += 1
+    # ===========================================================
+    if ("FaderData" or "FaderMenu" or "UIMessage") in logtext:
+        output.write("# Checking for MCM Crash....................CULPRIT FOUND! #")
+        output.write(f'> Priority : [3] | FaderData : {logtext.count("FaderData")} | FaderMenu : {logtext.count("FaderMenu")} | UIMessage : {logtext.count("UIMessage")}')
+        Buffout_Trap = True
+        statC_MCM += 1
+    # ===========================================================
+    if ("BGSDecalManager" or "BSTempEffectGeometryDecal") in logtext:
+        output.write("# Checking for Decal Crash..................CULPRIT FOUND! #")
+        output.write(f'> Priority : [5] | BGSDecalManager : {logtext.count("BGSDecalManager")} | BSTempEffectGeometryDecal : {logtext.count("BSTempEffectGeometryDecal")}')
+        Buffout_Trap = True
+        statC_Decal += 1
+    # ===========================================================
+    if logtext.count("PipboyMapData") >= 2:
+        output.write("# Checking for Equip Crash..................CULPRIT FOUND! #")
+        output.write(f'> Priority : [2] | PipboyMapData : {logtext.count("PipboyMapData")}')
+        Buffout_Trap = True
+        statC_Equip += 1
+    # ===========================================================
+    if (logtext.count("Papyrus") or logtext.count("VirtualMachine")) >= 2:
+        output.write("# Checking for Script Crash.................CULPRIT FOUND! #")
+        output.write(f'> Priority : [3] | Papyrus : {logtext.count("Papyrus")} | VirtualMachine : {logtext.count("VirtualMachine")}')
+        Buffout_Trap = True
+        statC_Papyrus += 1
+    # ===========================================================
+    if logtext.count("tbbmalloc.dll") >= 3 or "tbbmalloc" in buff_error:
+        output.write("# Checking for Generic Crash................CULPRIT FOUND! #")
+        output.write(f'> Priority : [2] | tbbmalloc.dll : {logtext.count("tbbmalloc.dll")}')
+        Buffout_Trap = True
+        statC_Generic += 1
+    # ===========================================================
+    if "LooseFileAsyncStream" in logtext:
+        output.write("# Checking for BA2 Limit Crash..............CULPRIT FOUND! #")
+        output.write(f'> Priority : [5] | LooseFileAsyncStream : {logtext.count("LooseFileAsyncStream")}')
+        Buffout_Trap = True
+        statC_BA2Limit += 1
+    # ===========================================================
+    if logtext.count("d3d11.dll") >= 3 or "d3d11" in buff_error:
+        output.write("# Checking for Rendering Crash..............CULPRIT FOUND! #")
+        output.write(f'> Priority : [4] | d3d11.dll : {logtext.count("d3d11.dll")}')
+        Buffout_Trap = True
+        statC_Rendering += 1
+    # ===========================================================
+    if ("GridAdjacencyMapNode" or "PowerUtils") in logtext:
+        output.write("# Checking for Grid Scrap Crash.............CULPRIT FOUND! #")
+        output.write(f'> Priority : [5] | GridAdjacencyMapNode : {logtext.count("GridAdjacencyMapNode")} | PowerUtils : {logtext.count("PowerUtils")}')
+        Buffout_Trap = True
+        statC_GridScrap += 1
+    # ===========================================================
+    if ("LooseFileStream" or "BSFadeNode" or "BSMultiBoundNode") in logtext and logtext.count("LooseFileAsyncStream") == 0:
+        output.write("# Checking for Mesh (NIF) Crash.............CULPRIT FOUND! #")
+        output.write(f'> Priority : [4] | LooseFileStream : {logtext.count("LooseFileStream")} | BSFadeNode : {logtext.count("BSFadeNode")}')
+        output.write(f'                   BSMultiBoundNode : {logtext.count("BSMultiBoundNode")}')
+        Buffout_Trap = True
+        statC_NIF += 1
+    # ===========================================================
+    if ("Create2DTexture" or "DefaultTexture") in logtext:
+        output.write("# Checking for Texture (DDS) Crash..........CULPRIT FOUND! #")
+        output.write(f'> Priority : [3] | Create2DTexture : {logtext.count("Create2DTexture")} | DefaultTexture : {logtext.count("DefaultTexture")}')
+        Buffout_Trap = True
+        statlogtexture += 1
+    # ===========================================================
+    if ("DefaultTexture_Black" or "NiAlphaProperty") in logtext:
+        output.write("# Checking for Material (BGSM) Crash........CULPRIT FOUND! #")
+        output.write(f'> Priority : [3] | DefaultTexture_Black : {logtext.count("DefaultTexture_Black")} | NiAlphaProperty : {logtext.count("NiAlphaProperty")}')
+        Buffout_Trap = True
+        statC_BGSM += 1
+    # ===========================================================
+    if (logtext.count("bdhkm64.dll") or logtext.count("usvfs::hook_DeleteFileW")) >= 2:
+        output.write("# Checking for BitDefender Crash............CULPRIT FOUND! #")
+        output.write(f'> Priority : [5] | bdhkm64.dll : {logtext.count("bdhkm64.dll")} | usvfs::hook_DeleteFileW : {logtext.count("usvfs::hook_DeleteFileW")}')
+        Buffout_Trap = True
+        statC_BitDefender += 1
+    # ===========================================================
+    if ("PathingCell" or "BSPathBuilder" or "PathManagerServer") in logtext:
+        output.write("# Checking for NPC Pathing Crash............CULPRIT FOUND! #")
+        output.write(f'> Priority : [3] | PathingCell : {logtext.count("PathingCell")} | BSPathBuilder : {logtext.count("BSPathBuilder")}')
+        output.write(f'                   PathManagerServer : {logtext.count("PathManagerServer")}')
+        Buffout_Trap = True
+        statC_NPCPathing += 1
+    elif ("NavMesh" or "BSNavmeshObstacleData" or "DynamicNavmesh") in logtext:
+        output.write("# Checking for NPC Pathing Crash............CULPRIT FOUND! #")
+        output.write(f'> Priority : [3] | NavMesh : {logtext.count("NavMesh")} | BSNavmeshObstacleData : {logtext.count("BSNavmeshObstacleData")}')
+        output.write(f'                   DynamicNavmesh : {logtext.count("DynamicNavmesh")}')
+        Buffout_Trap = True
+        statC_NPCPathing += 1
+    # ===========================================================
+    if logtext.count("X3DAudio1_7.dll") >= 3 or logtext.count("XAudio2_7.dll") >= 3 or ("X3DAudio1_7" or "XAudio2_7") in buff_error:
+        output.write("# Checking for Audio Driver Crash...........CULPRIT FOUND! #")
+        output.write(f'> Priority : [5] | X3DAudio1_7.dll : {logtext.count("X3DAudio1_7.dll")} | XAudio2_7.dll : {logtext.count("XAudio2_7.dll")}')
+        Buffout_Trap = True
+        statC_Audio += 1
+    # ===========================================================
+    if logtext.count("cbp.dll") >= 3 or "skeleton.nif" in logtext or "cbp.dll" in buff_error:
+        output.write("# Checking for Body Physics Crash...........CULPRIT FOUND! #")
+        output.write(f'> Priority : [4] | cbp.dll : {logtext.count("cbp.dll")} | skeleton.nif : {logtext.count("skeleton.nif")}')
+        Buffout_Trap = True
+        statC_BodyPhysics += 1
+    # ===========================================================
+    if ("BSMemStorage" or "DataFileHandleReaderWriter") in logtext:
+        output.write("# Checking for Plugin Limit Crash...........CULPRIT FOUND! #")
+        output.write(f'> Priority : [5] | BSMemStorage : {logtext.count("BSMemStorage")} | DataFileHandleReaderWriter : {logtext.count("DataFileHandleReaderWriter")}')
+        Buffout_Trap = True
+        statC_PluginLimit += 1
+    # ===========================================================
+    if "GamebryoSequenceGenerator" in logtext or "+0DB9300" in buff_error:
+        output.write("# Checking for Plugin Order Crash...........CULPRIT FOUND! #")
+        output.write(f'> Priority : [5] | GamebryoSequenceGenerator : {logtext.count("GamebryoSequenceGenerator")}')
+        Buffout_Trap = True
+        statC_LoadOrder += 1
+    # ===========================================================
+    if logtext.count("BSD3DResourceCreator") == 3 or logtext.count("BSD3DResourceCreator") == 6:
+        output.write("# Checking for MO2 Extractor Crash..........CULPRIT FOUND! #")
+        output.write(f'> Priority : [5] | BSD3DResourceCreator : {logtext.count("BSD3DResourceCreator")}')
+        Buffout_Trap = True
+        statC_MO2Unp += 1
+    # ===========================================================
+    if logtext.count("flexRelease_x64.dll") >= 2 or "flexRelease_x64" in buff_error:
+        output.write("# Checking for Nvidia Debris Crash..........CULPRIT FOUND! #")
+        output.write(f'> Priority : [5] | flexRelease_x64.dll : {logtext.count("flexRelease_x64.dll")}')
+        Buffout_Trap = True
+        statC_NVDebris += 1
+    # ===========================================================
+    if logtext.count("nvwgf2umx.dll") >= 10 or ("nvwgf2umx" or "USER32.dll") in buff_error:
+        output.write("# Checking for Nvidia Driver Crash..........CULPRIT FOUND! #")
+        output.write(f'> Priority : [5] | nvwgf2umx.dll : {logtext.count("nvwgf2umx.dll")} | USER32.dll : {logtext.count("USER32.dll")}')
+        Buffout_Trap = True
+        statC_NVDriver += 1
+    # ===========================================================
+    if (logtext.count("KERNELBASE.dll") or logtext.count("MSVCP140.dll")) >= 3 and "DxvkSubmissionQueue" in logtext:
+        output.write("# Checking for Vulkan Memory Crash..........CULPRIT FOUND! #")
+        output.write(f'> Priority : [5] | KERNELBASE.dll : {logtext.count("KERNELBASE.dll")} | MSVCP140.dll : {logtext.count("MSVCP140.dll")}')
+        output.write(f'                   DxvkSubmissionQueue : {logtext.count("DxvkSubmissionQueue")}')
+        Buffout_Trap = True
+        statC_VulkanMem += 1
+    # ===========================================================
+    if ("dxvk::DXGIAdapter" or "dxvk::DXGIFactory") in logtext:
+        output.write("# Checking for Vulkan Settings Crash........CULPRIT FOUND! #")
+        output.write(f'> Priority : [5] | dxvk::DXGIAdapter : {logtext.count("dxvk::DXGIAdapter")} | dxvk::DXGIFactory : {logtext.count("dxvk::DXGIFactory")}')
+        Buffout_Trap = True
+        statC_VulkanSet += 1
+    # ===========================================================
+    if ("BSXAudio2DataSrc" or "BSXAudio2GameSound") in logtext:
+        output.write("# Checking for Corrupted Audio Crash........CULPRIT FOUND! #")
+        output.write(f'> Priority : [4] | BSXAudio2DataSrc : {logtext.count("BSXAudio2DataSrc")} | BSXAudio2GameSound : {logtext.count("BSXAudio2GameSound")}')
+        Buffout_Trap = True
+        statC_CorruptedAudio += 1
+    # ===========================================================
+    if ("SysWindowCompileAndRun" or "ConsoleLogPrinter") in logtext:
+        output.write("# Checking for Console Command Crash........CULPRIT FOUND! #")
+        output.write(f'> Priority : [1] | SysWindowCompileAndRun : {logtext.count("SysWindowCompileAndRun")} | ConsoleLogPrinter : {logtext.count("ConsoleLogPrinter")}')
+        Buffout_Trap = True
+        statC_ConsoleCommands += 1
+    # ===========================================================
+    if "BGSWaterCollisionManager" in logtext:
+        output.write("# Checking for Water Collision Crash........CULPRIT FOUND! #")
+        output.write("PLEASE CONTACT ME AS SOON AS POSSIBLE! (CONTACT INFO BELOW)")
+        output.write(f'> Priority : [6] | BGSWaterCollisionManager : {logtext.count("BGSWaterCollisionManager")}')
+        Buffout_Trap = True
+        statC_Water += 1
+    # ===========================================================
+    if "ParticleSystem" in logtext:
+        output.write("# Checking for Particle Effects Crash.......CULPRIT FOUND! #")
+        output.write(f'> Priority : [4] | ParticleSystem : {logtext.count("ParticleSystem")}')
+        Buffout_Trap = True
+        statC_Particles += 1
+    # ===========================================================
+    if ("hkbVariableBindingSet" or "hkbHandIkControlsModifier" or "hkbBehaviorGraph" or "hkbModifierList") in logtext:
+        output.write("# Checking for Animation / Physics Crash....CULPRIT FOUND! #")
+        output.write(f'> Priority : [5] | hkbVariableBindingSet : {logtext.count("hkbVariableBindingSet")} | hkbHandIkControlsModifier : {logtext.count("hkbHandIkControlsModifier")}')
+        print("                   hkbBehaviorGraph : ", logtext.count("hkbBehaviorGraph"), " | hkbModifierList : ", logtext.count("hkbModifierList"))
+        Buffout_Trap = True
+        statC_AnimationPhysics += 1
+    # ===========================================================
+    if "DLCBanner05.dds" in logtext:
+        output.write("# Checking for Archive Invalidation Crash...CULPRIT FOUND! #")
+        output.write(f'> Priority : [5] | DLCBanner05.dds : {logtext.count("DLCBanner05.dds")}')
+        Buffout_Trap = True
+        statC_Invalidation += 1
+
+    # ===========================================================
+    output.write("---------- Unsolved Crash Messages Below ----------")
+
+    if "+01B59A4" in buff_error:
+        output.writelines(["Checking for *[Creation Club Crash].......DETECTED!", "> Priority : [5]"])
+        Buffout_Trap = True
+        statU_CClub += 1
+
+    if ("BGSMod::Attachment" or "BGSMod::Template" or "BGSMod::Template::Item") in logtext:
+        output.write("Checking for *[Item Crash]................DETECTED!")
+        output.write(f'> Priority : [5] | BGSMod::Attachment : {logtext.count("BGSMod::Attachment")} | BGSMod::Template : {logtext.count("BGSMod::Template")}')
+        output.write(f'                        BGSMod::Template::Item : {logtext.count("BGSMod::Template::Item")}')
+        Buffout_Trap = True
+        statU_Item += 1
+    # ===========================================================
+    if logtext.count("BGSSaveFormBuffer") >= 2:
+        output.write("Checking for *[Save Crash]................DETECTED!")
+        output.write(f'> Priority : [5] | BGSSaveFormBuffer : {logtext.count("BGSSaveFormBuffer")}')
+        Buffout_Trap = True
+        statU_Save += 1
+    # ===========================================================
+    if ("ButtonEvent" or "MenuControls" or "MenuOpenCloseHandler" or "PlayerControls" or "DXGISwapChain") in logtext:
+        output.write("Checking for *[Input Crash]...............DETECTED!")
+        output.write(f'> Priority : [5] | ButtonEvent : {logtext.count("ButtonEvent")} | MenuControls : {logtext.count("MenuControls")}')
+        output.write(f'                        MenuOpenCloseHandler : {logtext.count("MenuOpenCloseHandler")} | PlayerControls : {logtext.count("PlayerControls")}')
+        output.write(f'                        DXGISwapChain : {logtext.count("DXGISwapChain")}')
+        Buffout_Trap = True
+        statU_Input += 1
+    # ===========================================================
+    if ("BGSSaveLoadManager" or "BGSSaveLoadThread" or "BGSSaveFormBuffer") in logtext or ("+0CDAD30" or "+0D09AB7") in buff_error:
+        output.write("Checking for *[Bad INI Crash].............DETECTED!")
+        output.write(f'> Priority : [5] | BGSSaveLoadManager : {logtext.count("BGSSaveLoadManager")} | BGSSaveLoadThread : {logtext.count("BGSSaveLoadThread")}')
+        output.write(f'                        BGSSaveFormBuffer : {logtext.count("BGSSaveFormBuffer")}')
+        Buffout_Trap = True
+        statU_INI += 1
+    # ===========================================================
+    if ("BGSProcedurePatrol" or "BGSProcedurePatrolExecState" or "PatrolActorPackageData") in logtext:
+        output.write("Checking for *[NPC Patrol Crash]..........DETECTED!")
+        output.write(f'> Priority : [5] | BGSProcedurePatrol : {logtext.count("BGSProcedurePatrol")} | BGSProcedurePatrolExecStatel : {logtext.count("BGSProcedurePatrolExecState")}')
+        output.write(f'                        PatrolActorPackageData : {logtext.count("PatrolActorPackageData")}')
+        Buffout_Trap = True
+        statU_Patrol += 1
+    # ===========================================================
+    if ("BSPackedCombinedGeomDataExtra" or "BGSCombinedCellGeometryDB" or "BGSStaticCollection" or "TESObjectCELL") in logtext:
+        output.write("Checking for *[Precombines Crash].........DETECTED!")
+        output.write(f'> Priority : [5] | BGSStaticCollection : {logtext.count("BGSStaticCollection")} | BGSCombinedCellGeometryDB : {logtext.count("BGSCombinedCellGeometryDB")}')
+        output.write(f'                        BSPackedCombinedGeomDataExtra : {logtext.count("BSPackedCombinedGeomDataExtra")} | TESObjectCELL : {logtext.count("TESObjectCELL")}')
+        Buffout_Trap = True
+        statU_Precomb += 1
+    # ===========================================================
+    if "HUDAmmoCounter" in logtext:
+        output.write("Checking for *[Ammo Counter Crash]........DETECTED!")
+        output.write(f'> Priority : [5] | HUDAmmoCounter : {logtext.count("HUDAmmoCounter")}')
+        Buffout_Trap = True
+        statU_HUDAmmo += 1
+    # ===========================================================
+    if ("BGSProjectile" or "CombatProjectileAimController") in logtext:
+        output.write("Checking for *[NPC Projectile Crash].....DETECTED!")
+        output.write(f'> Priority : [5] | BGSProjectile : {logtext.count("BGSProjectile")} | CombatProjectileAimController : {logtext.count("CombatProjectileAimController")}')
+        Buffout_Trap = True
+    # ===========================================================
+    if logtext.count("PlayerCharacter") >= 1 and (logtext.count("0x00000007") or logtext.count("0x00000014") or logtext.count("0x00000008")) >= 3:
+        output.write("Checking for *[Player Character Crash]....DETECTED!")
+        output.write(f'> Priority : [5] | PlayerCharacter : {logtext.count("PlayerCharacter")} | 0x00000007 : {logtext.count("0x00000007")}')
+        output.write(f'                        0x00000008 : {logtext.count("0x00000008")} | 0x000000014 : {logtext.count("0x00000014")}')
+        Buffout_Trap = True
+        statU_Player += 1
+
+    # ===========================================================
+
+    if Buffout_Trap == False:  # DEFINE CHECK IF NOTHING TRIGGERED BUFFOUT TRAP
+        print("-----")
+        print("# AUTOSCAN FOUND NO CRASH ERRORS / CULPRITS THAT MATCH THE CURRENT DATABASE #")
+        print("Check below for mods that can cause frequent crashes and other problems.")
+        print("-----")
+    else:
+        print("-----")
+        print("FOR DETAILED DESCRIPTIONS AND POSSIBLE SOLUTIONS TO ANY ABOVE DETECTED CRASH CULPRITS,")
+        print("SEE: https://docs.google.com/document/d/17FzeIMJ256xE85XdjoPvv_Zi3C5uHeSTQh6wOZugs4c")
+        print("-----")
+
+    print("====================================================")
+    print("CHECKING FOR MODS THAT CAN CAUSE FREQUENT CRASHES...")
+    print("====================================================")
+    Mod_Trap1 = 1
+
+    # Why lists and not dictionaries? So I can preserve alphabetical order in code and
+    # numerical order in output without having to rename a bunch of variables.
+    # Needs 1 empty space as prefix to prevent duplicates.
+    List_Mods1 = [" DamageThresholdFramework.esm",
+                  " Endless Warfare.esm",
+                  " ExtendedWeaponSystem.esm",
+                  " EPO",
+                  " SakhalinWasteland",
+                  " 76HUD",
+                  " NCRenegade",
+                  " Respawnable Legendary Bosses",
+                  " Scrap Everything - Core",
+                  " Scrap Everything - Ultimate",
+                  " Shade Girl Leather Outfits",
+                  " SpringCleaning.esm",
+                  " (STO) NO",
+                  " TacticalTablet.esp",
+                  " True Nights v03.esp",
+                  " WeaponsFramework",
+                  " WOTC.esp"]
+
+    List_Warn1 = ["DAMAGE THRESHOLD FRAMEWORK \n"
+                  "- Can cause crashes in combat on some occasions due to how damage calculations are done.",
+
+                  "ENDLESS WARFARE \n"
+                  "- Some enemy spawn points could be bugged or crash the game due to scripts or pathfinding.",
+
+                  "EXTENDED WEAPON SYSTEMS \n"
+                  "- Alternative to Tactical Reload that suffers from similar weapon related problems and crashes.",
+
+                  "EXTREME PARTICLES OVERHAUL \n"
+                  "- Can cause particle effects related crashes, its INI file raises particle count to 500000. \n"
+                  "  Consider switching to Burst Impact Blast FX: https://www.nexusmods.com/fallout4/mods/57789",
+
+                  "FALLOUT SAKHALIN \n"
+                  "- Breaks the precombine system all across Far Harbor which will randomly crash your game.",
+
+                  "HUD76 HUD REPLACER \n"
+                  "- Can sometimes cause interface and pip-boy related bugs, glitches and crashes.",
+
+                  "NCR RENEGADE ARMOR \n"
+                  "- Broken outfit mesh that crashes the game in 3rd person or when NPCs wearing it are hit.",
+
+                  "RESPAWNABLE LEGENDARY BOSSES \n"
+                  "- Can sometimes cause Deathclaw / Behmoth boulder projectile crashes for unknown reasons.",
+
+                  "SCRAP EVERYTHING (CORE) \n"
+                  "- Weird crashes and issues due to multiple unknown problems. This mod must be always last in your load order.",
+
+                  "SCRAP EVERYTHING (ULTIMATE) \n"
+                  "- Weird crashes and issues due to multiple unknown problems. This mod must be always last in your load order.",
+
+                  "SHADE GIRL LEATHER OUTFITS \n"
+                  "- Outfits can crash the game while browsing the armor workbench or upon starting a new game due to bad meshes.",
+
+                  "SPRING CLEANING \n"
+                  "- Abandoned and severely outdated mod that breaks precombines and could potentially even break your save file.",
+
+                  "STALKER TEXTURE OVERHAUL \n"
+                  "- Doesn't work due to incorrect folder structure and has a corrupted dds file that causes Create2DTexture crashes.",
+
+                  "TACTICAL TABLET \n"
+                  "- Can cause flickering with certain scopes or crashes while browsing workbenches, most commonly with ECO.",
+
+                  "TRUE NIGHTS \n"
+                  "- Has an invalid Image Space Adapter (IMAD) Record that will corrupt your save memory and has to be manually fixed.",
+
+                  "WEAPONS FRAMEWORK BETA \n"
+                  "- Will randomly cause crashes when used with Tactical Reload and possibly other weapon or combat related mods. \n"
+                  "  Visit Important Patches List article for possible solutions: https://www.nexusmods.com/fallout4/articles/3769",
+
+                  "WAR OF THE COMMONWEALTH \n"
+                  "- Seems responsible for consistent crashes with specific spawn points or randomly during settlement attacks."]
+
+    if "[00]" in logtext:
+        for line in plugin_list:
+            for elem in List_Mods1:
+                if "File:" not in line and "[FE" not in line and elem in line:
+                    order_elem = List_Mods1.index(elem)
+                    print("[!] Found:", line[0:5].strip(), List_Warn1[order_elem])
+                    print("-----")
+                    Mod_Trap1 = 0
+                elif "File:" not in line and "[FE" in line and elem in line:
+                    order_elem = List_Mods1.index(elem)
+                    print("[!] Found:", line[0:9].strip(), List_Warn1[order_elem])
+                    print("-----")
+                    Mod_Trap1 = 0
+
+        if logtext.count("ClassicHolsteredWeapons") >= 3 or "ClassicHolsteredWeapons" in buff_error:
+            print("[!] Found: CLASSIC HOLSTERED WEAPONS")
+            print("AUTOSCAN IS PRETTY CERTAIN THAT CHW CAUSED THIS CRASH!")
+            print("You should disable CHW to further confirm this.")
+            print("Visit the main crash logs article for additional solutions.")
             print("-----")
-            print("These records were caught by Buffout 4 and some of them might be related to this crash.")
-            print("Named records should give extra information on involved game objects and record types.")
+            statM_CHW += 1
+            Mod_Trap1 = 0
+            Buffout_Trap = True
+        elif logtext.count("ClassicHolsteredWeapons") >= 2 and ("UniquePlayer.esp" or "HHS.dll" or "cbp.dll" or "Body.nif") in logtext:
+            print("[!] Found: CLASSIC HOLSTERED WEAPONS")
+            print("AUTOSCAN ALSO DETECTED ONE OR SEVERAL MODS THAT WILL CRASH WITH CHW.")
+            print("You should disable CHW to further confirm it caused this crash.")
+            print("Visit the main crash logs article for additional solutions.")
+            print("-----")
+            statM_CHW += 1
+            Mod_Trap1 = 0
+            Buffout_Trap = True
+        elif "ClassicHolsteredWeapons" in logtext and "d3d11" in buff_error:
+            print("[!] Found: CLASSIC HOLSTERED WEAPONS, BUT...")
+            print("AUTOSCAN CANNOT ACCURATELY DETERMINE IF CHW CAUSED THIS CRASH OR NOT.")
+            print("You should open CHW's ini file and change IsHolsterVisibleOnNPCs to 0.")
+            print("This usually prevents most common crashes with Classic Holstered Weapons.")
+            print("-----")
+            Mod_Trap1 = 0
+    if "[00]" in logtext and Mod_Trap1 == 0:
+        print("# CAUTION: ANY ABOVE DETECTED MODS HAVE A MUCH HIGHER CHANCE TO CRASH YOUR GAME! #")
+        print("You can disable any/all of them temporarily to confirm they caused this crash.")
+        print("-----")
+        statL_scanned += 1
+    elif "[00]" in logtext and Mod_Trap1 == 1:
+        print("# AUTOSCAN FOUND NO PROBLEMATIC MODS THAT MATCH THE CURRENT DATABASE FOR THIS LOG #")
+        print("THAT DOESN'T MEAN THERE AREN'T ANY! YOU SHOULD RUN PLUGIN CHECKER IN WRYE BASH.")
+        print("Wrye Bash Link: https://www.nexusmods.com/fallout4/mods/20032?tab=files")
+        print("-----")
+        statL_scanned += 1
+    elif not "[00]" in logtext:
+        print("# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #")
+        print("Autoscan cannot continue. Try scanning a different crash log.")
+        print("-----")
+        statL_incomplete += 1
+
+    print("====================================================")
+    print("CHECKING FOR MODS WITH SOLUTIONS & COMMUNITY PATCHES")
+    print("====================================================")
+    Mod_Trap2 = no_repeat1 = no_repeat2 = 1  # MOD TRAP 2 | NEED 8 SPACES FOR ESL [FE:XXX]
+
+    # Needs 1 empty space as prefix to prevent duplicates.
+    List_Mods2 = [" DLCUltraHighResolution.esm",
+                  " AAF.esm",
+                  " ArmorKeywords.esm",
+                  " BTInteriors_Project.esp",
+                  " CombatZoneRestored.esp",
+                  " D.E.C.A.Y.esp",
+                  " EveryonesBestFriend",
+                  " M8r_Item_Tags",
+                  " Fo4FI_FPS_fix",
+                  " BostonFPSFixAIO.esp",
+                  " FunctionalDisplays.esp",
+                  " skeletonmaleplayer",
+                  " skeletonfemaleplayer",
+                  " CapsWidget",
+                  " Homemaker.esm",
+                  " Horizon.esm",
+                  " ESPExplorerFO4.esp",
+                  " LegendaryModification.esp",
+                  " LooksMenu Customization Compendium.esp",
+                  " MilitarizedMinutemen.esp",
+                  " MoreUniques",
+                  " NAC.es",
+                  " Northland Diggers New.esp",
+                  " ProjectZeta.esm",
+                  " RaiderOverhaul.esp",
+                  " Rusty Face Fix",
+                  " SKKCraftableWeaponsAmmo",
+                  " SOTS.esp",
+                  " StartMeUp.esp",
+                  " SuperMutantRedux.esp",
+                  " TacticalReload.esm",
+                  " Creatures and Monsters.esp",
+                  " ZombieWalkers"]
+
+    List_Warn2 = ["HIGH RESOLUTION DLC. I STRONGLY ADVISE NOT USING IT! \n"
+                  "Right click on Fallout 4 in your Steam Library folder, then select Properties \n"
+                  "Switch to the DLC tab and uncheck / disable the High Resolution Texture Pack",
+                  #
+                  "ADVANCED ANIMATION FRAMEWORK \n"
+                  "Newest AAF version only available on Moddingham | AAF Tech Support: https://discord.gg/gWZuhMC \n"
+                  "Newest AAF Link (register / login to download): https://www.moddingham.com/viewtopic.php?t=2 \n"
+                  "-----\n"
+                  "Looks Menu versions 1.6.20 & 1.6.19 can frequently break adult mod related (erection) morphs \n"
+                  "If you notice AAF realted problems, remove latest version of Looks Menu and switch to 1.6.18",
+                  #
+                  "ARMOR AND WEAPON KEYWORDS \n"
+                  "If you don't rely on AWKCR, consider switching to Equipment and Crafting Overhaul \n"
+                  "Better Alternative: https://www.nexusmods.com/fallout4/mods/55503?tab=files",
+                  #
+                  "BEANTOWN INTERIORS PROJECT \n"
+                  "Usually causes fps drops, stuttering, crashing and culling issues in multiple locations. \n"
+                  "Patch Link: https://www.nexusmods.com/fallout4/mods/53894?tab=files",
+                  #
+                  "COMBAT ZONE RESTORED \n"
+                  "Contains few small issues and NPCs usually have trouble navigating the interior space. \n"
+                  "Patch Link: https://www.nexusmods.com/fallout4/mods/59329?tab=files",
+                  #
+                  "DECAY BETTER GHOULS \n"
+                  "You have to install DECAY Redux patch to prevent its audio files from crashing the game. \n"
+                  "Patch Link: https://www.nexusmods.com/fallout4/mods/59025?tab=files",
+                  #
+                  "EVERYONE'S BEST FRIEND \n"
+                  "This mod needs a compatibility patch to properly work with the Unofficial Patch (UFO4P). \n"
+                  "Patch Link: https://www.nexusmods.com/fallout4/mods/43409?tab=files",
+                  #
+                  "FALLUI ITEM SORTER (OLD) \n"
+                  "This is an outdated item tagging / sorting patch that can cause crashes or conflicts in all kinds of situations. \n"
+                  "I strongly recommend to instead generate your own sorting patch and place it last in your load order. \n"
+                  "That way, you won't experience any conflicts / crashes and even modded items will be sorted. \n"
+                  "Generate Sorting Patch With This: https://www.nexusmods.com/fallout4/mods/48826?tab=files",
+                  #
+                  "FO4FI FPS FIX \n"
+                  "This mod is severely outdated and will cause crashes even with compatibility patches. \n"
+                  "Better Alternative: https://www.nexusmods.com/fallout4/mods/46403?tab=files",
+                  #
+                  "BOSTON FPS FIX \n"
+                  "This mod is severely outdated and will cause crashes even with compatibility patches. \n"
+                  "Better Alternative: https://www.nexusmods.com/fallout4/mods/46403?tab=files",
+                  #
+                  "FUNCTIONAL DISPLAYS \n"
+                  "Frequently causes object model (nif) related crashes and this needs to be manually corrected. \n"
+                  "Advised Fix: Open its Meshes folder and delete everything inside EXCEPT for the Functional Displays folder.",
+                  #
+                  "GENDER SPECIFIC SKELETONS (MALE) \n"
+                  "High chance to cause a crash when starting a new game or during the game intro sequence. \n"
+                  "Advised Fix: Enable the mod only after leaving Vault 111. Existing saves shouldn't be affected.",
+                  #
+                  "GENDER SPECIFIC SKELETONS (FEMALE) \n"
+                  "High chance to cause a crash when starting a new game or during the game intro sequence. \n"
+                  "Advised Fix: Enable the mod only after leaving Vault 111. Existing saves shouldn't be affected.",
+                  #
+                  "HUD CAPS \n"
+                  "Often breaks the Save / Quicksave function due to poor script implementation. \n"
+                  "Advised Fix: Download fixed pex file and place it into HUDCaps/Scripts folder. \n"
+                  "Fix Link: https://drive.google.com/file/d/1egmtKVR7mSbjRgo106UbXv_ySKBg5az2",
+                  #
+                  "HOMEMAKER \n"
+                  "Causes a crash while scrolling over Military / BoS fences in the Settlement Menu. \n"
+                  "Patch Link: https://www.nexusmods.com/fallout4/mods/41434?tab=files",
+                  #
+                  "HORIZON \n"
+                  "Use the mod specific unofficial patch for 1.8.7 until a newer version gets released. \n"
+                  "Patch Link: https://www.nexusmods.com/fallout4/mods/61998?tab=files",
+                  #
+                  "IN GAME ESP EXPLORER \n"
+                  "Can cause a crash when pressing F10 due to a typo in the INI settings. \n"
+                  "Fix Link: https://www.nexusmods.com/fallout4/mods/64752?tab=files \n"
+                  "OR Switch To: https://www.nexusmods.com/fallout4/mods/56922?tab=files",
+                  #
+                  "LEGENDARY MODIFICATION \n"
+                  "Old mod plagued with all kinds of bugs and crashes, can conflict with some modded weapons. \n"
+                  "Better Alternative: https://www.nexusmods.com/fallout4/mods/55503?tab=files",
+                  #
+                  "LOOKS MENU CUSTOMIZATION COMPENDIUM \n"
+                  "Apparently breaks the original Looks Menu mod by turning off some important values. \n"
+                  "Fix Link: https://www.nexusmods.com/fallout4/mods/56465?tab=files",
+                  #
+                  "MILITARIZED MINUTEMEN \n"
+                  "Can occasionally crash the game due to a broken mesh on some minutemen outfits. \n"
+                  "Patch Link: https://www.nexusmods.com/fallout4/mods/55301?tab=files",
+                  #
+                  "MORE UNIQUE WEAPONS EXPANSION \n"
+                  "Causes crashes due to broken precombines and compatibility issues with other weapon mods. \n"
+                  "Patch Link: https://www.nexusmods.com/fallout4/mods/54848?tab=files",
+                  #
+                  "NATURAL AND ATMOSPHERIC COMMONWEALTH \n"
+                  "If you notice weird looking skin tones with either NAC or NACX, install this patch. \n"
+                  "Patch Link: https://www.nexusmods.com/fallout4/mods/57052?tab=files",
+                  #
+                  "NORTHLAND DIGGERS RESOURCES \n"
+                  "Contains various bugs and issues that can cause crashes or negatively affect other mods. \n"
+                  "Fix Link: https://www.nexusmods.com/fallout4/mods/53395?tab=files",
+                  #
+                  "PROJECT ZETA \n"
+                  "Invasion quests seem overly buggy or trigger too frequently, minor sound issues. \n"
+                  "Fix Link: https://www.nexusmods.com/fallout4/mods/65166?tab=files",
+                  #
+                  "RAIDER OVERHAUL \n"
+                  "Old mod that requires several patches to function as intended. Use ONE Version instead. \n"
+                  "Upated ONE Version: https://www.nexusmods.com/fallout4/mods/51658?tab=files",
+                  #
+                  "RUSTY FACE FIX \n"
+                  "Can cause script lag or even crash the game in very rare cases. Switch to REDUX Version instead. \n"
+                  "Updated REDUX Version: https://www.nexusmods.com/fallout4/mods/64270?tab=files",
+                  #
+                  "SKK CRAFT WEAPONS AND SCRAP AMMO \n"
+                  "Version 008 is incompatible with AWKCR and will cause crashes while saving the game. \n"
+                  "Advised Fix: Use Version 007 or remove AWKCR and switch to Equipment and Crafting Overhaul.",
+                  #
+                  "SOUTH OF THE SEA \n"
+                  "Very unstable mod that consistently and frequently causes strange problems and crashes. \n"
+                  "Patch Link: https://www.nexusmods.com/fallout4/mods/59792?tab=files",
+                  #
+                  "START ME UP \n"
+                  "Abandoned mod that can cause infinite loading and other problems. Switch to REDUX Version instead. \n"
+                  "Updated REDUX Version: https://www.nexusmods.com/fallout4/mods/56984?tab=files",
+                  #
+                  "SUPER MUTANT REDUX \n"
+                  "Causes crashes at specific locations or with certain Super Muntant enemies and items. \n"
+                  "Patch Link: https://www.nexusmods.com/fallout4/mods/51353?tab=files",
+                  #
+                  "TACTICAL RELOAD \n"
+                  "Can cause weapon and combat related crashes. TR Expansion For ECO is highly recommended. \n"
+                  "TR Expansion For ECO Link: https://www.nexusmods.com/fallout4/mods/62737",
+                  #
+                  "UNIQUE NPCs CREATURES AND MONSTERS \n"
+                  "Causes crashes and breaks precombines at specific locations, some creature spawns are too frequent. \n"
+                  "Patch Link: https://www.nexusmods.com/fallout4/mods/48637?tab=files",
+                  #
+                  "ZOMBIE WALKERS \n"
+                  "Version 2.6.3 contains a resurrection script that will regularly crash the game. \n"
+                  "Advised Fix: Make sure you're using the 3.0 Beta version of this mod or newer."]
+
+    if "[00]" in logtext:
+        for line in plugin_list:
+            for elem in List_Mods2:
+                if "File:" not in line and "[FE" not in line and elem in line:
+                    order_elem = List_Mods2.index(elem)
+                    print("[!] Found:", line[0:5].strip(), List_Warn2[order_elem])
+                    print("-----")
+                    Mod_Trap2 = 0
+                elif "File:" not in line and "[FE" in line and elem in line:
+                    order_elem = List_Mods2.index(elem)
+                    print("[!] Found:", line[0:9].strip(), List_Warn2[order_elem])
+                    print("-----")
+                    Mod_Trap2 = 0
+            if no_repeat1 == 1 and "File:" not in line and ("Depravity" or "FusionCityRising" or "HotC" or "OutcastsAndRemnants" or "ProjectValkyrie") in line:
+                print("[!] Found:", line[0:9].strip(), "THUGGYSMURF QUEST MOD")
+                print("If you have Depravity, Fusion City Rising, HOTC, Outcasts and Remnants and/or Project Valkyrie,")
+                print("install this patch with facegen data, fully generated precomb/previs data and several tweaks.")
+                print("Patch Link: https://www.nexusmods.com/fallout4/mods/56876?tab=files")
+                print("-----")
+                no_repeat1 = Mod_Trap2 = 0
+            if no_repeat1 == 1 and "File:" not in line and ("CaN.esm" or "AnimeRace_Nanako.esp") in line:
+                print("[!] Found:", line[0:9].strip(), "CUSTOM RACE SKELETON MOD")
+                print("If you have AnimeRace NanakoChan or Crimes Against Nature, install the Race Skeleton Fixes.")
+                print("Skeleton Fixes Link (READ THE DESCRIPTION): https://www.nexusmods.com/fallout4/mods/56101")
+                no_repeat2 = Mod_Trap2 = 0
+
+        if "FallSouls.dll" in logtext:
+            print("[!] Found: FALLSOULS UNPAUSED GAME MENUS")
+            print("Occasionally breaks the Quests menu, can cause crashes while changing MCM settings.")
+            print("Advised Fix: Toggle PipboyMenu in FallSouls MCM settings or completely reinstall the mod.")
+            print("-----")
+            Mod_Trap2 = 0
+    if "[00]" in logtext and Mod_Trap2 == 0:
+        print("[Due to inherent limitations, Auto-Scan will continue detecting certain mods,")
+        print(" even if fixes or patches for them are already installed. You can ignore these.]")
+        print("-----")
+    elif "[00]" in logtext and Mod_Trap2 == 1:
+        print("# AUTOSCAN FOUND NO PROBLEMATIC MODS WITH SOLUTIONS AND COMMUNITY PATCHES #")
+        print("-----")
+    elif logtext.count("[00]") == 0:
+        print("# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #")
+        print("Autoscan cannot continue. Try scanning a different crash log.")
+        print("-----")
+
+    print("FOR FULL LIST OF IMPORTANT PATCHES AND FIXES FOR THE BASE GAME AND MODS,")
+    print("VISIT THIS ARTICLE: https://www.nexusmods.com/fallout4/articles/3769")
+    print("-----")
+
+    print("====================================================")
+    print("CHECKING FOR MODS PATCHED THROUGH OPC INSTALLER...")
+    print("====================================================")
+    Mod_Trap3 = 1  # MOD TRAP 3 | NEED 8 SPACES FOR ESL [FE:XXX]
+
+    # Needs 1 empty space as prefix to prevent duplicates.
+    List_Mods3 = [" Beyond the Borders",
+                  " Deadly Commonwealth Expansion",
+                  " Dogmeat and Strong Armor",
+                  " DoYourDamnJobCodsworth",
+                  " ConcordEXPANDED",
+                  " HagenEXPANDED",
+                  " GlowingSeaEXPANDED",
+                  " SalemEXPANDED",
+                  " SwampsEXPANDED",
+                  " _hod",
+                  " ImmersiveBeantown",
+                  " CovenantComplex",
+                  " GunnersPlazaInterior",
+                  " ImmersiveHubCity",
+                  " Immersive_Lexington",
+                  " Immersive Nahant",
+                  " Immersive S Boston",
+                  " MutilatedDeadBodies",
+                  " Vault4.esp",
+                  " atlanticofficesf23",
+                  " Minutemen Supply Caches",
+                  " moreXplore",
+                  " NEST_BUNKER_PROJECT",
+                  " Raider Children.esp",
+                  " sectorv",
+                  " SettlementShelters",
+                  " subwayrunnnerdynamiclighting",
+                  " 3DNPC_FO4Settler.esp",
+                  " 3DNPC_FO4.esp",
+                  " The Hollow",
+                  " nvvault1080",
+                  " Vertibird Faction Paint Schemes",
+                  " MojaveImports.esp",
+                  " Firelance2.5",
+                  " zxcMicroAdditions"]
+
+    List_Warn3 = ["Beyond the Borders",
+                  "Deadly Commonwealth Expansion",
+                  "Dogmeat and Strong Armor",
+                  "Do Your Damn Job Codsworth",
+                  "Concord Expanded",
+                  "Fort Hagen Expanded",
+                  "Glowing Sea Expanded",
+                  "Salem Expanded",
+                  "Swamps Expanded",
+                  "Hearts Of Darkness",
+                  "Immersive Beantown Brewery",
+                  "Immersive Covenant Compound",
+                  "Immersive Gunners Plaza",
+                  "Immersive Hub City",
+                  "Immersive & Extended Lexington",
+                  "Immersive & Extended Nahant",
+                  "Immersive Military Checkpoint",
+                  "Mutilated Dead Bodies",
+                  "Fourville (Vault 4)",
+                  "Lost Building of Atlantic",
+                  "Minutemen Supply Caches",
+                  "MoreXplore",
+                  "NEST Survival Bunkers",
+                  "Raider Children & Other Horrors",
+                  "Sector Five - Rise and Fall",
+                  "Settlement Shelters",
+                  "Subway Runner (Dynamic Lights)",
+                  "Settlers of the Commonwealth",
+                  "Tales from the Commonwealth",
+                  "The Hollow",
+                  "Vault 1080 (Vault 80)",
+                  "Vertibird Faction Paint Schemes",
+                  "Wasteland Imports (Mojave Imports)",
+                  "Xander's Aid",
+                  "ZXC Micro Additions"]
+
+    if "[00]" in logtext:
+        for line in plugin_list:
+            for elem in List_Mods3:
+                if "File:" not in line and "[FE" not in line and elem in line:
+                    order_elem = List_Mods3.index(elem)
+                    print("- Found:", line[0:5].strip(), List_Warn3[order_elem])
+                    Mod_Trap3 = 0
+                elif "File:" not in line and "[FE" in line and elem in line:
+                    order_elem = List_Mods3.index(elem)
+                    print("- Found:", line[0:9].strip(), List_Warn3[order_elem])
+                    Mod_Trap3 = 0
+    if "[00]" in logtext and Mod_Trap3 == 0:
+        print("-----")
+        print("FOR PATCH REPOSITORY THAT PREVENTS CRASHES AND FIXES PROBLEMS IN THESE AND OTHER MODS,")
+        print("VISIT OPTIMIZATION PATCHES COLLECTION: https://www.nexusmods.com/fallout4/mods/54872")
+        print("-----")
+    elif "[00]" in logtext and Mod_Trap3 == 1:
+        print("# AUTOSCAN FOUND NO PROBLEMATIC MODS THAT ARE ALREADY PATCHED THROUGH OPC INSTALLER #")
+        print("-----")
+    elif logtext.count("[00]") == 0:
+        print("# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #")
+        print("Autoscan cannot continue. Try scanning a different crash log.")
+        print("-----")
+
+    # ===========================================================
+
+    print("====================================================")
+    print("CHECKING IF IMPORTANT PATCHES & FIXES ARE INSTALLED")
+    print("====================================================")
+
+    gpu_amd = False
+    gpu_nvidia = False
+    for line in loglines:
+        if "GPU" in line and "Nvidia" in line:
+            gpu_nvidia = True
+        if "GPU" in line and "AMD" in line:
+            gpu_amd = True
+
+    print("IF YOU'RE USING DYNAMIC PERFORMANCE TUNER AND/OR LOAD ACCELERATOR,")
+    print("remove these mods completely and switch to High FPS Physics Fix!")
+    print("Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files")
+    print("-----")
+
+    if CLAS_config.getboolean("MAIN", "FCX Mode") == True:
+        print("* NOTICE: FCX MODE IS ENABLED. AUTO-SCANNER MUST BE RUN BY ORIGINAL USER FOR CORRECT DETECTION *")
+        print("[ To disable game folder / mod files detection, set FCX Mode = false in Scan Crashlogs.ini ]")
+        print("-----")
+
+        if info.VR_EXE.is_file() and info.VR_Buffout.is_file():
+            print("*Buffout 4 VR Version* is (manually) installed. \n-----")
+        elif info.VR_EXE.is_file() and not info.VR_Buffout.is_file():
+            print("# BUFFOUT 4 FOR VR VERSION ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
+            print("# This is a mandatory Buffout 4 port for the VR Version of Fallout 4.")
+            print("Link: https://www.nexusmods.com/fallout4/mods/64880?tab=files")
+
+        if info.F4CK_EXE.is_file() and os.path.exists(info.F4CK_Fixes):
+            print("*Creation Kit Fixes* is (manually) installed. \n-----")
+        elif info.F4CK_EXE.is_file() and not os.path.exists(info.F4CK_Fixes):
+            print("# CREATION KIT FIXES ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
+            print("This is a highly recommended patch for the Fallout 4 Creation Kit.")
+            print("Link: https://www.nexusmods.com/fallout4/mods/51165?tab=files")
             print("-----")
 
-        print("FOR FULL LIST OF MODS THAT CAUSE PROBLEMS, THEIR ALTERNATIVES AND DETAILED SOLUTIONS,")
-        print("VISIT THE BUFFOUT 4 CRASH ARTICLE: https://www.nexusmods.com/fallout4/articles/3115")
-        print("===============================================================================")
-        print("END OF AUTOSCAN | Author/Made By: Poet#9800 (DISCORD) |", CLAS_Date)
-        c_log.close()
-        sys.stdout.close()
+    if "[00]" in logtext:
+        if any("CanarySaveFileMonitor" in elem for elem in plugin_list):
+            print("*Canary Save File Monitor* is installed. \n-----")
+        else:
+            print("# CANARY SAVE FILE MONITOR ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
+            print("This is a highly recommended mod that can detect save file corrpution.")
+            print("Link: https://www.nexusmods.com/fallout4/mods/44949?tab=files")
+            print("-----")
 
-        # MOVE UNSOLVED LOGS TO SPECIAL FOLDER
-        if CLAS_config.getboolean("MAIN", "Move Unsolved") == True:
-            if not os.path.exists("CLAS-UNSOLVED"):
-                os.mkdir("CLAS-UNSOLVED")
-            if int(Buffout_Trap) == 1:
-                uCRASH_path = "CLAS-UNSOLVED/" + crashlog
-                shutil.move(crashlog, uCRASH_path)
-                uSCAN_path = "CLAS-UNSOLVED/" + logname + "-AUTOSCAN.md"
-                shutil.move(logname + "-AUTOSCAN.md", uSCAN_path)
+        if "HighFPSPhysicsFix.dll" in logtext:
+            print("*High FPS Physics Fix* is installed. \n-----")
+        else:
+            print("# HIGH FPS PHYSICS FIX ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
+            print("This is a mandatory patch / fix that prevents game engine problems.")
+            print("Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files")
+            print("-----")
+
+        if any("PPF.esm" in elem for elem in plugin_list):
+            print("*Previs Repair Pack* is installed. \n-----")
+        else:
+            print("# PREVIS REPAIR PACK ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
+            print("This is a highly recommended mod that can improve performance.")
+            print("Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files")
+            print("-----")
+
+        if any("Unofficial Fallout 4 Patch.esp" in elem for elem in plugin_list):
+            print("*Unofficial Fallout 4 Patch* is installed. \n-----")
+        else:
+            print("# UNOFFICIAL FALLOUT 4 PATCH ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
+            print("If you own all DLCs, make sure that the Unofficial Patch is installed.")
+            print("Link: https://www.nexusmods.com/fallout4/mods/4598?tab=files")
+            print("-----")
+
+        if "vulkan-1.dll" in logtext and gpu_amd:
+            print("Vulkan Renderer is installed. \n-----")
+        elif logtext.count("vulkan-1.dll") == 0 and gpu_amd and not gpu_nvidia:
+            print("# VULKAN RENDERER ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
+            print("This is a highly recommended mod that can improve performance on AMD GPUs.")
+            print("-----")
+            print("Installation steps can be found in 'How To Read Crash Logs' PDF / Document.")
+            print("Link: https://www.nexusmods.com/fallout4/mods/48053?tab=files")
+            print("-----")
+
+        if "WeaponDebrisCrashFix.dll" in logtext and gpu_nvidia:
+            print("*Weapon Debris Crash Fix* is installed. \n-----")
+        elif "WeaponDebrisCrashFix.dll" in logtext and not gpu_nvidia and gpu_amd:
+            print("*Weapon Debris Crash Fix* is installed, but...")
+            print("# YOU DON'T HAVE AN NVIDIA GPU OR BUFFOUT 4 CANNOT DETECT YOUR GPU MODEL #")
+            print("Weapon Debris Crash Fix is only required for Nvidia GPUs (NOT AMD / OTHER)")
+            print("-----")
+        if not "WeaponDebrisCrashFix.dll" in logtext and gpu_nvidia:
+            print("# WEAPON DEBRIS CRASH FIX ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
+            print("This is a mandatory patch / fix for players with Nvidia graphics cards.")
+            print("Link: https://www.nexusmods.com/fallout4/mods/48078?tab=files")
+            print("-----")
+
+        if "NVIDIA_Reflex.dll" in logtext and gpu_nvidia:
+            print("*Nvidia Reflex Support* is installed. \n-----")
+        elif "NVIDIA_Reflex.dll" in logtext and not gpu_nvidia and gpu_amd:
+            print("*Nvidia Reflex Support* is installed, but...")
+            print("# YOU DON'T HAVE AN NVIDIA GPU OR BUFFOUT 4 CANNOT DETECT YOUR GPU MODEL #")
+            print("Nvidia Reflex Support is only required for Nvidia GPUs (NOT AMD / OTHER)")
+            print("-----")
+        if not "NVIDIA_Reflex.dll" in logtext and gpu_nvidia:
+            print("# NVIDIA REFLEX SUPPORT ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #")
+            print("This is a highly recommended mod that can reduce render latency.")
+            print("Link: https://www.nexusmods.com/fallout4/mods/64459?tab=files")
+            print("-----")
+    else:
+        print("# BUFFOUT 4 COULDN'T LOAD THE PLUGIN LIST FOR THIS CRASH LOG! #")
+        print("Autoscan cannot continue. Try scanning a different crash log.")
+        print("-----")
+
+    print("====================================================")
+    print("SCANNING THE LOG FOR SPECIFIC (POSSIBLE) CUPLRITS...")
+    print("====================================================")
+
+    list_DETPLUGINS = []
+    list_DETFORMIDS = []
+    list_DETFILES = []
+    list_ALLPLUGINS = []
+
+    if not "f4se_1_10_163.dll" in logtext and "steam_api64.dll" in logtext:
+        print("AUTOSCAN CANNOT FIND FALLOUT 4 SCRIPT EXTENDER DLL!")
+        print("MAKE SURE THAT F4SE IS CORRECTLY INSTALLED!")
+        print("Link: https://f4se.silverlock.org")
+        print("-----")
+
+    for line in loglines:
+        if len(line) >= 6 and "]" in line[4]:
+            list_ALLPLUGINS.append(line.strip())
+        if len(line) >= 7 and "]" in line[5]:
+            list_ALLPLUGINS.append(line.strip())
+        if len(line) >= 10 and "]" in line[8]:
+            list_ALLPLUGINS.append(line.strip())
+        if len(line) >= 11 and "]" in line[9]:
+            list_ALLPLUGINS.append(line.strip())
+
+    print("LIST OF (POSSIBLE) PLUGIN CULRIPTS:")
+    for line in loglines:
+        if "File:" in line:
+            line = line.replace("File: ", "")
+            line = line.replace('"', '')
+            list_DETPLUGINS.append(line.strip())
+
+    list_DETPLUGINS = list(dict.fromkeys(list_DETPLUGINS))
+    list_remove = ["Fallout4.esm", "DLCCoast.esm", "DLCNukaWorld.esm", "DLCRobot.esm", "DLCworkshop01.esm", "DLCworkshop02.esm", "DLCworkshop03.esm", ""]
+    for elem in list_remove:
+        if elem in list_DETPLUGINS:
+            list_DETPLUGINS.remove(elem)
+
+    PL_strings = list_ALLPLUGINS
+    PL_substrings = list_DETPLUGINS
+    PL_result = []
+
+    for string in PL_strings:
+        PL_matches = []
+        for substring in PL_substrings:
+            if substring in string:
+                PL_matches.append(string)
+        if PL_matches:
+            PL_result.append(PL_matches)
+            print("- " + ' '.join(PL_matches))
+
+    if not PL_result:
+        print("* AUTOSCAN COULDN'T FIND ANY PLUGIN CULRIPTS *")
+        print("-----")
+    else:
+        print("-----")
+        print("These Plugins were caught by Buffout 4 and some of them might be responsible for this crash.")
+        print("You can try disabling these plugins and recheck your game, though this method can be unreliable.")
+        print("-----")
+
+    # ===========================================================
+
+    print("LIST OF (POSSIBLE) FORM ID CULRIPTS:")
+    for line in loglines:
+        if "Form ID:" in line and not "0xFF" in line:
+            line = line.replace("0x", "")
+            if "[00]" in logtext:
+                line = line.replace("Form ID: ", "")
+                line = line.strip()
+                ID_Only = line
+                for elem in plugin_list:
+                    if "]" in elem and "[FE" not in elem:
+                        if elem[2:4].strip() == ID_Only[:2]:
+                            Full_Line = "Form ID: " + ID_Only + " | " + elem.strip()
+                            list_DETFORMIDS.append(Full_Line.replace("    ", ""))
+                    if "[FE" in elem:
+                        elem = elem.replace(":", "")
+                        if elem[2:7] == ID_Only[:5]:
+                            Full_Line = "Form ID: " + ID_Only + " | " + elem.strip()
+                            list_DETFORMIDS.append(Full_Line.replace("    ", ""))
+            else:
+                list_DETFORMIDS.append(line.strip())
+
+    list_DETFORMIDS = list(dict.fromkeys(list_DETFORMIDS))
+    for elem in list_DETFORMIDS:
+        print(elem)
+
+    if not list_DETFORMIDS:
+        print("* AUTOSCAN COULDN'T FIND ANY FORM ID CULRIPTS *")
+        print("-----")
+    else:
+        print("-----")
+        print("These Form IDs were caught by Buffout 4 and some of them might be related to this crash.")
+        print("You can try searching any listed Form IDs in FO4Edit and see if they lead to relevant records.")
+        print("-----")
+
+    # ===========================================================
+
+    List_Files = [".bgsm", ".bto", ".btr", ".dds", ".fuz", ".hkb", ".hkx", ".ini", ".nif", ".pex", ".swf", ".txt", ".uvd", ".wav", ".xwm", "data\\*"]
+    List_Exclude = ['""', "...", ".esp"]
+
+    print("LIST OF DETECTED (NAMED) RECORDS:")
+    List_Records = []
+    for line in loglines:
+        if "Name" in line or any(elem in line for elem in List_Files):
+            if not any(elem in line for elem in List_Exclude):
+                line = line.replace('"', '')
+                List_Records.append(line.strip())
+
+    List_Records = list(dict.fromkeys(List_Records))
+    for elem in List_Records:
+        print(elem)
+
+    if not List_Records:
+        print("* AUTOSCAN COULDN'T FIND ANY NAMED RECORDS *")
+        print("-----")
+    else:
+        print("-----")
+        print("These records were caught by Buffout 4 and some of them might be related to this crash.")
+        print("Named records should give extra information on involved game objects and record types.")
+        print("-----")
+
+    print("FOR FULL LIST OF MODS THAT CAUSE PROBLEMS, THEIR ALTERNATIVES AND DETAILED SOLUTIONS,")
+    print("VISIT THE BUFFOUT 4 CRASH ARTICLE: https://www.nexusmods.com/fallout4/articles/3115")
+    print("===============================================================================")
+    print("END OF AUTOSCAN | Author/Made By: Poet#9800 (DISCORD) |", CLAS_Date)
+    output.close()
+
+    # MOVE UNSOLVED LOGS TO SPECIAL FOLDER
+    if CLAS_config.getboolean("MAIN", "Move Unsolved") == True:
+        if not os.path.exists("CLAS-UNSOLVED"):
+            os.mkdir("CLAS-UNSOLVED")
+        if int(Buffout_Trap) == 1:
+            uCRASH_path = "CLAS-UNSOLVED/" + logname
+            shutil.move(logname, uCRASH_path)
+            uSCAN_path = "CLAS-UNSOLVED/" + logname + "-AUTOSCAN.md"
+            shutil.move(logname + "-AUTOSCAN.md", uSCAN_path)
 
 # dict.fromkeys -> Create dictionary, removes duplicates as dicts cannot have them.
 # BUFFOUT.INI BACK TO BUFFOUT.TOML BECAUSE PYTHON CAN'T WRITE
@@ -1499,7 +1492,6 @@ if info.Buffout_INI.is_file():
         os.rename(info.Buffout_INI, info.Buffout_TOML)
 
 # ========================== LOG END ==========================
-sys.stdout = orig_stdout
 print("SCAN COMPLETE! (IT MIGHT TAKE SEVERAL SECONDS FOR SCAN RESULTS TO APPEAR)")
 print("SCAN RESULTS ARE AVAILABE IN FILES NAMED crash-date-and-time-AUTOSCAN.md")
 print("===============================================================================")
@@ -1565,7 +1557,7 @@ if CLAS_config.getboolean("MAIN", "Stat Logging") == True:
     print("Logs with Rendering Crash................", statC_Rendering)
     print("Logs with Grid Scrap Crash...............", statC_GridScrap)
     print("Logs with Mesh (NIF) Crash...............", statC_NIF)
-    print("Logs with Texture (DDS) Crash............", statC_Texture)
+    print("Logs with Texture (DDS) Crash............", statlogtexture)
     print("Logs with Material (BGSM) Crash..........", statC_BGSM)
     print("Logs with BitDefender Crash..............", statC_BitDefender)
     print("Logs with NPC Pathing Crash..............", statC_NPCPathing)


### PR DESCRIPTION
- I switched the stdout redirection to traditional python file I/O and the text concatenation to f-strings. Traditional I/O does not have implicit newlines (which I get is a convenience of stdout redirection).
- Use some more of pathlib's features.
- Changed the file-list building from os.listdir/fnmatch to glob. glob does in one step what the os.listdir/fnmatch does in 2.
- Only import ctypes.wintypes on Windows. The only code that uses it only runs on windows, so no need to import a module that's not going to be used if the script is being run on linux.
- Stop the gpu detection for loop when it finds either an amd or nvidia gpu (no need to keep searching for something you already found).
- Modified the CK fixes check so that it doesn't just check for the launcher (which hasn't been bundled since v1.6 because Nexus false flags it as a virus).