### PR TITLE
Use configparser's dict notation instead of set() and get()

### DIFF
--- a/Scan_Crashlogs.py
+++ b/Scan_Crashlogs.py
@@ -286,7 +286,7 @@ def scan_logs():
             output.writelines(["\n====================================================\n",
                                "CHECKING IF NECESSARY FILES/SETTINGS ARE CORRECT...\n",
                                "====================================================\n"])
-            if CLAS_config.get("MAIN", "FCX Mode").lower() == "true":
+            if CLAS_config["MAIN"]["FCX Mode"].lower() == "true":
                 output.write(Warn_SCAN_NOTE_FCX)
                 from Scan_Gamefiles import scan_mainfiles
                 mainfiles_result = scan_mainfiles()

--- a/Scan_Crashlogs.py
+++ b/Scan_Crashlogs.py
@@ -1559,10 +1559,10 @@ if __name__ == "__main__":  # AKA only autorun / do the following when NOT impor
     if isinstance(args.move_unsolved, bool) and not args.move_unsolved == CLAS_config.getboolean("MAIN", "Move Unsolved"):
         clas_ini_update("Move Unsolved", str(args.move_unsolved).lower())
 
-    if isinstance(ini_path, Path) and ini_path.resolve().is_dir() and not str(ini_path) == CLAS_config.get("MAIN", "INI Path"):
+    if isinstance(ini_path, Path) and ini_path.resolve().is_dir() and not str(ini_path) == CLAS_config["MAIN"]["INI Path"]:
         clas_ini_update("INI Path", str(Path(ini_path).resolve()))
 
-    if isinstance(scan_path, Path) and scan_path.resolve().is_dir() and not str(scan_path) == CLAS_config.get("MAIN", "Scan Path"):
+    if isinstance(scan_path, Path) and scan_path.resolve().is_dir() and not str(scan_path) == CLAS_config["MAIN"]["Scan Path"]:
         clas_ini_update("Scan Path", str(Path(scan_path).resolve()))
 
     clas_update_run()

--- a/Scan_Crashlogs.py
+++ b/Scan_Crashlogs.py
@@ -63,9 +63,9 @@ CLAS_Updated = False
 
 def clas_ini_update(section: str, value: str):  # Convenience function for a code snippet that's repeated many times throughout both scripts.
     if isinstance(section, str) and isinstance(value, str):
-        CLAS_config.set("MAIN", section, value)
+        CLAS_config["MAIN"][section] = value
     else:
-        CLAS_config.set("MAIN", str(section), str(value))
+        CLAS_config["MAIN"][str(section)] = str(value)
 
     with open("Scan Crashlogs.ini", "w+", encoding="utf-8", errors="ignore") as INI_AUTOSCAN:
         CLAS_config.write(INI_AUTOSCAN)
@@ -229,8 +229,8 @@ def scan_logs():
     # =================== AUTOSCAN REPORT ===================
 
     SCAN_folder = os.getcwd()
-    if len(CLAS_config.get("MAIN", "Scan Path")) > 1:
-        SCAN_folder = CLAS_config.get("MAIN", "Scan Path")
+    if len(CLAS_config["MAIN"]["Scan Path"]) > 1:
+        SCAN_folder = CLAS_config["MAIN"]["Scan Path"]
 
     for file in glob(f"{SCAN_folder}/crash-*.log"):  # + glob(f"{SCAN_folder}/crash-*.txt")
         logpath = Path(file).resolve()
@@ -1200,7 +1200,7 @@ def scan_logs():
                     gpu_amd = True
                     break
 
-            if CLAS_config.get("MAIN", "FCX Mode").lower() == "true":
+            if CLAS_config["MAIN"]["FCX Mode"].lower() == "true":
                 output.write(Warn_SCAN_NOTE_FCX)
                 from Scan_Gamefiles import scan_modfiles
                 modfiles_result = scan_modfiles()

--- a/Scan_Gamefiles.py
+++ b/Scan_Gamefiles.py
@@ -17,15 +17,8 @@ except (ImportError, ModuleNotFoundError):
 
 if platform.system() == "Windows":
     import ctypes.wintypes
+
 clas_ini_create()
-
-
-def clas_ini_check(section: str, value: str):
-    if isinstance(section, str) and isinstance(value, str):
-        return CLAS_config[section][value]
-    else:
-        return CLAS_config[str(section)][str(value)]
-
 
 # =================== WARNING MESSAGES ==================
 # Can change first line to """\ to remove spacing.
@@ -161,8 +154,8 @@ def docs_path_check():
                         return Lin_Docs
 
     if Loc_Found is False:  # INI_Docs | CHECK CLAS INI IF DOCUMENTS FOLDER IS ALREADY GIVEN.
-        if "fallout4" in clas_ini_check("MAIN", "INI Path").lower():
-            INI_Line = clas_ini_check("MAIN", "INI Path").strip()
+        if "fallout4" in CLAS_config["MAIN"]["INI Path"].lower():
+            INI_Line = CLAS_config["MAIN"]["INI Path"].strip()
             INI_Docs = Path(INI_Line)
             return INI_Docs
         else:  # Manual_Docs | PROMPT MANUAL INPUT IF DOCUMENTS FOLDER CANNOT BE FOUND.
@@ -360,7 +353,7 @@ def scan_mainfiles():
         scan_mainfiles_report.append("✔️ Available logs in your Game Folder do not report any additional errors.\n  -----")
 
     # CHECK BUFFOUT 4 REQUIREMENTS | IMI MODE
-    if str(clas_ini_check("MAIN", "IMI Mode")).lower() == "false":
+    if str(CLAS_config["MAIN"]["IMI Mode"]).lower() == "false":
         if info.Preloader_XML.is_file() and info.Preloader_DLL.is_file():
             scan_mainfiles_report.append(Warn_SCAN_NOTE_Preloader)
         else:
@@ -441,7 +434,7 @@ def scan_modfiles():
     scan_modfiles_report = []
 
     # CHECK SPECIFIC GAME MODS / EXTENSIONS | IMI MODE
-    if str(clas_ini_check("MAIN", "IMI Mode")).lower() == "false":
+    if str(CLAS_config["MAIN"]["IMI Mode"]).lower() == "false":
         scan_modfiles_report.extend(["IF YOU'RE USING DYNAMIC PERFORMANCE TUNER AND/OR LOAD ACCELERATOR,",
                                      "remove these mods completely and switch to High FPS Physics Fix!",
                                      "Link: https://www.nexusmods.com/fallout4/mods/44798?tab=files",

--- a/Scan_Gamefiles.py
+++ b/Scan_Gamefiles.py
@@ -22,9 +22,9 @@ clas_ini_create()
 
 def clas_ini_check(section: str, value: str):
     if isinstance(section, str) and isinstance(value, str):
-        return CLAS_config.get(section, value)
+        return CLAS_config[section][value]
     else:
-        return CLAS_config.get(str(section), str(value))
+        return CLAS_config[str(section)][str(value)]
 
 
 # =================== WARNING MESSAGES ==================

--- a/Scan_Interface.py
+++ b/Scan_Interface.py
@@ -65,8 +65,8 @@ class UiClasMainwin(object):
         self.Line_SelectedFolder.setGeometry(QtCore.QRect(20, 30, 450, 22))
         self.Line_SelectedFolder.setObjectName("Line_SelectedFolder")
         self.Line_SelectedFolder.setText("(Optional) Press 'Browse Folder...' to set a different scan folder location.")
-        if len(CLAS_config.get("MAIN", "Scan Path")) > 1:
-            SCAN_folder = CLAS_config.get("MAIN", "Scan Path")
+        if len(CLAS_config["MAIN"]["Scan Path"].strip()) > 1:
+            SCAN_folder = CLAS_config["MAIN"]["Scan Path"].strip()
             self.Line_SelectedFolder.setText(SCAN_folder)
         # Change text color to gray.
         LSF_palette = self.Line_SelectedFolder.palette()


### PR DESCRIPTION
I was looking at the documentation for configparser and found that you can use a dictionary-esque notation instead of get() and set() calls. getboolean() will still be necessary if we need boolean values.