### PR TITLE
Add encoding="utf-8" to open line for the game path check.

### DIFF
--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -216,7 +216,7 @@ if CLAS_config.getboolean("MAIN", "FCX Mode") == True:
 
 # Check if f4se.log exists and find game path inside.
 if info.FO4_F4SE_Path.is_file():
-    with open(info.FO4_F4SE_Path, "r") as LOG_Check:
+    with open(info.FO4_F4SE_Path, "r", encoding="utf-8") as LOG_Check:
         Path_Check = LOG_Check.readlines()
         for line in Path_Check:
             if "plugin directory" in line:


### PR DESCRIPTION
I saw a post in the posts section on nexus reporting this as a problem. I immediately recognized it as a character encoding issue that has occured in the past and was fixed by adding the encoding parameter to the open statement.