### PR TITLE
Add Modern Firearms New Calibers Patch to the broken mods list.

### DIFF
--- a/CLAS_Database.py
+++ b/CLAS_Database.py
@@ -941,7 +941,7 @@ class ClasCheckMods:
          "warn": ["WAR OF THE COMMONWEALTH \n",
                   "[Seems responsible for consistent crashes with specific spawn points or random ones during settlement attacks.]"]},
         
-        {"mod": regx.compile(r"\bNewCalibers_ModernFirearms\.esp$", regx.MULTILINE),
+        {"mod": regx.compile(r"\bNewCalibers_Modern(Firearms|Sidearms)\.esp$", regx.MULTILINE),
          "warn": ["MODERN FIREARMS - NEW CALIBERS PATCH \n",
                   "Unresolvable errors in the plugin that can potentially cause crashes."]}  # Warning message is a placeholder.
     ]

--- a/CLAS_Database.py
+++ b/CLAS_Database.py
@@ -943,7 +943,7 @@ class ClasCheckMods:
         
         {"mod": regx.compile(r"\bNewCalibers_Modern(Firearms|Sidearms)\.esp$", regx.MULTILINE),
          "warn": ["MODERN FIREARMS - NEW CALIBERS PATCH \n",
-                  "Unresolvable errors in the plugin that can potentially cause crashes."]}  # Warning message is a placeholder.
+                  "Plugin is out of date and can cause severe crashes."]}  # Warning message is a placeholder.
     ]
 
     # 2) CHECKING FOR MODS THAT CONFLICT WITH OTHER MODS

--- a/CLAS_Database.py
+++ b/CLAS_Database.py
@@ -939,7 +939,11 @@ class ClasCheckMods:
 
         {"mod": regx.compile(r"\bWOTC\.esp$", regx.MULTILINE),
          "warn": ["WAR OF THE COMMONWEALTH \n",
-                  "[Seems responsible for consistent crashes with specific spawn points or random ones during settlement attacks.]"]}
+                  "[Seems responsible for consistent crashes with specific spawn points or random ones during settlement attacks.]"]},
+        
+        {"mod": regx.compile(r"\bNewCalibers_ModernFirearms\.esp$", regx.MULTILINE),
+         "warn": ["MODERN FIREARMS - NEW CALIBERS PATCH \n",
+                  "Unresolvable errors in the plugin that can potentially cause crashes."]}  # Warning message is a placeholder.
     ]
 
     # 2) CHECKING FOR MODS THAT CONFLICT WITH OTHER MODS


### PR DESCRIPTION
This is based on a report from the crash log thread and a request from 4estgimp, this mod was shown to have multiple unresolved errors in xedit and is suspected as at least one of the culprits for the OP's crashes.
The warning message is a placeholder because I'm not good with writing those out.