### PR TITLE
Small stuff until release

### DIFF
--- a/CLASSIC Changelog.md
+++ b/CLASSIC Changelog.md
@@ -1,6 +1,10 @@
 =====================================================================================================
 # CLASSIC CHANGELOG #
 
+7.25.7 Unofficial
+*CHANGES*
+- Further improve exception handling when parsing INI files with FCX mode or Scan Game Files.
+
 7.25.6 Unofficial
 *CHANGES*
 - Fix plugin tests not running when loadorder.txt was used instead of a log's plugin section.

--- a/CLASSIC Changelog.md
+++ b/CLASSIC Changelog.md
@@ -1,6 +1,10 @@
 =====================================================================================================
 # CLASSIC CHANGELOG #
 
+7.25.5 Unofficial
+*CHANGES*
+- Fix plugin tests running when there was no plugin list loaded.
+
 7.25.4 Unofficial
 *CHANGES*
 - Make reading text files more resilient

--- a/CLASSIC Changelog.md
+++ b/CLASSIC Changelog.md
@@ -1,6 +1,10 @@
 =====================================================================================================
 # CLASSIC CHANGELOG #
 
+7.25.6 Unofficial
+*CHANGES*
+- Fix plugin tests not running when loadorder.txt was used instead of a log's plugin section.
+
 7.25.5 Unofficial
 *CHANGES*
 - Fix plugin tests running when there was no plugin list loaded.

--- a/CLASSIC Data/databases/CLASSIC Fallout4.yaml
+++ b/CLASSIC Data/databases/CLASSIC Fallout4.yaml
@@ -465,7 +465,6 @@ Crashlog_Stack_Check:
 Mods_CORE:  # 0) MODS THAT EVERY PLAYER SHOULD HAVE INSTALLED
   CanarySaveFileMonitor | Canary Save File Monitor: |
     This is a highly recommended mod that can detect save file corruption.
-    If you do have this mod installed and enabled, but your log doesn't show it, it is safe to ignore this warning.
     Link: https://www.nexusmods.com/fallout4/mods/44949?tab=files
 
   HighFPSPhysicsFix | High FPS Physics Fix: |
@@ -474,12 +473,10 @@ Mods_CORE:  # 0) MODS THAT EVERY PLAYER SHOULD HAVE INSTALLED
 
   PRP.esp | Previs Repair Pack (PRP): |
     This is a highly recommended mod that can vastly improve performance.
-    If you do have this mod installed and enabled, but your log doesn't show it, it is safe to ignore this warning.
     Link: https://www.nexusmods.com/fallout4/mods/46403?tab=files
 
   Unofficial Fallout 4 Patch | Unofficial Fallout 4 Patch: |
     If you own all DLCs, make sure that the Unofficial Patch is installed.
-    If you do have this mod installed and enabled, but your log doesn't show it, it is safe to ignore this warning.
     Link: https://www.nexusmods.com/fallout4/mods/4598?tab=files
 
   vulkan-1.dll | Vulkan Renderer: |

--- a/CLASSIC Data/databases/CLASSIC Main.yaml
+++ b/CLASSIC Data/databases/CLASSIC Main.yaml
@@ -4,8 +4,8 @@ CLASSIC_Info:
   # ========================================================================================
   # CAUTION: DO NOT CHANGE YOUR SETTINGS HERE! OPEN & EDIT CLASSIC Settings.yaml instead!
   # ========================================================================================
-  version: CLASSIC v7.25.5 Unofficial
-  version_date: 24.04.13 #YY/MM/DD
+  version: CLASSIC v7.25.6 Unofficial
+  version_date: 24.05.04 #YY/MM/DD
   default_settings: |
     # This file contains settings for CLASSIC v7.00+, used by both source scripts and the executable.
     

--- a/CLASSIC Data/databases/CLASSIC Main.yaml
+++ b/CLASSIC Data/databases/CLASSIC Main.yaml
@@ -4,8 +4,8 @@ CLASSIC_Info:
   # ========================================================================================
   # CAUTION: DO NOT CHANGE YOUR SETTINGS HERE! OPEN & EDIT CLASSIC Settings.yaml instead!
   # ========================================================================================
-  version: CLASSIC v7.25.6 Unofficial
-  version_date: 24.05.04 #YY/MM/DD
+  version: CLASSIC v7.25.7 Unofficial
+  version_date: 24.05.08 #YY/MM/DD
   default_settings: |
     # This file contains settings for CLASSIC v7.00+, used by both source scripts and the executable.
     

--- a/CLASSIC Data/databases/CLASSIC Main.yaml
+++ b/CLASSIC Data/databases/CLASSIC Main.yaml
@@ -4,8 +4,8 @@ CLASSIC_Info:
   # ========================================================================================
   # CAUTION: DO NOT CHANGE YOUR SETTINGS HERE! OPEN & EDIT CLASSIC Settings.yaml instead!
   # ========================================================================================
-  version: CLASSIC v7.25.4 Unofficial
-  version_date: 24.03.24 #YY/MM/DD
+  version: CLASSIC v7.25.5 Unofficial
+  version_date: 24.04.13 #YY/MM/DD
   default_settings: |
     # This file contains settings for CLASSIC v7.00+, used by both source scripts and the executable.
     

--- a/CLASSIC_Interface.py
+++ b/CLASSIC_Interface.py
@@ -577,7 +577,8 @@ if __name__ == "__main__":
     print(CMain.yaml_settings("CLASSIC Data/databases/CLASSIC Main.yaml", "CLASSIC_Interface.start_message"))
     classic_ver = CMain.yaml_settings("CLASSIC Data/databases/CLASSIC Main.yaml", "CLASSIC_Info.version")
     app = QtWidgets.QApplication(sys.argv)
-    app.setStyle("windowsvista")
+    if platform.system() == "Windows":
+        app.setStyle("windowsvista")
 
     # Add widgets of other "tabs" through function calls, not here.
     screen_switch = QtWidgets.QStackedWidget()

--- a/CLASSIC_Interface.py
+++ b/CLASSIC_Interface.py
@@ -5,8 +5,13 @@ import time
 import platform
 import subprocess
 import multiprocessing
-import soundfile as sfile
-import sounddevice as sdev
+try:  # soundfile (specically its Numpy dependency) seem to cause virus alerts from some AV programs, including Windows Defender.
+    import soundfile as sfile
+    import sounddevice as sdev
+except ImportError:
+    has_soundfile = False
+else:
+    has_soundfile = True
 # sfile and sdev need Numpy
 import CLASSIC_Main as CMain
 import CLASSIC_ScanGame as CGame
@@ -198,6 +203,8 @@ def papyrus_worker(q, stop_event):
 
 
 def play_sound(sound_file):
+    if not has_soundfile:
+        return
     sound, samplerate = sfile.read(f"CLASSIC Data/sounds/{sound_file}")
     sdev.play(sound, samplerate)
     sdev.wait()

--- a/CLASSIC_Interface.py
+++ b/CLASSIC_Interface.py
@@ -577,6 +577,7 @@ if __name__ == "__main__":
     print(CMain.yaml_settings("CLASSIC Data/databases/CLASSIC Main.yaml", "CLASSIC_Interface.start_message"))
     classic_ver = CMain.yaml_settings("CLASSIC Data/databases/CLASSIC Main.yaml", "CLASSIC_Info.version")
     app = QtWidgets.QApplication(sys.argv)
+    app.setStyle("windowsvista")
 
     # Add widgets of other "tabs" through function calls, not here.
     screen_switch = QtWidgets.QStackedWidget()

--- a/CLASSIC_ScanGame.py
+++ b/CLASSIC_ScanGame.py
@@ -5,6 +5,7 @@ import logging
 import tomlkit
 import subprocess
 import configparser
+import functools
 import CLASSIC_Main as CMain
 from bs4 import BeautifulSoup
 from pathlib import Path
@@ -15,22 +16,32 @@ CMain.configure_logging()
 # ================================================
 # DEFINE MAIN FILE / YAML FUNCTIONS
 # ================================================
+def handle_ini_exceptions(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except FileNotFoundError as e:
+            logging.error(f"ERROR: File not found - {e}")
+        except KeyError as e:
+            logging.error(f"ERROR: Invalid section or key - {e}")
+        except IOError as e:
+            logging.error(f"ERROR: Unable to read or write the file - {e}")
+        except Exception as e:
+            logging.error(f"ERROR: An unexpected error occurred - {e}")
+        return None
+    return wrapper
+
+@handle_ini_exceptions
 def mod_ini_config(ini_path, section, key, new_value=None):
-    try:
-        mod_config = configparser.ConfigParser()
-        mod_config.optionxform = str
-        mod_config.read(ini_path)
-    except FileNotFoundError:
-        logging.error(f"ERROR: File '{ini_path}' not found.")
-        mod_config = {}
-        pass
+    mod_config = configparser.ConfigParser()
+    mod_config.optionxform = str
+    mod_config.read(ini_path)
 
     if section not in mod_config.keys():
-        logging.error(f"ERROR : Section '{section}' does not exist in '{ini_path}'")
-        pass
-    if section in mod_config.keys() and key not in mod_config[section]:
-        logging.error(f"ERROR : Key '{key}' does not exist in section '{section}'")
-        pass
+        raise KeyError(f"Section '{section}' does not exist in '{ini_path}'")
+    if key not in mod_config[section]:
+        raise KeyError(f"Key '{key}' does not exist in section '{section}'")
 
     # If new_value is specified, update value in INI.
     if new_value is not None:

--- a/CLASSIC_ScanGame.py
+++ b/CLASSIC_ScanGame.py
@@ -371,11 +371,8 @@ def scan_mod_inis():  # Mod INI files check.
                     if mod_ini_config(ini_path, "Limiter", "EnableVSync") is True:
                         vsync_list.append(f"{ini_path} | SETTING: EnableVSync \n")
                 case "reshade.ini":
-                    try:
-                        if mod_ini_config(ini_path, "APP", "ForceVsync") is True:
-                            vsync_list.append(f"{ini_path} | SETTING: ForceVsync \n")
-                    except KeyError:
-                        pass
+                    if mod_ini_config(ini_path, "APP", "ForceVsync") is True:
+                        vsync_list.append(f"{ini_path} | SETTING: ForceVsync \n")
 
     if vsync_list:
         message_list.append("* NOTICE : VSYNC IS CURRENTLY ENABLED IN THE FOLLOWING FILES * \n")

--- a/CLASSIC_ScanLogs.py
+++ b/CLASSIC_ScanLogs.py
@@ -236,7 +236,7 @@ def crashlogs_scan():
             try:
                 index_end = next(index for index, item in enumerate(crash_data) if segment_end.lower() in item.lower() and xse_acronym.lower() not in item.lower()) - 1
             except StopIteration:
-                index_end: int = len(crash_data) - 1
+                index_end: int = len(crash_data)
 
             if index_start <= index_end:
                 segment_output = [s_line.strip() for s_line in crash_data[index_start:index_end] if all(item.lower() not in s_line.lower() for item in remove_list)]

--- a/CLASSIC_ScanLogs.py
+++ b/CLASSIC_ScanLogs.py
@@ -315,6 +315,7 @@ def crashlogs_scan():
             for elem in loadorder_data[1:]:
                 if all(elem not in item for item in crashlog_plugins):
                     crashlog_plugins[elem] = "LO"
+            trigger_plugins_loaded = True
 
         else:  # OTHERWISE, USE PLUGINS FROM CRASH LOG
             for elem in segment_plugins:

--- a/CLASSIC_ScanLogs.py
+++ b/CLASSIC_ScanLogs.py
@@ -289,8 +289,12 @@ def crashlogs_scan():
 
         crashlog_GPUAMD = crashlog_GPUNV = False
         crashlog_plugins = {}
-        if len(segment_plugins) > 1:
-            trigger_plugins_loaded = True
+        if CMain.game == "Fallout4":
+            if any("Fallout4.esm" in elem for elem in segment_plugins):
+                trigger_plugins_loaded = True
+        elif CMain.game == "SkyrimSE":
+            if any("Skyrim.esm" in elem for elem in segment_plugins):
+                trigger_plugins_loaded = True
 
         # ================================================
         # 3) CHECK EACH SEGMENT AND CREATE REQUIRED VALUES
@@ -450,7 +454,7 @@ def crashlogs_scan():
                                 "CHECKING FOR MODS THAT CAN CAUSE FREQUENT CRASHES...\n",
                                 "====================================================\n"])
 
-        if trigger_plugins_loaded:
+        if trigger_plugins_loaded == True:
             if detect_mods_single(game_mods_freq):
                 autoscan_report.extend(["# [!] CAUTION : ANY ABOVE DETECTED MODS HAVE A MUCH HIGHER CHANCE TO CRASH YOUR GAME! #\n",
                                         "* YOU CAN DISABLE ANY / ALL OF THEM TEMPORARILY TO CONFIRM THEY CAUSED THIS CRASH. * \n\n"])
@@ -465,7 +469,7 @@ def crashlogs_scan():
                                 "CHECKING FOR MODS THAT CONFLICT WITH OTHER MODS...\n",
                                 "====================================================\n"])
 
-        if trigger_plugins_loaded:
+        if trigger_plugins_loaded == True:
             if detect_mods_double(game_mods_conf):
                 autoscan_report.extend(["# [!] CAUTION : FOUND MODS THAT ARE INCOMPATIBLE OR CONFLICT WITH YOUR OTHER MODS # \n",
                                         "* YOU SHOULD CHOOSE WHICH MOD TO KEEP AND DISABLE OR COMPLETELY REMOVE THE OTHER MOD * \n\n"])
@@ -478,7 +482,7 @@ def crashlogs_scan():
                                 "CHECKING FOR MODS WITH SOLUTIONS & COMMUNITY PATCHES\n",
                                 "====================================================\n"])
 
-        if trigger_plugins_loaded:
+        if trigger_plugins_loaded == True:
             if detect_mods_single(game_mods_solu):
                 autoscan_report.extend(["# [!] CAUTION : FOUND PROBLEMATIC MODS WITH SOLUTIONS AND COMMUNITY PATCHES # \n",
                                         "[Due to limitations, CLASSIC will show warnings for some mods even if fixes or patches are already installed.] \n",
@@ -493,7 +497,7 @@ def crashlogs_scan():
                                     "CHECKING FOR MODS PATCHED THROUGH OPC INSTALLER...\n",
                                     "====================================================\n"])
 
-            if trigger_plugins_loaded:
+            if trigger_plugins_loaded == True:
                 if detect_mods_single(game_mods_opc2):
                     autoscan_report.extend(["\n* FOR PATCH REPOSITORY THAT PREVENTS CRASHES AND FIXES PROBLEMS IN THESE AND OTHER MODS,* \n",
                                             "* VISIT OPTIMIZATION PATCHES COLLECTION: https://www.nexusmods.com/fallout4/mods/54872 * \n\n"])
@@ -506,7 +510,7 @@ def crashlogs_scan():
                                 "CHECKING IF IMPORTANT PATCHES & FIXES ARE INSTALLED\n",
                                 "====================================================\n"])
 
-        if trigger_plugins_loaded:
+        if trigger_plugins_loaded == True:
             detect_mods_important(game_mods_core)
         else:
             autoscan_report.append(warn_noplugins)


### PR DESCRIPTION
Starting with an update to the interface to disable OS dark mode.
With Qt/PySide 6.7+, the default style for Windows is now "windows", which has OS dark mode capability. Before, it was "windowsvista" which does not. With the "windows" style, the LineEdit boxes have a dark grey background, making boxes with custom text illegible because custom text (at least how it is now) is always black. So far, I have not found a way to change custom text color in a QLineEdit widget.