### PR TITLE
00-nothing

### DIFF
--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -292,7 +292,7 @@ for file in logs:
             plugin_list = []
             with open("loadorder.txt", "r", errors="ignore") as loadorder_check:
                 plugin_format = loadorder_check.readlines()
-                if len(plugin_format) >= 1:
+                if len(plugin_format) >= 1 and "[00]" not in plugin_list:
                     plugin_list.append("[00]")
                 for line in plugin_format:
                     line = "[LO] " + line.strip()

--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -292,10 +292,11 @@ for file in logs:
             plugin_list = []
             with open("loadorder.txt", "r", errors="ignore") as loadorder_check:
                 plugin_format = loadorder_check.readlines()
+                if len(plugin_format) >= 1:
+                    plugin_list.append("[00]")
                 for line in plugin_format:
                     line = "[LO] " + line.strip()
                     plugin_list.append(line)
-
         # BUFFOUT VERSION CHECK
         buff_latest = "Buffout 4 v1.26.2"
         output.write(f"Main Error: {buff_error}\n")


### PR DESCRIPTION
The hotfix didn't work on the original loadorder.txt log that exposed the bug. I don't know how the [00] thing is supposed to work, so I just added it to the list if len(plugin_format) >= 1 and "[00]" not in plugin_list and it worked.