### PR TITLE
Move crashgen_ignore to the YAML file and add ArchiveLimit to the list

### DIFF
--- a/CLASSIC Data/databases/CLASSIC FO4.yaml
+++ b/CLASSIC Data/databases/CLASSIC FO4.yaml
@@ -47,8 +47,19 @@ Game_Info:
     Utility.pex: e10d65904d0a1e9ee568bdaba02636f0183bfa9565b4056758b1461540f9be75
     WaterType.pex: c4f8589ed33f72265e95a6bec2c9cab58667795e972bcf5f7d17c40deed43207
     Weapon.pex: f39cf899d90d47d694873ccaa2a72308c6717f5e36a302d6f95243e53672d77d
-  
 
+
+  Crashgen_Ignore:
+    - F4EE
+    - WaitForDebugger
+    - Achievements
+    - InputSwitch
+    - MemoryManager
+    - AutoOpen
+    - PromptUpload
+    - MemoryManagerDebug
+    - BSTextureStreamerLocalHeap
+    - ArchiveLimit
 GameVR_Info:
   Main_Root_Name: Fallout 4 VR
   Main_Docs_Name: Fallout4VR
@@ -96,8 +107,19 @@ GameVR_Info:
     Utility.pex: 9bff49b59e18636ea84033f362b45f1962c2b3740eb36ad9e9dcae94556f3490
     WaterType.pex: 8711f4a818c1fed8b549f9cfb0fc49186bf6875cd2c8b0146c4e3154da91028f
     Weapon.pex: e9a18d4f7e3aa6b67fb79dee501b221e62e4fbe10baad0b47fb087735f7fb7a9
-  
 
+
+  Crashgen_Ignore:
+    - F4EE
+    - WaitForDebugger
+    - Achievements
+    - InputSwitch
+    - MemoryManager
+    - AutoOpen
+    - PromptUpload
+    - MemoryManagerDebug
+    - BSTextureStreamerLocalHeap
+    - ArchiveLimit
 Game_Hints:
   - 'Random Hint: [Ctrl] + [F] is a handy-dandy key combination. You should use it more often. Please.'
   - 'Random Hint: Patrolling the Buffout 4 Nexus Page almost makes you wish this joke was more overused.'
@@ -131,9 +153,9 @@ Default_CustomINI: |  # Default settings for *Fallout4Custom.ini* if that file d
 
 Default_FIDMods: |  # Default text for *FO4 FID Mods.yaml* if that file doesn't already exist.
   >>> THIS IS ONLY A PLACEHOLDER | YOU NEED TO GENERATE THIS FILE WITH FO4EDIT!
-  
+
   - CLASSIC can automatically look up (most) values of mod FormIDs, you just need to generate your own FormID List.
-  
+
   - To generate the FormID List:
     1) Place the *Generate FormID List.pas* from the CLASSIC Config folder into your FO4Edit/Edit Scripts folder.
     2) Now run FO4Edit.exe and check all plugins you wish to include in the FormID List (I RECOMMEND YOU CHECK ALL PLUGINS).

--- a/CLASSIC_ScanLogs.py
+++ b/CLASSIC_ScanLogs.py
@@ -418,8 +418,7 @@ def crashlogs_scan():
             autoscan_report.extend(["* NOTICE: FCX MODE IS DISABLED. YOU CAN ENABLE IT TO DETECT PROBLEMS IN YOUR MOD & GAME FILES * \n",
                                     "[ FCX Mode can be enabled in the exe or CLASSIC Settings.yaml located in your CLASSIC folder. ] \n\n"])
 
-            crashgen_ignore = ["F4EE", "WaitForDebugger", "Achievements", "InputSwitch", "MemoryManager",
-                               "AutoOpen", "PromptUpload", "MemoryManagerDebug", "BSTextureStreamerLocalHeap"]
+            crashgen_ignore = CMain.yaml_get("CLASSIC Data/databases/CLASSIC FO4.yaml", f"Game{CMain.vr}_Info", "Crashgen_Ignore")
             for line in segment_crashgen:
 
                 if "false" in line.lower() and all(elem.lower() not in line.lower() for elem in crashgen_ignore):


### PR DESCRIPTION
I figure that it will be easier to add or remove settings we want to ignore whether they are disabled or not with this. I also took the liberty of adding ArchiveLimit to the list because it is unstable at the moment.