### PR TITLE
Make FormID Lookups More Scalable

### DIFF
--- a/CLASSIC Changelog.md
+++ b/CLASSIC Changelog.md
@@ -1,6 +1,14 @@
 =====================================================================================================
 # CLASSIC CHANGELOG #
 
+7.25 EvilDarkArchon Beta 1
+*NEW FEATURES*
+- CLASSIC will now generate a cache of the Form-IDs list for faster searching
+- Added tools to add new form-ids or update existing form-ids in the cache.
+
+DISCLAIMER:
+This is just a reflection of my copy of the code and may or may not make it into the final build.
+
 7.20
 *NEW FEATURES*
 - CLASSIC now automatically creates backups of your game's main EXE files.

--- a/CLASSIC Data/databases/CLASSIC Fallout4.yaml
+++ b/CLASSIC Data/databases/CLASSIC Fallout4.yaml
@@ -771,7 +771,8 @@ Mods_SOLU:  # 3) MODS WITH SOLUTIONS & COMMUNITY PATCHES
   Homemaker: |
     Homemaker
         - Causes a crash while scrolling over Military / BoS fences in the Settlement Menu.
-          Patch Link: https://www.nexusmods.com/fallout4/mods/41434?tab=files
+          Advised Fix: Make sure you are using at least version 1.73 of this mod.
+          Alternate Fix: https://www.nexusmods.com/fallout4/mods/41434?tab=files
         -----
 
   LegendaryModification: |

--- a/CLASSIC Data/databases/CLASSIC Main.yaml
+++ b/CLASSIC Data/databases/CLASSIC Main.yaml
@@ -4,8 +4,8 @@ CLASSIC_Info:
   # ========================================================================================
   # CAUTION: DO NOT CHANGE YOUR SETTINGS HERE! OPEN & EDIT CLASSIC Settings.yaml instead!
   # ========================================================================================
-  version: CLASSIC v7.20
-  version_date: 23.09.29 #YY/MM/DD
+  version: CLASSIC v7.25 EvilDarkArchon Beta 1
+  version_date: 23.10.22 #YY/MM/DD
   default_settings: |
     # This file contains settings for CLASSIC v7.00+, used by both source scripts and the executable.
     

--- a/CLASSIC Data/databases/CLASSIC Main.yaml
+++ b/CLASSIC Data/databases/CLASSIC Main.yaml
@@ -5,7 +5,7 @@ CLASSIC_Info:
   # CAUTION: DO NOT CHANGE YOUR SETTINGS HERE! OPEN & EDIT CLASSIC Settings.yaml instead!
   # ========================================================================================
   version: CLASSIC v7.20
-  version_date: 23.10.22 #YY/MM/DD
+  version_date: 23.09.29 #YY/MM/DD
   default_settings: |
     # This file contains settings for CLASSIC v7.00+, used by both source scripts and the executable.
     

--- a/CLASSIC Data/databases/CLASSIC Main.yaml
+++ b/CLASSIC Data/databases/CLASSIC Main.yaml
@@ -4,7 +4,7 @@ CLASSIC_Info:
   # ========================================================================================
   # CAUTION: DO NOT CHANGE YOUR SETTINGS HERE! OPEN & EDIT CLASSIC Settings.yaml instead!
   # ========================================================================================
-  version: CLASSIC v7.25 EvilDarkArchon Beta 1
+  version: CLASSIC v7.20
   version_date: 23.10.22 #YY/MM/DD
   default_settings: |
     # This file contains settings for CLASSIC v7.00+, used by both source scripts and the executable.

--- a/CLASSIC Tools/add_forms_to_db.py
+++ b/CLASSIC Tools/add_forms_to_db.py
@@ -1,10 +1,9 @@
 import argparse
 import os
 import sqlite3
-from init_formids_db import insert
 
 argparser = argparse.ArgumentParser()
-argparser.add_argument("file", help="The file to add to the database", default="FormID_List.txt", nargs=1)
+argparser.add_argument("file", help="The file to add to the database", default="FormID_List.txt")
 argparser.add_argument("-t", "--table", help="The table to add the file to", default="Fallout4", nargs=1)
 argparser.add_argument("-d", "--db", help="The database to add the file to", default="../CLASSIC Data/databases/FormIDs.db", nargs=1)
 argparser.add_argument("-v", "--verbose", help="Prints out the lines as they are added", action="store_true")
@@ -19,8 +18,12 @@ c = conn.cursor()
 with open(args.file, encoding="utf-8", errors="ignore") as f:
     for line in f:
         line = line.strip()
+        data = line.split(" | ")
         if args.verbose:
             print(f"Adding {line} to {args.table}")
-        insert(line, args.table, c)
+        if len(data) >= 3:
+            plugin, formid, entry, *extra = data
+            c.execute(f'''INSERT INTO {args.table} (plugin, formid, entry) 
+                      VALUES (?, ?, ?)''', (plugin, formid, entry))
 conn.commit()
 conn.close()

--- a/CLASSIC Tools/add_forms_to_db.py
+++ b/CLASSIC Tools/add_forms_to_db.py
@@ -4,7 +4,7 @@ import sqlite3
 from init_formids_db import insert
 
 argparser = argparse.ArgumentParser()
-argparser.add_argument("file", help="The file to add to the database")
+argparser.add_argument("file", help="The file to add to the database", default="FormID_List.txt", nargs=1)
 argparser.add_argument("--table", help="The table to add the file to", default="Fallout4", nargs=1)
 argparser.add_argument("--db", help="The database to add the file to", default="../CLASSIC Data/databases/FormIDs.db", nargs=1)
 argparser.add_argument("--verbose", help="Prints out the lines as they are added", action="store_true")

--- a/CLASSIC Tools/add_forms_to_db.py
+++ b/CLASSIC Tools/add_forms_to_db.py
@@ -12,23 +12,22 @@ args = argparser.parse_args()
 if not os.path.exists(args.db):
     raise FileNotFoundError(f"Database {args.db} not found")
 
-conn = sqlite3.connect(args.db)
-c = conn.cursor()
-
 with open(args.file, encoding="utf-8", errors="ignore") as f:
-    if not args.verbose:
-        print(f"Adding FormIDs from {args.file} to {args.table}")
-    for line in f:
-        line = line.strip()
-        if " | " in line:
-            data = line.split(" | ")
-            if args.verbose:
-                print(f"Adding {line} to {args.table}")
-            if len(data) >= 3:
-                plugin, formid, entry, *extra = data
-                c.execute(f'''INSERT INTO {args.table} (plugin, formid, entry) 
+    with sqlite3.connect(args.db) as conn:
+        c = conn.cursor()
+        if not args.verbose:
+            print(f"Adding FormIDs from {args.file} to {args.table}")
+        for line in f:
+            line = line.strip()
+            if " | " in line:
+                data = line.split(" | ")
+                if args.verbose:
+                    print(f"Adding {line} to {args.table}")
+                if len(data) >= 3:
+                    plugin, formid, entry, *extra = data
+                    c.execute(f'''INSERT INTO {args.table} (plugin, formid, entry) 
                       VALUES (?, ?, ?)''', (plugin, formid, entry))
-conn.commit()
-print("Optimizing database...")
-c.execute("vacuum")
-conn.close()
+        conn.commit()
+        print("Optimizing database...")
+        c.execute("vacuum")
+

--- a/CLASSIC Tools/add_forms_to_db.py
+++ b/CLASSIC Tools/add_forms_to_db.py
@@ -5,7 +5,7 @@ import sqlite3
 argparser = argparse.ArgumentParser()
 argparser.add_argument("file", help="The file to add to the database", default="FormID_List.txt")
 argparser.add_argument("-t", "--table", help="The table to add the file to", default="Fallout4", type=str, nargs=1)
-argparser.add_argument("-d", "--db", help="The database to add the file to", default="../CLASSIC Data/databases/FormIDs.db", type=str, nargs=1)
+argparser.add_argument("-d", "--db", help="The database to add the file to", default="../CLASSIC Data/databases/Fallout4 FormIDs.db", type=str, nargs=1)
 argparser.add_argument("-v", "--verbose", help="Prints out the lines as they are added", action="store_true")
 args = argparser.parse_args()
 

--- a/CLASSIC Tools/add_forms_to_db.py
+++ b/CLASSIC Tools/add_forms_to_db.py
@@ -22,3 +22,5 @@ with open(args.file, encoding="utf-8", errors="ignore") as f:
         if args.verbose:
             print(f"Adding {line} to {args.table}")
         insert(line, args.table, c)
+conn.commit()
+conn.close()

--- a/CLASSIC Tools/add_forms_to_db.py
+++ b/CLASSIC Tools/add_forms_to_db.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import sqlite3
 from init_formids_db import insert
 
@@ -8,6 +9,9 @@ argparser.add_argument("--table", help="The table to add the file to", default="
 argparser.add_argument("--db", help="The database to add the file to", default="../CLASSIC Data/databases/FormIDs.db", nargs=1)
 argparser.add_argument("--verbose", help="Prints out the lines as they are added", action="store_true")
 args = argparser.parse_args()
+
+if not os.path.exists(args.db):
+    raise FileNotFoundError(f"Database {args.db} not found")
 
 conn = sqlite3.connect(args.db)
 c = conn.cursor()

--- a/CLASSIC Tools/add_forms_to_db.py
+++ b/CLASSIC Tools/add_forms_to_db.py
@@ -27,7 +27,8 @@ with open(args.file, encoding="utf-8", errors="ignore") as f:
                     plugin, formid, entry, *extra = data
                     c.execute(f'''INSERT INTO {args.table} (plugin, formid, entry) 
                       VALUES (?, ?, ?)''', (plugin, formid, entry))
-        conn.commit()
+        if conn.in_transaction:
+            conn.commit()
         print("Optimizing database...")
         c.execute("vacuum")
 

--- a/CLASSIC Tools/add_forms_to_db.py
+++ b/CLASSIC Tools/add_forms_to_db.py
@@ -18,12 +18,13 @@ c = conn.cursor()
 with open(args.file, encoding="utf-8", errors="ignore") as f:
     for line in f:
         line = line.strip()
-        data = line.split(" | ")
-        if args.verbose:
-            print(f"Adding {line} to {args.table}")
-        if " | " in line and len(data) >= 3:
-            plugin, formid, entry, *extra = data
-            c.execute(f'''INSERT INTO {args.table} (plugin, formid, entry) 
+        if " | " in line:
+            data = line.split(" | ")
+            if args.verbose:
+                print(f"Adding {line} to {args.table}")
+            if len(data) >= 3:
+                plugin, formid, entry, *extra = data
+                c.execute(f'''INSERT INTO {args.table} (plugin, formid, entry) 
                       VALUES (?, ?, ?)''', (plugin, formid, entry))
 conn.commit()
 conn.close()

--- a/CLASSIC Tools/add_forms_to_db.py
+++ b/CLASSIC Tools/add_forms_to_db.py
@@ -1,0 +1,19 @@
+import argparse
+import sqlite3
+from init_formids_db import insert
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument("file", help="The file to add to the database")
+argparser.add_argument("--table", help="The table to add the file to", default="Fallout4", nargs=1)
+argparser.add_argument("--db", help="The database to add the file to", default="../CLASSIC Data/databases/FormIDs.db", nargs=1)
+argparser.add_argument("--verbose", help="Prints out the lines as they are added", action="store_true")
+args = argparser.parse_args()
+
+conn = sqlite3.connect(args.db)
+
+with open(args.file, encoding="utf-8", errors="ignore") as f:
+    for line in f:
+        line = line.strip()
+        if args.verbose:
+            print(f"Adding {line} to {args.table}")
+        insert(line, args.table)

--- a/CLASSIC Tools/add_forms_to_db.py
+++ b/CLASSIC Tools/add_forms_to_db.py
@@ -10,10 +10,11 @@ argparser.add_argument("--verbose", help="Prints out the lines as they are added
 args = argparser.parse_args()
 
 conn = sqlite3.connect(args.db)
+c = conn.cursor()
 
 with open(args.file, encoding="utf-8", errors="ignore") as f:
     for line in f:
         line = line.strip()
         if args.verbose:
             print(f"Adding {line} to {args.table}")
-        insert(line, args.table)
+        insert(line, args.table, c)

--- a/CLASSIC Tools/add_forms_to_db.py
+++ b/CLASSIC Tools/add_forms_to_db.py
@@ -21,7 +21,7 @@ with open(args.file, encoding="utf-8", errors="ignore") as f:
         data = line.split(" | ")
         if args.verbose:
             print(f"Adding {line} to {args.table}")
-        if len(data) >= 3:
+        if " | " in line and len(data) >= 3:
             plugin, formid, entry, *extra = data
             c.execute(f'''INSERT INTO {args.table} (plugin, formid, entry) 
                       VALUES (?, ?, ?)''', (plugin, formid, entry))

--- a/CLASSIC Tools/add_forms_to_db.py
+++ b/CLASSIC Tools/add_forms_to_db.py
@@ -16,6 +16,8 @@ conn = sqlite3.connect(args.db)
 c = conn.cursor()
 
 with open(args.file, encoding="utf-8", errors="ignore") as f:
+    if not args.verbose:
+        print(f"Adding FormIDs from {args.file} to {args.table}")
     for line in f:
         line = line.strip()
         if " | " in line:

--- a/CLASSIC Tools/add_forms_to_db.py
+++ b/CLASSIC Tools/add_forms_to_db.py
@@ -5,9 +5,9 @@ from init_formids_db import insert
 
 argparser = argparse.ArgumentParser()
 argparser.add_argument("file", help="The file to add to the database", default="FormID_List.txt", nargs=1)
-argparser.add_argument("--table", help="The table to add the file to", default="Fallout4", nargs=1)
-argparser.add_argument("--db", help="The database to add the file to", default="../CLASSIC Data/databases/FormIDs.db", nargs=1)
-argparser.add_argument("--verbose", help="Prints out the lines as they are added", action="store_true")
+argparser.add_argument("-t", "--table", help="The table to add the file to", default="Fallout4", nargs=1)
+argparser.add_argument("-d", "--db", help="The database to add the file to", default="../CLASSIC Data/databases/FormIDs.db", nargs=1)
+argparser.add_argument("-v", "--verbose", help="Prints out the lines as they are added", action="store_true")
 args = argparser.parse_args()
 
 if not os.path.exists(args.db):

--- a/CLASSIC Tools/init_formids_db.py
+++ b/CLASSIC Tools/init_formids_db.py
@@ -1,3 +1,4 @@
+from calendar import c
 import os
 import sqlite3
 import hashlib
@@ -5,53 +6,61 @@ import hashlib
 if os.path.exists("../CLASSIC Data/databases/FormIDs.db"):
     os.remove("../CLASSIC Data/databases/FormIDs.db")
 
-def insert(line, table="Fallout4"):
+with sqlite3.connect("../CLASSIC Data/databases/FormIDs.db") as conn:
+    c = conn.cursor()
+    if os.path.exists("../CLASSIC Data/databases/Fallout4 FID Main.txt"):
+        c.execute('''CREATE TABLE IF NOT EXISTS Fallout4 
+              (id INTEGER PRIMARY KEY AUTOINCREMENT,  
+               plugin TEXT, formid TEXT, entry TEXT)''')
+        c.execute("CREATE INDEX IF NOT EXISTS Fallout4_index ON Fallout4(formid, plugin COLLATE nocase);")
+    if os.path.exists("../CLASSIC Data/databases/Skyrim FID Main.txt"):
+        c.execute('''CREATE TABLE IF NOT EXISTS Skyrim
+                (id INTEGER PRIMARY KEY AUTOINCREMENT,  
+                 plugin TEXT, formid TEXT, entry TEXT)''')
+        c.execute("CREATE INDEX IF NOT EXISTS Skyrim_index ON Skyrim (formid, plugin COLLATE nocase);")
+    if os.path.exists("../CLASSIC Data/databases/Starfield FID Main.txt"):
+        c.execute('''CREATE TABLE IF NOT EXISTS Starfield
+                (id INTEGER PRIMARY KEY AUTOINCREMENT,  
+                 plugin TEXT, formid TEXT, entry TEXT)''')
+        c.execute("CREATE INDEX IF NOT EXISTS Starfield_index ON Starfield (formid, plugin COLLATE nocase);")
+
+def insert(lines, table="Fallout4"):
     with sqlite3.connect("../CLASSIC Data/databases/FormIDs.db") as conn:
         c = conn.cursor()
-        if line:
-            if "|" in line and len(line.split(" | ")) >= 3:
-                plugin, formid, entry, *extra = line.split(" | ")  # the *extra is for any extraneous data that might be in the line (Python thinks there are more than 3 items in the list for some reason)
-                c.execute(f'''INSERT INTO {table} (plugin, formid, entry) 
-                      VALUES (?, ?, ?)''', (plugin, formid, entry))
-        conn.commit()
+        if lines:
+            for line in lines:
+                line = line.strip()
+                if "|" in line and len(line.split(" | ")) >= 3:
+                    plugin, formid, entry, *extra = line.split(" | ")  # the *extra is for any extraneous data that might be in the line (Python thinks there are more than 3 items in the list for some reason)
+                    c.execute(f'''INSERT INTO {table} (plugin, formid, entry) 
+                          VALUES (?, ?, ?)''', (plugin, formid, entry))
+            conn.commit()
 
 if os.path.exists("../CLASSIC Data/databases/Fallout4 FID Main.txt"):
     with open("../CLASSIC Data/databases/Fallout4 FID Main.txt", encoding="utf-8", errors="ignore") as f:
         print("Inserting Fallout 4 Main FormIDs...")
-        for line in f:
-            line = line.strip()
-            insert(line)
+        insert(f.readlines())
 if os.path.exists("../CLASSIC Data/databases/Fallout4 FID Mods.txt"):
     print("Inserting Fallout 4 Mod FormIDs...")
     with open("../CLASSIC Data/databases/Fallout4 FID Mods.txt", encoding="utf-8", errors="ignore") as f:
-        for line in f:
-            line = line.strip()
-            insert(line)
+        insert(f.readlines())
 
 if os.path.exists("../CLASSIC Data/databases/Skyrim FID Main.txt"):
     print("Inserting Skyrim Main FormIDs...")
     with open("../CLASSIC Data/databases/Skyrim FID Main.txt", encoding="utf-8", errors="ignore") as f:
-        for line in f:
-            line = line.strip()
-            insert(line, "Skyrim")
+        insert(f.readlines(), "Skyrim")
 
 if os.path.exists("../CLASSIC Data/databases/Skyrim FID Mods.txt"):
     print("Inserting Skyrim Mod FormIDs...")
     with open("../CLASSIC Data/databases/Skyrim FID Mods.txt", encoding="utf-8", errors="ignore") as f:
-        for line in f:
-            line = line.strip()
-            insert(line, "Skyrim")
+        insert(f.readlines(), "Skyrim")
 
 if os.path.exists("../CLASSIC Data/databases/Starfield FID Main.txt"):
     print("Inserting Starfield Main FormIDs...")
     with open("../CLASSIC Data/databases/Starfield FID Main.txt", encoding="utf-8", errors="ignore") as f:
-        for line in f:
-            line = line.strip()
-            insert(line, "Starfield")
+        insert(f.readlines(), "Starfield")
 
 if os.path.exists("../CLASSIC Data/databases/Starfield FID Mods.txt"):
     print("Inserting Starfield Mod FormIDs...")
     with open("../CLASSIC Data/databases/Starfield FID Mods.txt", encoding="utf-8", errors="ignore") as f:
-        for line in f:
-            line = line.strip()
-            insert(line, "Starfield")
+        insert(f.readlines(), "Starfield")

--- a/CLASSIC Tools/init_formids_db.py
+++ b/CLASSIC Tools/init_formids_db.py
@@ -1,32 +1,44 @@
-from calendar import c
 import os
 import sqlite3
 
-if os.path.exists("../CLASSIC Data/databases/FormIDs.db"):
-    os.remove("../CLASSIC Data/databases/FormIDs.db")
+if os.path.exists("../CLASSIC Data/databases/Fallout4 FormIDs.db"):
+    os.remove("../CLASSIC Data/databases/Fallout4 FormIDs.db")
 
-with sqlite3.connect("../CLASSIC Data/databases/FormIDs.db") as conn:
-    c = conn.cursor()
-    if os.path.exists("../CLASSIC Data/databases/Fallout4 FID Main.txt"):
-        c.execute('''CREATE TABLE IF NOT EXISTS Fallout4 
+if os.path.exists("../CLASSIC Data/databases/Skyrim FormIDs.db"):
+    os.remove("../CLASSIC Data/databases/Skyrim FormIDs.db")
+
+if os.path.exists("../CLASSIC Data/databases/Starfield FormIDs.db"):
+    os.remove("../CLASSIC Data/databases/Starfield FormIDs.db")
+
+if os.path.exists("../CLASSIC Data/databases/Fallout4 FID Main.txt"):
+    with sqlite3.connect("../CLASSIC Data/databases/Fallout4 FormIDs.db") as conn:
+        conn.execute('''CREATE TABLE IF NOT EXISTS Fallout4 
               (id INTEGER PRIMARY KEY AUTOINCREMENT,  
                plugin TEXT, formid TEXT, entry TEXT)''')
-        c.execute("CREATE INDEX IF NOT EXISTS Fallout4_index ON Fallout4(formid, plugin COLLATE nocase);")
-    if os.path.exists("../CLASSIC Data/databases/Skyrim FID Main.txt"):
-        c.execute('''CREATE TABLE IF NOT EXISTS Skyrim
+        conn.execute("CREATE INDEX IF NOT EXISTS Fallout4_index ON Fallout4(formid, plugin COLLATE nocase);")
+        if conn.in_transaction:
+            conn.commit()
+
+if os.path.exists("../CLASSIC Data/databases/Skyrim FID Main.txt"):
+    with sqlite3.connect("../CLASSIC Data/databases/Skyrim FormIDs.db") as conn:
+        conn.execute('''CREATE TABLE IF NOT EXISTS Skyrim
                 (id INTEGER PRIMARY KEY AUTOINCREMENT,  
                  plugin TEXT, formid TEXT, entry TEXT)''')
-        c.execute("CREATE INDEX IF NOT EXISTS Skyrim_index ON Skyrim (formid, plugin COLLATE nocase);")
-    if os.path.exists("../CLASSIC Data/databases/Starfield FID Main.txt"):
-        c.execute('''CREATE TABLE IF NOT EXISTS Starfield
+        conn.execute("CREATE INDEX IF NOT EXISTS Skyrim_index ON Skyrim (formid, plugin COLLATE nocase);")
+        if conn.in_transaction:
+            conn.commit()
+    
+if os.path.exists("../CLASSIC Data/databases/Starfield FID Main.txt"):
+    with sqlite3.connect("../CLASSIC Data/databases/Starfield FormIDs.db") as conn:
+        conn.execute('''CREATE TABLE IF NOT EXISTS Starfield
                 (id INTEGER PRIMARY KEY AUTOINCREMENT,  
                  plugin TEXT, formid TEXT, entry TEXT)''')
-        c.execute("CREATE INDEX IF NOT EXISTS Starfield_index ON Starfield (formid, plugin COLLATE nocase);")
+        conn.execute("CREATE INDEX IF NOT EXISTS Starfield_index ON Starfield (formid, plugin COLLATE nocase);")
     if conn.in_transaction:
         conn.commit()
 
 def insert(lines, table="Fallout4"):
-    with sqlite3.connect("../CLASSIC Data/databases/FormIDs.db") as conn:
+    with sqlite3.connect(f"../CLASSIC Data/databases/{table} FormIDs.db") as conn:
         c = conn.cursor()
         if lines:
             for line in lines:

--- a/CLASSIC Tools/init_formids_db.py
+++ b/CLASSIC Tools/init_formids_db.py
@@ -22,6 +22,8 @@ with sqlite3.connect("../CLASSIC Data/databases/FormIDs.db") as conn:
                 (id INTEGER PRIMARY KEY AUTOINCREMENT,  
                  plugin TEXT, formid TEXT, entry TEXT)''')
         c.execute("CREATE INDEX IF NOT EXISTS Starfield_index ON Starfield (formid, plugin COLLATE nocase);")
+    if conn.in_transaction:
+        conn.commit()
 
 def insert(lines, table="Fallout4"):
     with sqlite3.connect("../CLASSIC Data/databases/FormIDs.db") as conn:
@@ -33,7 +35,8 @@ def insert(lines, table="Fallout4"):
                     plugin, formid, entry, *extra = line.split(" | ")  # the *extra is for any extraneous data that might be in the line (Python thinks there are more than 3 items in the list for some reason)
                     c.execute(f'''INSERT INTO {table} (plugin, formid, entry) 
                           VALUES (?, ?, ?)''', (plugin, formid, entry))
-            conn.commit()
+            if conn.in_transaction:
+                conn.commit()
 
 if os.path.exists("../CLASSIC Data/databases/Fallout4 FID Main.txt"):
     with open("../CLASSIC Data/databases/Fallout4 FID Main.txt", encoding="utf-8", errors="ignore") as f:

--- a/CLASSIC Tools/init_formids_db.py
+++ b/CLASSIC Tools/init_formids_db.py
@@ -5,31 +5,15 @@ import hashlib
 if os.path.exists("../CLASSIC Data/databases/FormIDs.db"):
     os.remove("../CLASSIC Data/databases/FormIDs.db")
 
-conn = sqlite3.connect("../CLASSIC Data/databases/FormIDs.db")
-c = conn.cursor()
-
-if os.path.exists("../CLASSIC Data/databases/Fallout4 FID Main.txt"):
-    c.execute('''CREATE TABLE IF NOT EXISTS Fallout4 
-              (id INTEGER PRIMARY KEY AUTOINCREMENT,  
-               plugin TEXT, formid TEXT, entry TEXT)''')
-    c.execute("CREATE INDEX IF NOT EXISTS Fallout4_index ON Fallout4(formid, plugin COLLATE nocase);")
-if os.path.exists("../CLASSIC Data/databases/Skyrim FID Main.txt"):
-    c.execute('''CREATE TABLE IF NOT EXISTS Skyrim
-                (id INTEGER PRIMARY KEY AUTOINCREMENT,  
-                 plugin TEXT, formid TEXT, entry TEXT)''')
-    c.execute("CREATE INDEX IF NOT EXISTS Skyrim_index ON Skyrim (formid, plugin COLLATE nocase);")
-if os.path.exists("../CLASSIC Data/databases/Starfield FID Main.txt"):
-    c.execute('''CREATE TABLE IF NOT EXISTS Starfield
-                (id INTEGER PRIMARY KEY AUTOINCREMENT,  
-                 plugin TEXT, formid TEXT, entry TEXT)''')
-    c.execute("CREATE INDEX IF NOT EXISTS Starfield_index ON Starfield (formid, plugin COLLATE nocase);")
-
 def insert(line, table="Fallout4"):
-    if line:
-        if "|" in line and len(line.split(" | ")) >= 3:
-            plugin, formid, entry, *extra = line.split(" | ")  # the *extra is for any extraneous data that might be in the line (Python thinks there are more than 3 items in the list for some reason)
-            c.execute(f'''INSERT INTO {table} (plugin, formid, entry) 
+    with sqlite3.connect("../CLASSIC Data/databases/FormIDs.db") as conn:
+        c = conn.cursor()
+        if line:
+            if "|" in line and len(line.split(" | ")) >= 3:
+                plugin, formid, entry, *extra = line.split(" | ")  # the *extra is for any extraneous data that might be in the line (Python thinks there are more than 3 items in the list for some reason)
+                c.execute(f'''INSERT INTO {table} (plugin, formid, entry) 
                       VALUES (?, ?, ?)''', (plugin, formid, entry))
+        conn.commit()
 
 if os.path.exists("../CLASSIC Data/databases/Fallout4 FID Main.txt"):
     with open("../CLASSIC Data/databases/Fallout4 FID Main.txt", encoding="utf-8", errors="ignore") as f:
@@ -39,13 +23,10 @@ if os.path.exists("../CLASSIC Data/databases/Fallout4 FID Main.txt"):
             insert(line)
 if os.path.exists("../CLASSIC Data/databases/Fallout4 FID Mods.txt"):
     print("Inserting Fallout 4 Mod FormIDs...")
-    with open("../CLASSIC Data/databases/Fallout4 FID Mods.txt", "rb") as f:
-        hash = hashlib.sha256(f.read()).hexdigest()
-    if not hash == "bb9ebacc7b1cf232becbf00a942105348ced8a25d8e556fa7739845985cb2553":
-        with open("../CLASSIC Data/databases/Fallout4 FID Mods.txt", encoding="utf-8", errors="ignore") as f:
-            for line in f:
-                line = line.strip()
-                insert(line)
+    with open("../CLASSIC Data/databases/Fallout4 FID Mods.txt", encoding="utf-8", errors="ignore") as f:
+        for line in f:
+            line = line.strip()
+            insert(line)
 
 if os.path.exists("../CLASSIC Data/databases/Skyrim FID Main.txt"):
     print("Inserting Skyrim Main FormIDs...")
@@ -74,6 +55,3 @@ if os.path.exists("../CLASSIC Data/databases/Starfield FID Mods.txt"):
         for line in f:
             line = line.strip()
             insert(line, "Starfield")
-
-conn.commit()
-conn.close()

--- a/CLASSIC Tools/init_formids_db.py
+++ b/CLASSIC Tools/init_formids_db.py
@@ -1,0 +1,51 @@
+import os
+import sqlite3
+import hashlib
+
+if os.path.exists("../CLASSIC Data/databases/FormIDs.db"):
+    os.remove("../CLASSIC Data/databases/FormIDs.db")
+
+conn = sqlite3.connect("../CLASSIC Data/databases/FormIDs.db")
+c = conn.cursor()
+
+c.execute('''CREATE TABLE IF NOT EXISTS Fallout4 
+              (id INTEGER PRIMARY KEY AUTOINCREMENT,  
+               plugin TEXT, formid TEXT, entry TEXT)''')
+c.execute('''CREATE TABLE IF NOT EXISTS Skyrim
+                (id INTEGER PRIMARY KEY AUTOINCREMENT,  
+                 plugin TEXT, formid TEXT, entry TEXT)''')
+
+def insert(line, table="Fallout4"):
+    if line:
+        if len(line.split(" | ")) >= 3:
+            plugin, formid, entry, *extra = line.split(" | ")  # the *extra is for any extraneous data that might be in the line (Python thinks there are more than 3 items in the list for some reason)
+            c.execute(f'''INSERT INTO {table} (plugin, formid, entry) 
+                      VALUES (?, ?, ?)''', (plugin, formid, entry))
+
+with open("../CLASSIC Data/databases/Fallout4 FID Main.txt", encoding="utf-8", errors="ignore") as f:
+    for line in f:
+        line = line.strip()
+        insert(line)
+if os.path.exists("../CLASSIC Data/databases/Fallout4 FID Mods.txt"):
+    with open("../CLASSIC Data/databases/Fallout4 FID Mods.txt", "rb") as f:
+        hash = hashlib.sha256(f.read()).hexdigest()
+    if not hash == "bb9ebacc7b1cf232becbf00a942105348ced8a25d8e556fa7739845985cb2553":
+        with open("../CLASSIC Data/databases/Fallout4 FID Mods.txt", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                line = line.strip()
+                insert(line)
+
+if os.path.exists("../CLASSIC Data/databases/Skyrim FID Main.txt"):
+    with open("../CLASSIC Data/databases/Skyrim FID Main.txt", encoding="utf-8", errors="ignore") as f:
+        for line in f:
+            line = line.strip()
+            insert(line, "Skyrim")
+
+if os.path.exists("../CLASSIC Data/databases/Skyrim FID Mods.txt"):
+    with open("../CLASSIC Data/databases/Skyrim FID Mods.txt", encoding="utf-8", errors="ignore") as f:
+        for line in f:
+            line = line.strip()
+            insert(line, "Skyrim")
+
+conn.commit()
+conn.close()

--- a/CLASSIC Tools/init_formids_db.py
+++ b/CLASSIC Tools/init_formids_db.py
@@ -27,10 +27,12 @@ def insert(line, table="Fallout4"):
                       VALUES (?, ?, ?)''', (plugin, formid, entry))
 
 with open("../CLASSIC Data/databases/Fallout4 FID Main.txt", encoding="utf-8", errors="ignore") as f:
+    print("Inserting Fallout 4 Main FormIDs...")
     for line in f:
         line = line.strip()
         insert(line)
 if os.path.exists("../CLASSIC Data/databases/Fallout4 FID Mods.txt"):
+    print("Inserting Fallout 4 Mod FormIDs...")
     with open("../CLASSIC Data/databases/Fallout4 FID Mods.txt", "rb") as f:
         hash = hashlib.sha256(f.read()).hexdigest()
     if not hash == "bb9ebacc7b1cf232becbf00a942105348ced8a25d8e556fa7739845985cb2553":
@@ -40,12 +42,14 @@ if os.path.exists("../CLASSIC Data/databases/Fallout4 FID Mods.txt"):
                 insert(line)
 
 if os.path.exists("../CLASSIC Data/databases/Skyrim FID Main.txt"):
+    print("Inserting Skyrim Main FormIDs...")
     with open("../CLASSIC Data/databases/Skyrim FID Main.txt", encoding="utf-8", errors="ignore") as f:
         for line in f:
             line = line.strip()
             insert(line, "Skyrim")
 
 if os.path.exists("../CLASSIC Data/databases/Skyrim FID Mods.txt"):
+    print("Inserting Skyrim Mod FormIDs...")
     with open("../CLASSIC Data/databases/Skyrim FID Mods.txt", encoding="utf-8", errors="ignore") as f:
         for line in f:
             line = line.strip()

--- a/CLASSIC Tools/init_formids_db.py
+++ b/CLASSIC Tools/init_formids_db.py
@@ -51,8 +51,8 @@ def insert(lines, table="Fallout4"):
                 conn.commit()
 
 if os.path.exists("../CLASSIC Data/databases/Fallout4 FID Main.txt"):
+    print("Inserting Fallout 4 Main FormIDs...")
     with open("../CLASSIC Data/databases/Fallout4 FID Main.txt", encoding="utf-8", errors="ignore") as f:
-        print("Inserting Fallout 4 Main FormIDs...")
         insert(f.readlines())
 if os.path.exists("../CLASSIC Data/databases/Fallout4 FID Mods.txt"):
     print("Inserting Fallout 4 Mod FormIDs...")

--- a/CLASSIC Tools/init_formids_db.py
+++ b/CLASSIC Tools/init_formids_db.py
@@ -16,10 +16,8 @@ c.execute('''CREATE TABLE IF NOT EXISTS Skyrim
                  plugin TEXT, formid TEXT, entry TEXT)''')
 
 # The indexes may increase the size of the DB, but they make searches almost instantaneous.
-c.execute("CREATE INDEX IF NOT EXISTS Fallout4_index1 ON Fallout4 (formid)")
-c.execute("CREATE INDEX IF NOT EXISTS Fallout4_index2 ON Fallout4 (plugin, formid)")
-c.execute("CREATE INDEX IF NOT EXISTS Skyrim_index1 ON Skyrim (formid)")
-c.execute("CREATE INDEX IF NOT EXISTS Skyrim_index2 ON Skyrim (plugin, formid)")
+c.execute("CREATE INDEX IF NOT EXISTS Fallout4_index ON Fallout4 (plugin, formid)")
+c.execute("CREATE INDEX IF NOT EXISTS Skyrim_index ON Skyrim (plugin, formid)")
 
 def insert(line, table="Fallout4"):
     if line:

--- a/CLASSIC Tools/init_formids_db.py
+++ b/CLASSIC Tools/init_formids_db.py
@@ -1,7 +1,6 @@
 from calendar import c
 import os
 import sqlite3
-import hashlib
 
 if os.path.exists("../CLASSIC Data/databases/FormIDs.db"):
     os.remove("../CLASSIC Data/databases/FormIDs.db")

--- a/CLASSIC Tools/init_formids_db.py
+++ b/CLASSIC Tools/init_formids_db.py
@@ -16,8 +16,8 @@ c.execute('''CREATE TABLE IF NOT EXISTS Skyrim
                  plugin TEXT, formid TEXT, entry TEXT)''')
 
 # The indexes may increase the size of the DB, but they make searches almost instantaneous.
-c.execute("CREATE INDEX IF NOT EXISTS Fallout4_index ON Fallout4 (plugin, formid)")
-c.execute("CREATE INDEX IF NOT EXISTS Skyrim_index ON Skyrim (plugin, formid)")
+c.execute("CREATE INDEX IF NOT EXISTS Fallout4_index ON Fallout4(formid, plugin COLLATE nocase);")
+c.execute("CREATE INDEX IF NOT EXISTS Skyrim_index ON Skyrim (formid, plugin COLLATE nocase);")
 
 def insert(line, table="Fallout4"):
     if line:

--- a/CLASSIC Tools/init_formids_db.py
+++ b/CLASSIC Tools/init_formids_db.py
@@ -17,7 +17,7 @@ c.execute('''CREATE TABLE IF NOT EXISTS Skyrim
 
 def insert(line, table="Fallout4"):
     if line:
-        if len(line.split(" | ")) >= 3:
+        if "|" in line and len(line.split(" | ")) >= 3:
             plugin, formid, entry, *extra = line.split(" | ")  # the *extra is for any extraneous data that might be in the line (Python thinks there are more than 3 items in the list for some reason)
             c.execute(f'''INSERT INTO {table} (plugin, formid, entry) 
                       VALUES (?, ?, ?)''', (plugin, formid, entry))

--- a/CLASSIC Tools/init_formids_db.py
+++ b/CLASSIC Tools/init_formids_db.py
@@ -15,11 +15,11 @@ c.execute('''CREATE TABLE IF NOT EXISTS Skyrim
                 (id INTEGER PRIMARY KEY AUTOINCREMENT,  
                  plugin TEXT, formid TEXT, entry TEXT)''')
 
-def insert(line, table="Fallout4", cursor=c):
+def insert(line, table="Fallout4"):
     if line:
         if "|" in line and len(line.split(" | ")) >= 3:
             plugin, formid, entry, *extra = line.split(" | ")  # the *extra is for any extraneous data that might be in the line (Python thinks there are more than 3 items in the list for some reason)
-            cursor.execute(f'''INSERT INTO {table} (plugin, formid, entry) 
+            c.execute(f'''INSERT INTO {table} (plugin, formid, entry) 
                       VALUES (?, ?, ?)''', (plugin, formid, entry))
 
 with open("../CLASSIC Data/databases/Fallout4 FID Main.txt", encoding="utf-8", errors="ignore") as f:

--- a/CLASSIC Tools/init_formids_db.py
+++ b/CLASSIC Tools/init_formids_db.py
@@ -15,6 +15,12 @@ c.execute('''CREATE TABLE IF NOT EXISTS Skyrim
                 (id INTEGER PRIMARY KEY AUTOINCREMENT,  
                  plugin TEXT, formid TEXT, entry TEXT)''')
 
+# The indexes may increase the size of the DB, but they make searches almost instantaneous.
+c.execute("CREATE INDEX IF NOT EXISTS Fallout4_index1 ON Fallout4 (formid)")
+c.execute("CREATE INDEX IF NOT EXISTS Fallout4_index2 ON Fallout4 (plugin, formid)")
+c.execute("CREATE INDEX IF NOT EXISTS Skyrim_index1 ON Skyrim (formid)")
+c.execute("CREATE INDEX IF NOT EXISTS Skyrim_index2 ON Skyrim (plugin, formid)")
+
 def insert(line, table="Fallout4"):
     if line:
         if "|" in line and len(line.split(" | ")) >= 3:

--- a/CLASSIC Tools/init_formids_db.py
+++ b/CLASSIC Tools/init_formids_db.py
@@ -8,16 +8,24 @@ if os.path.exists("../CLASSIC Data/databases/FormIDs.db"):
 conn = sqlite3.connect("../CLASSIC Data/databases/FormIDs.db")
 c = conn.cursor()
 
-c.execute('''CREATE TABLE IF NOT EXISTS Fallout4 
+if os.path.exists("../CLASSIC Data/databases/Fallout4 FID Main.txt"):
+    c.execute('''CREATE TABLE IF NOT EXISTS Fallout4 
               (id INTEGER PRIMARY KEY AUTOINCREMENT,  
                plugin TEXT, formid TEXT, entry TEXT)''')
-c.execute('''CREATE TABLE IF NOT EXISTS Skyrim
+    c.execute("CREATE INDEX IF NOT EXISTS Fallout4_index ON Fallout4(formid, plugin COLLATE nocase);")
+if os.path.exists("../CLASSIC Data/databases/Skyrim FID Main.txt"):
+    c.execute('''CREATE TABLE IF NOT EXISTS Skyrim
                 (id INTEGER PRIMARY KEY AUTOINCREMENT,  
                  plugin TEXT, formid TEXT, entry TEXT)''')
+    c.execute("CREATE INDEX IF NOT EXISTS Skyrim_index ON Skyrim (formid, plugin COLLATE nocase);")
+if os.path.exists("../CLASSIC Data/databases/Starfield FID Main.txt"):
+    c.execute('''CREATE TABLE IF NOT EXISTS Starfield
+                (id INTEGER PRIMARY KEY AUTOINCREMENT,  
+                 plugin TEXT, formid TEXT, entry TEXT)''')
+    c.execute("CREATE INDEX IF NOT EXISTS Starfield_index ON Starfield (formid, plugin COLLATE nocase);")
 
-# The indexes may increase the size of the DB, but they make searches almost instantaneous.
-c.execute("CREATE INDEX IF NOT EXISTS Fallout4_index ON Fallout4(formid, plugin COLLATE nocase);")
-c.execute("CREATE INDEX IF NOT EXISTS Skyrim_index ON Skyrim (formid, plugin COLLATE nocase);")
+
+
 
 def insert(line, table="Fallout4"):
     if line:
@@ -26,11 +34,12 @@ def insert(line, table="Fallout4"):
             c.execute(f'''INSERT INTO {table} (plugin, formid, entry) 
                       VALUES (?, ?, ?)''', (plugin, formid, entry))
 
-with open("../CLASSIC Data/databases/Fallout4 FID Main.txt", encoding="utf-8", errors="ignore") as f:
-    print("Inserting Fallout 4 Main FormIDs...")
-    for line in f:
-        line = line.strip()
-        insert(line)
+if os.path.exists("../CLASSIC Data/databases/Fallout4 FID Main.txt"):
+    with open("../CLASSIC Data/databases/Fallout4 FID Main.txt", encoding="utf-8", errors="ignore") as f:
+        print("Inserting Fallout 4 Main FormIDs...")
+        for line in f:
+            line = line.strip()
+            insert(line)
 if os.path.exists("../CLASSIC Data/databases/Fallout4 FID Mods.txt"):
     print("Inserting Fallout 4 Mod FormIDs...")
     with open("../CLASSIC Data/databases/Fallout4 FID Mods.txt", "rb") as f:
@@ -54,6 +63,20 @@ if os.path.exists("../CLASSIC Data/databases/Skyrim FID Mods.txt"):
         for line in f:
             line = line.strip()
             insert(line, "Skyrim")
+
+if os.path.exists("../CLASSIC Data/databases/Starfield FID Main.txt"):
+    print("Inserting Starfield Main FormIDs...")
+    with open("../CLASSIC Data/databases/Starfield FID Main.txt", encoding="utf-8", errors="ignore") as f:
+        for line in f:
+            line = line.strip()
+            insert(line, "Starfield")
+
+if os.path.exists("../CLASSIC Data/databases/Starfield FID Mods.txt"):
+    print("Inserting Starfield Mod FormIDs...")
+    with open("../CLASSIC Data/databases/Starfield FID Mods.txt", encoding="utf-8", errors="ignore") as f:
+        for line in f:
+            line = line.strip()
+            insert(line, "Starfield")
 
 conn.commit()
 conn.close()

--- a/CLASSIC Tools/init_formids_db.py
+++ b/CLASSIC Tools/init_formids_db.py
@@ -15,11 +15,11 @@ c.execute('''CREATE TABLE IF NOT EXISTS Skyrim
                 (id INTEGER PRIMARY KEY AUTOINCREMENT,  
                  plugin TEXT, formid TEXT, entry TEXT)''')
 
-def insert(line, table="Fallout4"):
+def insert(line, table="Fallout4", cursor=c):
     if line:
         if "|" in line and len(line.split(" | ")) >= 3:
             plugin, formid, entry, *extra = line.split(" | ")  # the *extra is for any extraneous data that might be in the line (Python thinks there are more than 3 items in the list for some reason)
-            c.execute(f'''INSERT INTO {table} (plugin, formid, entry) 
+            cursor.execute(f'''INSERT INTO {table} (plugin, formid, entry) 
                       VALUES (?, ?, ?)''', (plugin, formid, entry))
 
 with open("../CLASSIC Data/databases/Fallout4 FID Main.txt", encoding="utf-8", errors="ignore") as f:

--- a/CLASSIC Tools/init_formids_db.py
+++ b/CLASSIC Tools/init_formids_db.py
@@ -24,9 +24,6 @@ if os.path.exists("../CLASSIC Data/databases/Starfield FID Main.txt"):
                  plugin TEXT, formid TEXT, entry TEXT)''')
     c.execute("CREATE INDEX IF NOT EXISTS Starfield_index ON Starfield (formid, plugin COLLATE nocase);")
 
-
-
-
 def insert(line, table="Fallout4"):
     if line:
         if "|" in line and len(line.split(" | ")) >= 3:

--- a/CLASSIC Tools/update_mod_forms.py
+++ b/CLASSIC Tools/update_mod_forms.py
@@ -12,32 +12,32 @@ args = argparser.parse_args()
 if not os.path.exists(args.db):
     raise FileNotFoundError(f"Database {args.db} not found")
 
-conn = sqlite3.connect(args.db)
-c = conn.cursor()
+
 
 with open(args.file, encoding="utf-8", errors="ignore") as f:
-    if not args.verbose:
-        print(f"Updating database with FormIDs from {args.file} to {args.table}")
-    plugins_deleted = []
-    plugins_announced = []
-    for line in f:
-        line = line.strip()
-        if " | " in line:
-            data = line.split(" | ")
-            if len(data) >= 3:
-                plugin, formid, entry, *extra = data
-                if plugin not in plugins_deleted:
-                    print(f"Deleting {plugin}'s FormIDs from {args.table}")
-                    c.execute(f"delete from {args.table} where plugin = ?", (plugin,))
-                    plugins_deleted.append(plugin)
-                if plugin not in plugins_announced and not args.verbose:
-                    print(f"Adding {plugin}'s FormIDs to {args.table}")
-                    plugins_announced.append(plugin)
-                if args.verbose:
-                    print(f"Adding {line} to {args.table}")
-                c.execute(f'''INSERT INTO {args.table} (plugin, formid, entry) 
+    with sqlite3.connect(args.db) as conn:
+        c = conn.cursor()
+        if not args.verbose:
+            print(f"Updating database with FormIDs from {args.file} to {args.table}")
+        plugins_deleted = []
+        plugins_announced = []
+        for line in f:
+            line = line.strip()
+            if " | " in line:
+                data = line.split(" | ")
+                if len(data) >= 3:
+                    plugin, formid, entry, *extra = data
+                    if plugin not in plugins_deleted:
+                        print(f"Deleting {plugin}'s FormIDs from {args.table}")
+                        c.execute(f"delete from {args.table} where plugin = ?", (plugin,))
+                        plugins_deleted.append(plugin)
+                    if plugin not in plugins_announced and not args.verbose:
+                        print(f"Adding {plugin}'s FormIDs to {args.table}")
+                        plugins_announced.append(plugin)
+                    if args.verbose:
+                        print(f"Adding {line} to {args.table}")
+                    c.execute(f'''INSERT INTO {args.table} (plugin, formid, entry) 
                       VALUES (?, ?, ?)''', (plugin, formid, entry))
-conn.commit()
-print("Optimizing database...")
-c.execute("vacuum")
-conn.close()
+        conn.commit()
+        print("Optimizing database...")
+        c.execute("vacuum")

--- a/CLASSIC Tools/update_mod_forms.py
+++ b/CLASSIC Tools/update_mod_forms.py
@@ -5,7 +5,7 @@ import sqlite3
 argparser = argparse.ArgumentParser()
 argparser.add_argument("file", help="The file to add to the database", default="FormID_List.txt")
 argparser.add_argument("-t", "--table", help="The table to add the file to", default="Fallout4", type=str, nargs=1)
-argparser.add_argument("-d", "--db", help="The database to add the file to", default="../CLASSIC Data/databases/FormIDs.db", type=str, nargs=1)
+argparser.add_argument("-d", "--db", help="The database to add the file to", default="../CLASSIC Data/databases/Fallout4 FormIDs.db", type=str, nargs=1)
 argparser.add_argument("-v", "--verbose", help="Prints out the lines as they are added", action="store_true")
 args = argparser.parse_args()
 

--- a/CLASSIC Tools/update_mod_forms.py
+++ b/CLASSIC Tools/update_mod_forms.py
@@ -37,7 +37,7 @@ with open(args.file, encoding="utf-8", errors="ignore") as f:
                     print(f"Adding {line} to {args.table}")
                 c.execute(f'''INSERT INTO {args.table} (plugin, formid, entry) 
                       VALUES (?, ?, ?)''', (plugin, formid, entry))
-c.commit()
+conn.commit()
 print("Optimizing database...")
 c.execute("vacuum")
 conn.close()

--- a/CLASSIC Tools/update_mod_forms.py
+++ b/CLASSIC Tools/update_mod_forms.py
@@ -17,18 +17,27 @@ c = conn.cursor()
 
 with open(args.file, encoding="utf-8", errors="ignore") as f:
     if not args.verbose:
-        print(f"Adding FormIDs from {args.file} to {args.table}")
+        print(f"Updating database with FormIDs from {args.file} to {args.table}")
+    plugins_deleted = []
+    plugins_announced = []
     for line in f:
         line = line.strip()
         if " | " in line:
             data = line.split(" | ")
-            if args.verbose:
-                print(f"Adding {line} to {args.table}")
             if len(data) >= 3:
                 plugin, formid, entry, *extra = data
+                if plugin not in plugins_deleted:
+                    print(f"Deleting {plugin}'s FormIDs from {args.table}")
+                    c.execute(f"delete from {args.table} where plugin = ?", (plugin,))
+                    plugins_deleted.append(plugin)
+                if plugin not in plugins_announced and not args.verbose:
+                    print(f"Adding {plugin}'s FormIDs to {args.table}")
+                    plugins_announced.append(plugin)
+                if args.verbose:
+                    print(f"Adding {line} to {args.table}")
                 c.execute(f'''INSERT INTO {args.table} (plugin, formid, entry) 
                       VALUES (?, ?, ?)''', (plugin, formid, entry))
-conn.commit()
+c.commit()
 print("Optimizing database...")
 c.execute("vacuum")
 conn.close()

--- a/CLASSIC Tools/update_mod_forms.py
+++ b/CLASSIC Tools/update_mod_forms.py
@@ -38,6 +38,7 @@ with open(args.file, encoding="utf-8", errors="ignore") as f:
                         print(f"Adding {line} to {args.table}")
                     c.execute(f'''INSERT INTO {args.table} (plugin, formid, entry) 
                       VALUES (?, ?, ?)''', (plugin, formid, entry))
-        conn.commit()
+        if conn.in_transaction:
+            conn.commit()
         print("Optimizing database...")
         c.execute("vacuum")

--- a/CLASSIC_Main.py
+++ b/CLASSIC_Main.py
@@ -529,7 +529,8 @@ def docs_check_ini(ini_name) -> str:
                                  f"    Delete this file from your Documents/My Games/{docs_name} folder, then press \n",
                                  f"    *Scan Game Files* in CLASSIC to generate a new {ini_name} file. \n-----\n"])
         except configparser.DuplicateOptionError as e:
-            message_list.append(f"[!] ERROR : {e} \n-----\n")
+            message_list.extend([f"[!] ERROR : Your {ini_name} file has duplicate options! \n",
+                                 f"{e} \n-----\n"])
     else:
         if ini_name.lower() == f"{docs_name.lower()}.ini":
             message_list.extend([f"❌ CAUTION : {ini_name} FILE IS MISSING FROM YOUR DOCUMENTS FOLDER! \n",

--- a/CLASSIC_Main.py
+++ b/CLASSIC_Main.py
@@ -529,7 +529,7 @@ def docs_check_ini(ini_name) -> str:
                                  f"    Delete this file from your Documents/My Games/{docs_name} folder, then press \n",
                                  f"    *Scan Game Files* in CLASSIC to generate a new {ini_name} file. \n-----\n"])
         except configparser.DuplicateOptionError as e:
-            message_list.append(f"[!] ERROR : {e} \n")
+            message_list.append(f"[!] ERROR : {e} \n-----\n")
     else:
         if ini_name.lower() == f"{docs_name.lower()}.ini":
             message_list.extend([f"❌ CAUTION : {ini_name} FILE IS MISSING FROM YOUR DOCUMENTS FOLDER! \n",

--- a/CLASSIC_Main.py
+++ b/CLASSIC_Main.py
@@ -528,6 +528,8 @@ def docs_check_ini(ini_name) -> str:
             message_list.extend([f"[!] CAUTION : YOUR {ini_name} FILE IS VERY LIKELY BROKEN, PLEASE CREATE A NEW ONE \n",
                                  f"    Delete this file from your Documents/My Games/{docs_name} folder, then press \n",
                                  f"    *Scan Game Files* in CLASSIC to generate a new {ini_name} file. \n-----\n"])
+        except configparser.DuplicateOptionError as e:
+            message_list.append(f"[!] ERROR : {e} \n")
     else:
         if ini_name.lower() == f"{docs_name.lower()}.ini":
             message_list.extend([f"❌ CAUTION : {ini_name} FILE IS MISSING FROM YOUR DOCUMENTS FOLDER! \n",

--- a/CLASSIC_Main.py
+++ b/CLASSIC_Main.py
@@ -530,7 +530,7 @@ def docs_check_ini(ini_name) -> str:
                                  f"    *Scan Game Files* in CLASSIC to generate a new {ini_name} file. \n-----\n"])
         except configparser.DuplicateOptionError as e:
             message_list.extend([f"[!] ERROR : Your {ini_name} file has duplicate options! \n",
-                                 f"{e} \n-----\n"])
+                                 f"    {e} \n-----\n"])
     else:
         if ini_name.lower() == f"{docs_name.lower()}.ini":
             message_list.extend([f"❌ CAUTION : {ini_name} FILE IS MISSING FROM YOUR DOCUMENTS FOLDER! \n",

--- a/CLASSIC_ScanLogs.py
+++ b/CLASSIC_ScanLogs.py
@@ -32,8 +32,8 @@ def pastebin_fetch(url):
         response.raise_for_status()
 
 def get_entry(formid, plugin) -> str | None:
-    if os.path.isfile("CLASSIC Data/databases/FormIDs.db"):
-        with sqlite3.connect("CLASSIC Data/databases/FormIDs.db") as conn:
+    if os.path.isfile(f"CLASSIC Data/databases/{CMain.game} FormIDs.db"):
+        with sqlite3.connect(f"CLASSIC Data/databases/{CMain.game} FormIDs.db") as conn:
             c = conn.cursor()
             c.execute(f'''SELECT entry FROM {CMain.game} WHERE formid=? AND plugin=? COLLATE nocase''', (formid, plugin))
             entry = c.fetchone()
@@ -550,7 +550,7 @@ def crashlogs_scan():
                 for plugin, plugin_id in crashlog_plugins.items():
                     if len(formid_split) >= 2 and str(plugin_id) == str(formid_split[1][:2]):
                         if CMain.classic_settings("Show FormID Values"):
-                            if os.path.exists(f"CLASSIC Data/databases/FormIDs.db"):
+                            if os.path.exists(f"CLASSIC Data/databases/{CMain.game} FormIDs.db"):
                                 report = get_entry(formid_split[1][2:], plugin)
                                 if report:
                                     autoscan_report.append(f"- {formid_full} | [{plugin}] | {report} | {count}\n")

--- a/CLASSIC_ScanLogs.py
+++ b/CLASSIC_ScanLogs.py
@@ -538,7 +538,7 @@ def crashlogs_scan():
             autoscan_report.append("* COULDN'T FIND ANY PLUGIN SUSPECTS *\n\n")
 
         # ================================================
-
+        autoscan_report.append("# LIST OF (POSSIBLE) FORM ID SUSPECTS #\n")
         formids_matches = [line.replace('0x', '').strip() for line in segment_callstack if "id:" in line.lower() and "0xFF" not in line]
         if formids_matches:
             formids_found = dict(Counter(sorted(formids_matches)))

--- a/CLASSIC_ScanLogs.py
+++ b/CLASSIC_ScanLogs.py
@@ -545,7 +545,7 @@ def crashlogs_scan():
             for formid_full, count in formids_found.items():
                 formid_split = formid_full.split(": ", 1)
                 for plugin, plugin_id in crashlog_plugins.items():
-                    if str(plugin_id) == str(formid_split[1][:2]):
+                    if len(formid_split) >= 2 and str(plugin_id) == str(formid_split[1][:2]):
                         if CMain.classic_settings("Show FormID Values"):
                             report = get_entry(formid_split[1][2:], plugin)
                             if report:

--- a/CLASSIC_ScanLogs.py
+++ b/CLASSIC_ScanLogs.py
@@ -32,14 +32,17 @@ def pastebin_fetch(url):
         response.raise_for_status()
 
 def get_entry(formid, plugin) -> str | None:
-    with sqlite3.connect(f"CLASSIC Data/databases/FormIDs.db") as conn:
-        c = conn.cursor()
-        c.execute(f'''SELECT entry FROM {CMain.game} WHERE formid=? AND plugin=? COLLATE nocase''', (formid, plugin))
-        entry = c.fetchone()
-        if entry:
-            return entry[0]
-        else:
-            return None
+    if os.path.isfile("CLASSIC Data/databases/FormIDs.db"):
+        with sqlite3.connect("CLASSIC Data/databases/FormIDs.db") as conn:
+            c = conn.cursor()
+            c.execute(f'''SELECT entry FROM {CMain.game} WHERE formid=? AND plugin=? COLLATE nocase''', (formid, plugin))
+            entry = c.fetchone()
+            if entry:
+                return entry[0]
+            else:
+                return None
+    else:
+        return None
 
 # ================================================
 # INITIAL REFORMAT FOR CRASH LOG FILES

--- a/CLASSIC_ScanLogs.py
+++ b/CLASSIC_ScanLogs.py
@@ -677,25 +677,28 @@ if __name__ == "__main__":
     # Argument values will simply change INI values since that requires the least refactoring
     # I will figure out a better way in a future iteration, this iteration simply mimics the GUI. - evildarkarchon
     parser.add_argument("--fcx-mode", action=argparse.BooleanOptionalAction, help="Enable (or disable) FCX mode")
-    parser.add_argument("--imi-mode", action=argparse.BooleanOptionalAction, help="Enable (or disable) IMI mode")
+    parser.add_argument("--show-fid-values", action=argparse.BooleanOptionalAction, help="Enable (or disable) IMI mode")
     parser.add_argument("--stat-logging", action=argparse.BooleanOptionalAction, help="Enable (or disable) Stat Logging")
     parser.add_argument("--move-unsolved", action=argparse.BooleanOptionalAction, help="Enable (or disable) moving unsolved logs to a separate directory")
     parser.add_argument("--ini-path", type=Path, help="Set the directory that stores the game's INI files.")
     parser.add_argument("--scan-path", type=Path, help="Set which custom directory to scan crash logs from.")
+    parser.add_argument("--mods-folder-path", type=Path, help="Set the directory where your mod manager stores your mods (Optional).")
+    parser.add_argument("--simplify-logs", action=argparse.BooleanOptionalAction, help="Enable (or disable) Simplify Logs")
     args = parser.parse_args()
 
     scan_path: Path = args.scan_path  # VSCode gives me type errors because args.* is set at runtime (doesn't know what types it's dealing with).
     ini_path: Path = args.ini_path  # Using intermediate variables with type annotations to satisfy it.
+    mods_folder_path: Path = args.mods_folder_path
 
     # Default output value for an argparse.BooleanOptionalAction is None, and so fails the isinstance check.
     # So it will respect current INI values if not specified on the command line.
     if isinstance(args.fcx_mode, bool) and not args.fcx_mode == CMain.classic_settings("FCX Mode"):
         CMain.yaml_settings("CLASSIC Settings.yaml", "CLASSIC_Settings.FCX Mode", args.fcx_mode)
 
-    if isinstance(args.imi_mode, bool) and not args.imi_mode == CMain.classic_settings("IMI Mode"):
+    if isinstance(args.show_fid_vaues, bool) and not args.imi_mode == CMain.classic_settings("Show FormID Values"):
         CMain.yaml_settings("CLASSIC Settings.yaml", "CLASSIC_Settings.IMI Mode", args.imi_mode)
 
-    if isinstance(args.move_unsolved, bool) and not args.move_unsolved == CMain.classic_settings("Move Unsolved"):
+    if isinstance(args.move_unsolved, bool) and not args.move_unsolved == CMain.classic_settings("Move Unsolved Logs"):
         CMain.yaml_settings("CLASSIC Settings.yaml", "CLASSIC_Settings.Move Unsolved", args.args.move_unsolved)
 
     if isinstance(ini_path, Path) and ini_path.resolve().is_dir() and not str(ini_path) == CMain.classic_settings("INI Folder Path"):
@@ -703,6 +706,12 @@ if __name__ == "__main__":
 
     if isinstance(scan_path, Path) and scan_path.resolve().is_dir() and not str(scan_path) == CMain.classic_settings("SCAN Custom Path"):
         CMain.yaml_settings("CLASSIC Settings.yaml", "CLASSIC_Settings.SCAN Custom Path", str(Path(scan_path).resolve()))
+    
+    if isinstance(mods_folder_path, Path) and mods_folder_path.resolve().is_dir() and not str(mods_folder_path) == CMain.classic_settings("MODS Folder Path"):
+        CMain.yaml_settings("CLASSIC Settings.yaml", "CLASSIC_Settings.MODS Folder Path", str(Path(mods_folder_path).resolve()))
+    
+    if isinstance(args.simplify_logs, bool) and not args.simplify_logs == CMain.classic_settings("Simplify Logs"):
+        CMain.yaml_settings("CLASSIC Settings.yaml", "CLASSIC_Settings.Simplify Logs", args.simplify_logs)
 
     crashlogs_scan()
     os.system("pause")

--- a/CLASSIC_ScanLogs.py
+++ b/CLASSIC_ScanLogs.py
@@ -550,27 +550,29 @@ def crashlogs_scan():
                 for plugin, plugin_id in crashlog_plugins.items():
                     if len(formid_split) >= 2 and str(plugin_id) == str(formid_split[1][:2]):
                         if CMain.classic_settings("Show FormID Values"):
-                            report = get_entry(formid_split[1][2:], plugin)
-                            if report:
-                                autoscan_report.append(f"- {formid_full} | [{plugin}] | {report} | {count}\n")
+                            if os.path.exists(f"CLASSIC Data/databases/FormIDs.db"):
+                                report = get_entry(formid_split[1][2:], plugin)
+                                if report:
+                                    autoscan_report.append(f"- {formid_full} | [{plugin}] | {report} | {count}\n")
+                                else:
+                                    autoscan_report.append(f"- {formid_full} | [{plugin}] | {count}\n")
+                                    break
                             else:
-                                autoscan_report.append(f"- {formid_full} | [{plugin}] | {count}\n")
-                                break
-                            """with open(f"CLASSIC Data/databases/{CMain.game} FID Main.txt", encoding="utf-8", errors="ignore") as fid_main:
-                                with open(f"CLASSIC Data/databases/{CMain.game} FID Mods.txt", encoding="utf-8", errors="ignore") as fid_mods:
-                                    line_match_main = next((line for line in fid_main if str(formid_split[1][2:]) in line and plugin.lower() in line.lower()), None)
-                                    line_match_mods = next((line for line in fid_mods if str(formid_split[1][2:]) in line and plugin.lower() in line.lower()), None)
-                                    if line_match_main:
-                                        line_split = line_match_main.split(" | ")
-                                        fid_report = line_split[2].strip()  # 0 - Plugin | 1 - FormID | 2 - FID Value
-                                        autoscan_report.append(f"- {formid_full} | [{plugin}] | {fid_report} | {count}\n")
-                                    elif line_match_mods:
-                                        line_split = line_match_mods.split(" | ")
-                                        fid_report = line_split[2].strip()  # 0 - Plugin | 1 - FormID | 2 - FID Value
-                                        autoscan_report.append(f"- {formid_full} | [{plugin}] | {fid_report} | {count}\n")
-                                    else:
-                                        autoscan_report.append(f"- {formid_full} | [{plugin}] | {count}\n")
-                                        break"""
+                                with open(f"CLASSIC Data/databases/{CMain.game} FID Main.txt", encoding="utf-8", errors="ignore") as fid_main:
+                                    with open(f"CLASSIC Data/databases/{CMain.game} FID Mods.txt", encoding="utf-8", errors="ignore") as fid_mods:
+                                        line_match_main = next((line for line in fid_main if str(formid_split[1][2:]) in line and plugin.lower() in line.lower()), None)
+                                        line_match_mods = next((line for line in fid_mods if str(formid_split[1][2:]) in line and plugin.lower() in line.lower()), None)
+                                        if line_match_main:
+                                            line_split = line_match_main.split(" | ")
+                                            fid_report = line_split[2].strip()  # 0 - Plugin | 1 - FormID | 2 - FID Value
+                                            autoscan_report.append(f"- {formid_full} | [{plugin}] | {fid_report} | {count}\n")
+                                        elif line_match_mods:
+                                            line_split = line_match_mods.split(" | ")
+                                            fid_report = line_split[2].strip()  # 0 - Plugin | 1 - FormID | 2 - FID Value
+                                            autoscan_report.append(f"- {formid_full} | [{plugin}] | {fid_report} | {count}\n")
+                                        else:
+                                            autoscan_report.append(f"- {formid_full} | [{plugin}] | {count}\n")
+                                            break
                         else:
                             autoscan_report.append(f"- {formid_full} | [{plugin}] | {count}\n")
                             break

--- a/CLASSIC_ScanLogs.py
+++ b/CLASSIC_ScanLogs.py
@@ -530,13 +530,10 @@ def crashlogs_scan():
 
         # ================================================
 
-        def get_entry(formid, plugin=None) -> str | None:
+        def get_entry(formid, plugin) -> str | None:
             with sqlite3.connect(f"CLASSIC Data/databases/FormIDs.db") as conn:
                 c = conn.cursor()
-                if plugin:
-                    c.execute(f'''SELECT entry FROM {CMain.game} WHERE formid=? AND plugin=? COLLATE nocase''', (formid, plugin))
-                else:
-                    c.execute(f'''SELECT entry FROM {CMain.game} WHERE formid=? COLLATE nocase''', (formid,))
+                c.execute(f'''SELECT entry FROM {CMain.game} WHERE formid=? AND plugin=? COLLATE nocase''', (formid, plugin))
                 entry = c.fetchone()
                 if entry:
                     return entry[0]

--- a/CLASSIC_ScanLogs.py
+++ b/CLASSIC_ScanLogs.py
@@ -31,6 +31,15 @@ def pastebin_fetch(url):
     else:
         response.raise_for_status()
 
+def get_entry(formid, plugin) -> str | None:
+    with sqlite3.connect(f"CLASSIC Data/databases/FormIDs.db") as conn:
+        c = conn.cursor()
+        c.execute(f'''SELECT entry FROM {CMain.game} WHERE formid=? AND plugin=? COLLATE nocase''', (formid, plugin))
+        entry = c.fetchone()
+        if entry:
+            return entry[0]
+        else:
+            return None
 
 # ================================================
 # INITIAL REFORMAT FOR CRASH LOG FILES
@@ -529,16 +538,6 @@ def crashlogs_scan():
             autoscan_report.append("* COULDN'T FIND ANY PLUGIN SUSPECTS *\n\n")
 
         # ================================================
-
-        def get_entry(formid, plugin) -> str | None:
-            with sqlite3.connect(f"CLASSIC Data/databases/FormIDs.db") as conn:
-                c = conn.cursor()
-                c.execute(f'''SELECT entry FROM {CMain.game} WHERE formid=? AND plugin=? COLLATE nocase''', (formid, plugin))
-                entry = c.fetchone()
-                if entry:
-                    return entry[0]
-                else:
-                    return None
 
         formids_matches = [line.replace('0x', '').strip() for line in segment_callstack if "id:" in line.lower() and "0xFF" not in line]
         if formids_matches:


### PR DESCRIPTION
Using an SQLite database to make FormID Lookups much faster, with my ~250MB database, I went from 60 seconds with just 29 logs down to about 17 seconds. The standard DB should be even faster.
You will have to generate the DB yourself because the database is too large for GitHub without using Git LFS. There is a script to generate the DB in the new CLASSIC Tools directory. I also have it prepped and ready to go for Skyrim support. This PR includes the changes from #74.