### PR TITLE
Improvements and fixes from VSCode's fine-toothed comb (aka type-checker)

### DIFF
--- a/Scan_Crashlogs.py
+++ b/Scan_Crashlogs.py
@@ -272,7 +272,8 @@ def scan_logs():
                 from Scan_Gamefiles import scan_mainfiles
                 mainfiles_result = scan_mainfiles()
                 for line in mainfiles_result:
-                    output.writelines([line,"\n"])
+                    output.writelines(line)
+                output.write("\n")
             else:
                 # CHECK BUFFOUT 4 TOML SETTINGS IN CRASH LOG ONLY
                 if ("Achievements: true" in logtext and "achievements.dll" in logtext) or ("Achievements: true" in logtext and "UnlimitedSurvivalMode.dll" in logtext):
@@ -663,6 +664,7 @@ def scan_logs():
                 if plugins_loaded:
                     for elem in mods.keys():
                         if mods[elem]["mod_1"] in plugins_list and mods[elem]["mod_2"] in plugins_list:
+                            warn = ''.join(mods[elem]["warn"])
                             output.writelines([f"[!] Found: {warn}\n",
                                                "-----\n"])
                             mod_trap = True
@@ -749,7 +751,7 @@ def scan_logs():
                      "warn": ["WAR OF THE COMMONWEALTH \n",
                               "- Seems responsible for consistent crashes with specific spawn points or randomly during settlement attacks."]}
             }
-
+            Mod_Check1 = False
             if plugins_loaded:
                 Mod_Check1 = check_plugins(Mods1, Mod_Trap1)
 
@@ -784,7 +786,7 @@ def scan_logs():
                     output.write("This usually prevents most common crashes with Classic Holstered Weapons.\n")
                     output.write("-----\n")
                     Mod_Trap1 = True
-
+            
             if plugins_loaded and (Mod_Check1 or Mod_Trap1) is True:
                 output.writelines(["# [!] CAUTION : ANY ABOVE DETECTED MODS HAVE A MUCH HIGHER CHANCE TO CRASH YOUR GAME! #\n",
                                    "  You can disable any/all of them temporarily to confirm they caused this crash.\n",
@@ -845,12 +847,12 @@ def scan_logs():
                     "warn": ["MOD_1_NAME ❌ CONFLICTS WITH : MOD_2_NAME \n",
                              "- TEMPLATE."]},
             }
-            
+            Mod_Check2 = False
             if plugins_loaded:
                 Mod_Check2 = check_conflicts(Mods2, Mod_Trap2)
                 # =============== SPECIAL MOD / PLUGIN CHECKS ===============
                 # CURRENTLY NONE
-
+            
             if plugins_loaded and (Mod_Check2 or Mod_Trap2) is True:
                 output.writelines(["# AUTOSCAN FOUND MODS THAT ARE INCOMPATIBLE OR CONFLICT WITH YOUR OTHER MODS # \n",
                                    "* YOU SHOULD CHOOSE WHICH MOD TO KEEP AND REMOVE OR DISABLE THE OTHER MOD * \n",
@@ -1045,24 +1047,24 @@ def scan_logs():
                               "- Version 2.6.3 contains a resurrection script that will regularly crash the game. \n",
                               "  Advised Fix: Make sure you're using the 3.0 Beta version of this mod or newer."]}
             }
-
+            Mod_Check3 = False
             if plugins_loaded:
                 Mod_Check3 = check_plugins(Mods3, Mod_Trap3)
+                for line in loglines:
+                    # =============== SPECIAL MOD / PLUGIN CHECKS ===============
+                    if no_repeat1 is False and "File:" not in line and ("Depravity" or "FusionCityRising" or "HotC" or "OutcastsAndRemnants" or "ProjectValkyrie") in line:
+                        output.writelines([f"[!] Found: {line[0:9].strip()} THUGGYSMURF QUEST MOD\n",
+                                           "If you have Depravity, Fusion City Rising, HOTC, Outcasts and Remnants and/or Project Valkyrie\n",
+                                           "install this patch with facegen data, fully generated precomb/previs data and several tweaks.\n",
+                                           "Patch Link: https://www.nexusmods.com/fallout4/mods/56876?tab=files\n",
+                                           "-----\n"])
+                        no_repeat1 = Mod_Trap3 = True
 
-                # =============== SPECIAL MOD / PLUGIN CHECKS ===============
-                if no_repeat1 is False and "File:" not in line and ("Depravity" or "FusionCityRising" or "HotC" or "OutcastsAndRemnants" or "ProjectValkyrie") in line:
-                    output.writelines([f"[!] Found: {line[0:9].strip()} THUGGYSMURF QUEST MOD\n",
-                                       "If you have Depravity, Fusion City Rising, HOTC, Outcasts and Remnants and/or Project Valkyrie\n",
-                                       "install this patch with facegen data, fully generated precomb/previs data and several tweaks.\n",
-                                       "Patch Link: https://www.nexusmods.com/fallout4/mods/56876?tab=files\n",
-                                       "-----\n"])
-                    no_repeat1 = Mod_Trap3 = True
-
-                if no_repeat2 is False and "File:" not in line and ("CaN.esm" or "AnimeRace_Nanako.esp") in line:
-                    output.writelines([f"[!] Found: {line[0:9].strip()} CUSTOM RACE SKELETON MOD\n",
-                                       "If you have AnimeRace NanakoChan or Crimes Against Nature, install the Race Skeleton Fixes.\n",
-                                       "Skeleton Fixes Link (READ THE DESCRIPTION): https://www.nexusmods.com/fallout4/mods/56101\n"])
-                    no_repeat2 = Mod_Trap3 = True
+                    if no_repeat2 is False and "File:" not in line and ("CaN.esm" or "AnimeRace_Nanako.esp") in line:
+                        output.writelines([f"[!] Found: {line[0:9].strip()} CUSTOM RACE SKELETON MOD\n",
+                                           "If you have AnimeRace NanakoChan or Crimes Against Nature, install the Race Skeleton Fixes.\n",
+                                           "Skeleton Fixes Link (READ THE DESCRIPTION): https://www.nexusmods.com/fallout4/mods/56101\n"])
+                        no_repeat2 = Mod_Trap3 = True
 
                 if "FallSouls.dll" in logtext:
                     output.writelines([f"[!] Found: FALLSOULS UNPAUSED GAME MENUS\n",
@@ -1163,7 +1165,7 @@ def scan_logs():
                 34: {"mod": " zxcMicroAdditions",
                      "warn": "ZXC Micro Additions"}
             }
-
+            Mod_Check4 = False
             if plugins_loaded:
                 Mod_Check4 = check_plugins(Mods4, Mod_Trap4)
                 # =============== SPECIAL MOD / PLUGIN CHECKS ===============

--- a/Scan_Gamefiles.py
+++ b/Scan_Gamefiles.py
@@ -2,6 +2,7 @@ import os
 import stat
 import platform
 import configparser
+from dataclasses import dataclass, field
 from glob import glob
 from pathlib import Path
 from Scan_Crashlogs import clas_ini_create
@@ -79,38 +80,38 @@ Warn_BLOG_NOTE_Modules = """\
 
 
 # =================== DEFINE LOCAL FILES ===================
+@dataclass
 class Info:
-    def __init__(self):
-        # FO4 GAME FILES
-        self.Address_Library: Path | None = None
-        self.Buffout_DLL: Path | None = None
-        self.Buffout_INI: Path | None = None
-        self.Buffout_TOML: Path | None = None
-        self.F4CK_EXE: Path | None = None
-        self.F4CK_Fixes: Path | None = None
-        self.F4SE_DLL: Path | None = None
-        self.F4SE_Loader: Path | None = None
-        self.F4SE_SDLL: Path | None = None
-        self.F4SE_VRDLL: Path | None = None
-        self.F4SE_VRLoader: Path | None = None
-        self.FO4_EXE: Path | None = None
-        self.Game_Path: str | None = None
-        self.Game_Scripts: Path | None = None
-        self.Preloader_DLL: Path | None = None
-        self.Preloader_XML: Path | None = None
-        self.Steam_INI: Path | None = None
-        self.VR_Buffout: Path | None = None
-        self.VR_EXE: Path | None = None
-        # FO4 DOC FILES
-        self.BO4_Achievements: Path | None = None
-        self.BO4_Looksmenu: Path | None = None
-        self.BO4_BakaSH: Path | None = None
-        self.FO4_F4SE_Logs: Path | None = None
-        self.FO4_F4SE_Path: Path | None = None
-        self.FO4_F4SEVR_Path: Path | None = None
-        self.FO4_Custom_Path: Path | None = None
-
-    def docs_file_check(self, docs_location):
+    # FO4 GAME FILES
+    Address_Library: Path = field(default_factory=Path)
+    Buffout_DLL: Path = field(default_factory=Path)
+    Buffout_INI: Path = field(default_factory=Path)
+    Buffout_TOML: Path = field(default_factory=Path)
+    F4CK_EXE: Path = field(default_factory=Path)
+    F4CK_Fixes: Path = field(default_factory=Path)
+    F4SE_DLL: Path = field(default_factory=Path)
+    F4SE_Loader: Path = field(default_factory=Path)
+    F4SE_SDLL: Path = field(default_factory=Path)
+    F4SE_VRDLL: Path = field(default_factory=Path)
+    F4SE_VRLoader: Path = field(default_factory=Path)
+    FO4_EXE: Path = field(default_factory=Path)
+    Game_Path: str = field(default_factory=str)
+    Game_Scripts: Path = field(default_factory=Path)
+    Preloader_DLL: Path = field(default_factory=Path)
+    Preloader_XML: Path = field(default_factory=Path)
+    Steam_INI: Path = field(default_factory=Path)
+    VR_Buffout: Path = field(default_factory=Path)
+    VR_EXE: Path = field(default_factory=Path)
+    # FO4 DOC FILES
+    BO4_Achievements: Path = field(default_factory=Path)
+    BO4_Looksmenu: Path = field(default_factory=Path)
+    BO4_BakaSH: Path = field(default_factory=Path)
+    FO4_F4SE_Logs: str = field(default_factory=str)
+    FO4_F4SE_Path: Path = field(default_factory=Path)
+    FO4_F4SEVR_Path: Path = field(default_factory=Path)
+    FO4_Custom_Path: Path = field(default_factory=Path)
+    
+    def docs_file_check(self, docs_location: Path):
         self.BO4_Achievements = docs_location.joinpath("My Games", "Fallout4", "F4SE", "achievements.log")
         self.BO4_Looksmenu = docs_location.joinpath("My Games", "Fallout4", "F4SE", "f4ee.log")
         self.BO4_BakaSH = docs_location.joinpath("My Games", "Fallout4", "F4SE", "BakaScrapHeap.log")
@@ -164,7 +165,7 @@ def docs_path_check():
             return Manual_Docs
 
 
-info.docs_file_check(docs_path_check())
+info.docs_file_check(docs_path_check()) # type: ignore
 
 
 # =================== CHECK MAIN FILES ===================
@@ -453,7 +454,7 @@ def scan_modfiles():
         else:
             scan_modfiles_report.append("❌ *Fallout 4 VR* is NOT installed.\n  -----")
 
-        if (info.F4CK_EXE.is_file() and os.path.exists(info.F4CK_Fixes)) or (isinstance(info.Game_Path, str) and Path(info.Game_Path).joinpath("winhttp.dll").is_file()):
+        if (info.F4CK_EXE.is_file() and os.path.exists(info.F4CK_Fixes)) or (isinstance(info.Game_Path, str) and Path(info.Game_Path).joinpath("winhttp.dll").is_file()): # type: ignore
             scan_modfiles_report.append("✔️ *Creation Kit Fixes* is (manually) installed.\n  -----")
         elif info.F4CK_EXE.is_file() and not os.path.exists(info.F4CK_Fixes):
             scan_modfiles_report.extend(["# ❌ CREATION KIT FIXES ISN'T INSTALLED OR AUTOSCAN CANNOT DETECT IT #",

--- a/Scan_Interface.py
+++ b/Scan_Interface.py
@@ -209,37 +209,37 @@ class UiClasMainwin(object):
         self.ArtBT_Buffout4.setGeometry(QtCore.QRect(40, 370, 150, 30))
         self.ArtBT_Buffout4.setObjectName("ArtBT_Buffout4")
         self.ArtBT_Buffout4.setText("BUFFOUT 4 INSTALLATION")
-        self.ArtBT_Buffout4.clicked.connect(lambda: QDesktopServices.openUrl(QUrl("https://www.nexusmods.com/fallout4/articles/3115")))
+        self.ArtBT_Buffout4.clicked.connect(lambda: QDesktopServices.openUrl(QUrl("https://www.nexusmods.com/fallout4/articles/3115"))) # type: ignore
         # Button - Article Advanced Troubleshooting
         self.ArtBT_Troubleshoot = QtWidgets.QPushButton(CLAS_MainWin)
         self.ArtBT_Troubleshoot.setGeometry(QtCore.QRect(220, 370, 200, 30))
         self.ArtBT_Troubleshoot.setObjectName("ArtBT_Troubleshoot")
         self.ArtBT_Troubleshoot.setText("ADVANCED TROUBLESHOOTING")
-        self.ArtBT_Troubleshoot.clicked.connect(lambda: QDesktopServices.openUrl(QUrl("https://www.nexusmods.com/fallout4/articles/4141")))
+        self.ArtBT_Troubleshoot.clicked.connect(lambda: QDesktopServices.openUrl(QUrl("https://www.nexusmods.com/fallout4/articles/4141"))) # type: ignore
         # Button - Article Important Patches 
         self.ArtBT_Patches = QtWidgets.QPushButton(CLAS_MainWin)
         self.ArtBT_Patches.setGeometry(QtCore.QRect(450, 370, 150, 30))
         self.ArtBT_Patches.setObjectName("ArtBT_Patches")
         self.ArtBT_Patches.setText("IMPORTANT PATCHES LIST")
-        self.ArtBT_Patches.clicked.connect(lambda: QDesktopServices.openUrl(QUrl("https://www.nexusmods.com/fallout4/articles/3769")))
+        self.ArtBT_Patches.clicked.connect(lambda: QDesktopServices.openUrl(QUrl("https://www.nexusmods.com/fallout4/articles/3769"))) # type: ignore
         # Button - Website Buffout 4
         self.WebBT_Buffout4_Nexus = QtWidgets.QPushButton(CLAS_MainWin)
         self.WebBT_Buffout4_Nexus.setGeometry(QtCore.QRect(40, 420, 150, 30))
         self.WebBT_Buffout4_Nexus.setObjectName("WebBT_Buffout4")
         self.WebBT_Buffout4_Nexus.setText("BUFFOUT 4 NEXUS PAGE")
-        self.WebBT_Buffout4_Nexus.clicked.connect(lambda: QDesktopServices.openUrl(QUrl("https://www.nexusmods.com/fallout4/mods/47359")))
+        self.WebBT_Buffout4_Nexus.clicked.connect(lambda: QDesktopServices.openUrl(QUrl("https://www.nexusmods.com/fallout4/mods/47359"))) # type: ignore
         # Button - Website CLAS Nexus
         self.WebBT_CLAS_Nexus = QtWidgets.QPushButton(CLAS_MainWin)
         self.WebBT_CLAS_Nexus.setGeometry(QtCore.QRect(220, 420, 200, 30))
         self.WebBT_CLAS_Nexus.setObjectName("WebBT_CLAS_Nexus")
         self.WebBT_CLAS_Nexus.setText("AUTO SCANNER NEXUS PAGE")
-        self.WebBT_CLAS_Nexus.clicked.connect(lambda: QDesktopServices.openUrl(QUrl("https://www.nexusmods.com/fallout4/mods/56255")))
+        self.WebBT_CLAS_Nexus.clicked.connect(lambda: QDesktopServices.openUrl(QUrl("https://www.nexusmods.com/fallout4/mods/56255"))) # type: ignore
         # Button - Website CLAS Github
         self.WebBT_CLAS_Github = QtWidgets.QPushButton(CLAS_MainWin)
         self.WebBT_CLAS_Github.setGeometry(QtCore.QRect(450, 420, 150, 30))
         self.WebBT_CLAS_Github.setObjectName("WebBT_CLAS_Git")
         self.WebBT_CLAS_Github.setText("AUTO SCANNER GITHUB")
-        self.WebBT_CLAS_Github.clicked.connect(lambda: QDesktopServices.openUrl(QUrl("https://github.com/GuidanceOfGrace/Buffout4-CLAS/releases")))
+        self.WebBT_CLAS_Github.clicked.connect(lambda: QDesktopServices.openUrl(QUrl("https://github.com/GuidanceOfGrace/Buffout4-CLAS/releases"))) # type: ignore
 
         # BOTTOM
 


### PR DESCRIPTION
Changed Info to a dataclass now that it's feasible to do so.
VSCode's type-checker was always getting confused by the None placeholders.
In retrospect, I should have used the dataclass in the first place.
In the Mod_Check3 section, the special mod checks were looking for a variable from a for-loop that wasn't there.
A nested list in FCX mode where it printed the main files report was causing the script to error out.
Plus, the standard placation regarding unbound variables.