### PR TITLE
Added isinstance check to the CK fixes check and only run it if creatonkit.exe is found

### DIFF
--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -1308,14 +1308,14 @@ for file in logs:
                 output.write("# BUFFOUT 4 FOR VR VERSION ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #\n")
                 output.write("# This is a mandatory Buffout 4 port for the VR Version of Fallout 4.\n")
                 output.write("Link: https://www.nexusmods.com/fallout4/mods/64880?tab=files\n")
-
-            if (info.F4CK_EXE.is_file() and os.path.exists(info.F4CK_Fixes)) or Path(info.Game_Path).joinpath("winhttp.dll").is_file():
-                output.write("*Creation Kit Fixes* is (manually) installed. \n-----\n")
-            elif info.F4CK_EXE.is_file() and not os.path.exists(info.F4CK_Fixes):
-                output.write("# CREATION KIT FIXES ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #\n")
-                output.write("This is a highly recommended patch for the Fallout 4 Creation Kit.\n")
-                output.write("Link: https://www.nexusmods.com/fallout4/mods/51165?tab=files\n")
-                output.write("-----\n")
+            if (isinstance(info.Game_Path, str) and Path(info.Game_Path).joinpath("CreationKit.exe")):
+                if (info.F4CK_EXE.is_file() and os.path.exists(info.F4CK_Fixes)) or (isinstance(info.Game_Path, str) and Path(info.Game_Path).joinpath("winhttp.dll").is_file()):
+                    output.write("*Creation Kit Fixes* is (manually) installed. \n-----\n")
+                elif info.F4CK_EXE.is_file() and not os.path.exists(info.F4CK_Fixes):
+                    output.write("# CREATION KIT FIXES ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #\n")
+                    output.write("This is a highly recommended patch for the Fallout 4 Creation Kit.\n")
+                    output.write("Link: https://www.nexusmods.com/fallout4/mods/51165?tab=files\n")
+                    output.write("-----\n")
 
         if any("[00]" in elem for elem in plugin_list):
             if any("CanarySaveFileMonitor" in elem for elem in plugin_list):

--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -1309,14 +1309,13 @@ for file in logs:
                 output.write("# This is a mandatory Buffout 4 port for the VR Version of Fallout 4.\n")
                 output.write("Link: https://www.nexusmods.com/fallout4/mods/64880?tab=files\n")
             
-            if (isinstance(info.Game_Path, str) and Path(info.Game_Path).joinpath("CreationKit.exe")):
-                if (info.F4CK_EXE.is_file() and os.path.exists(info.F4CK_Fixes)) or (isinstance(info.Game_Path, str) and Path(info.Game_Path).joinpath("winhttp.dll").is_file()):
-                    output.write("*Creation Kit Fixes* is (manually) installed. \n-----\n")
-                elif info.F4CK_EXE.is_file() and not os.path.exists(info.F4CK_Fixes):
-                    output.write("# CREATION KIT FIXES ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #\n")
-                    output.write("This is a highly recommended patch for the Fallout 4 Creation Kit.\n")
-                    output.write("Link: https://www.nexusmods.com/fallout4/mods/51165?tab=files\n")
-                    output.write("-----\n")
+            if (info.F4CK_EXE.is_file() and os.path.exists(info.F4CK_Fixes)) or (isinstance(info.Game_Path, str) and Path(info.Game_Path).joinpath("winhttp.dll").is_file()):
+                output.write("*Creation Kit Fixes* is (manually) installed. \n-----\n")
+            elif info.F4CK_EXE.is_file() and not os.path.exists(info.F4CK_Fixes):
+                output.write("# CREATION KIT FIXES ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #\n")
+                output.write("This is a highly recommended patch for the Fallout 4 Creation Kit.\n")
+                output.write("Link: https://www.nexusmods.com/fallout4/mods/51165?tab=files\n")
+                output.write("-----\n")
 
         if any("[00]" in elem for elem in plugin_list):
             if any("CanarySaveFileMonitor" in elem for elem in plugin_list):

--- a/Scan Crashlogs.py
+++ b/Scan Crashlogs.py
@@ -1308,6 +1308,7 @@ for file in logs:
                 output.write("# BUFFOUT 4 FOR VR VERSION ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #\n")
                 output.write("# This is a mandatory Buffout 4 port for the VR Version of Fallout 4.\n")
                 output.write("Link: https://www.nexusmods.com/fallout4/mods/64880?tab=files\n")
+            
             if (isinstance(info.Game_Path, str) and Path(info.Game_Path).joinpath("CreationKit.exe")):
                 if (info.F4CK_EXE.is_file() and os.path.exists(info.F4CK_Fixes)) or (isinstance(info.Game_Path, str) and Path(info.Game_Path).joinpath("winhttp.dll").is_file()):
                     output.write("*Creation Kit Fixes* is (manually) installed. \n-----\n")


### PR DESCRIPTION
VSCode showed me that because info.Game_Path is None by default, it couldn't be used to create a Path in its default state. I added an isinstance check to make sure it is being passed a string and that seems to have placated VSCode's linter. I also took the opportunity to put the CK Fixes check behind a check for creationkit.exe since you wouldn't need/want CK Fixes without CK installed.